### PR TITLE
Fix marker motion and walking calibration for watch GPS

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/core/service/location/activity/LocationActivityClassifier.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/core/service/location/activity/LocationActivityClassifier.kt
@@ -3,14 +3,14 @@ package com.glancemap.glancemapwearos.core.service.location.activity
 internal enum class LocationActivityState { ACTIVE, STATIONARY }
 
 internal data class LocationActivityClassifierConfig(
-    val enterStationaryWindowMs: Long = 30000L,
-    val enterStationaryConfirmMs: Long = 8000L,
-    val enterStationarySpeedThresholdMps: Float = 0.35f,
-    val enterStationaryDistanceThresholdMeters: Float = 12.0f,
+    val enterStationaryWindowMs: Long = 45000L,
+    val enterStationaryConfirmMs: Long = 15000L,
+    val enterStationarySpeedThresholdMps: Float = 0.25f,
+    val enterStationaryDistanceThresholdMeters: Float = 8.0f,
     val exitActiveWindowMs: Long = 12000L,
-    val exitActiveConfirmMs: Long = 4000L,
-    val exitActiveSpeedThresholdMps: Float = 0.70f,
-    val exitActiveDistanceThresholdMeters: Float = 18.0f,
+    val exitActiveConfirmMs: Long = 2000L,
+    val exitActiveSpeedThresholdMps: Float = 0.40f,
+    val exitActiveDistanceThresholdMeters: Float = 10.0f,
 )
 
 internal class LocationActivityClassifier(

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/effects/NavigateLocationEffects.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/effects/NavigateLocationEffects.kt
@@ -23,6 +23,9 @@ import com.glancemap.glancemapwearos.presentation.features.navigate.LocationView
 import com.glancemap.glancemapwearos.presentation.features.navigate.NavigateViewModel
 import com.glancemap.glancemapwearos.presentation.features.navigate.UI_WAKE_REACQUIRE_TIMEOUT_SOURCE
 import com.glancemap.glancemapwearos.presentation.features.navigate.motion.MarkerMotionController
+import com.glancemap.glancemapwearos.presentation.features.navigate.motion.MarkerMotionGpsFix
+import com.glancemap.glancemapwearos.presentation.features.navigate.motion.MarkerMotionReading
+import com.glancemap.glancemapwearos.presentation.features.navigate.motion.MarkerMotionSeed
 import com.glancemap.glancemapwearos.presentation.features.navigate.requestLayerRedrawSafely
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterNotNull
@@ -157,12 +160,18 @@ internal fun rememberNavigateLocationUiState(
                     LocationSourceMode.AUTO_FUSED
                 }
             markerMotionController.seedAnchor(
-                latLong = anchor.latLong,
-                fixElapsedMs = anchor.fixElapsedMs,
-                accuracyM = anchor.accuracyM,
-                speedMps = anchor.speedMps,
-                bearingDeg = anchor.bearingDeg,
-                sourceMode = markerSourceMode,
+                seed =
+                    MarkerMotionSeed(
+                        latLong = anchor.latLong,
+                        reading =
+                            MarkerMotionReading(
+                                fixElapsedMs = anchor.fixElapsedMs,
+                                accuracyM = anchor.accuracyM,
+                                speedMps = anchor.speedMps,
+                                bearingDeg = anchor.bearingDeg,
+                            ),
+                        sourceMode = markerSourceMode,
+                    ),
             )
             lastRenderedMarkerLatLong = anchor.latLong
             wakeAnchorSeeded = true
@@ -468,19 +477,25 @@ internal fun rememberNavigateLocationUiState(
 
                 val displayLatLong =
                     markerMotionController.onGpsFix(
-                        latLong = ll,
-                        nowElapsedMs = receivedAtElapsedMs,
-                        fixElapsedMs = fixElapsedMs,
-                        accuracyM = loc.accuracy,
-                        rawSpeedMps = motionSpeedMps,
-                        rawBearingDeg = if (loc.hasBearing()) loc.bearing else null,
-                        allowLargeCorrection =
-                            shouldBypassCorrectionClamp(
-                                releaseFromWakeHold = releaseFromWakeHold,
-                                previousAcceptedFixGapMs = previousAcceptedFixGapMs,
-                                expectedGpsIntervalMs = expectedGpsIntervalMs,
+                        fix =
+                            MarkerMotionGpsFix(
+                                latLong = ll,
+                                nowElapsedMs = receivedAtElapsedMs,
+                                reading =
+                                    MarkerMotionReading(
+                                        fixElapsedMs = fixElapsedMs,
+                                        accuracyM = loc.accuracy,
+                                        speedMps = motionSpeedMps,
+                                        bearingDeg = if (loc.hasBearing()) loc.bearing else null,
+                                    ),
+                                allowLargeCorrection =
+                                    shouldBypassCorrectionClamp(
+                                        releaseFromWakeHold = releaseFromWakeHold,
+                                        previousAcceptedFixGapMs = previousAcceptedFixGapMs,
+                                        expectedGpsIntervalMs = expectedGpsIntervalMs,
+                                    ),
+                                sourceMode = markerSourceMode,
                             ),
-                        sourceMode = markerSourceMode,
                     )
                 lastAcceptedLocationFixElapsedMs =
                     fixElapsedMs.takeIf { it > 0L } ?: receivedAtElapsedMs

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/effects/NavigateLocationEffects.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/effects/NavigateLocationEffects.kt
@@ -15,6 +15,7 @@ import com.glancemap.glancemapwearos.core.service.location.model.LocationScreenS
 import com.glancemap.glancemapwearos.core.service.location.model.isNonInteractive
 import com.glancemap.glancemapwearos.core.service.location.model.resolveLocationTimingProfile
 import com.glancemap.glancemapwearos.core.service.location.policy.LocationFixPolicy
+import com.glancemap.glancemapwearos.core.service.location.policy.LocationSourceMode
 import com.glancemap.glancemapwearos.domain.sensors.CompassViewModel
 import com.glancemap.glancemapwearos.presentation.features.maps.RotatableMarker
 import com.glancemap.glancemapwearos.presentation.features.navigate.GpsFixIndicatorState
@@ -80,6 +81,7 @@ internal fun rememberNavigateLocationUiState(
     var indicatorFixFreshMaxAgeMs by remember { mutableLongStateOf(0L) }
     var indicatorLocationAvailable by remember { mutableStateOf(true) }
     var indicatorUnavailableSinceElapsedMs by remember { mutableLongStateOf(0L) }
+    var indicatorWatchGpsOnlyActive by remember { mutableStateOf(false) }
     var indicatorWatchGpsDegraded by remember { mutableStateOf(false) }
     var holdMarkerUntilFreshFix by
         remember(shouldTrackLocation, screenState) {
@@ -148,12 +150,19 @@ internal fun rememberNavigateLocationUiState(
             maxAgeMs = computeWakeAnchorMaxAgeMs(expectedGpsIntervalMs),
             maxAccuracyM = WAKE_ANCHOR_MAX_ACCURACY_M,
         )?.let { anchor ->
+            val markerSourceMode =
+                if (indicatorWatchGpsOnlyActive) {
+                    LocationSourceMode.WATCH_GPS
+                } else {
+                    LocationSourceMode.AUTO_FUSED
+                }
             markerMotionController.seedAnchor(
                 latLong = anchor.latLong,
                 fixElapsedMs = anchor.fixElapsedMs,
                 accuracyM = anchor.accuracyM,
                 speedMps = anchor.speedMps,
                 bearingDeg = anchor.bearingDeg,
+                sourceMode = markerSourceMode,
             )
             lastRenderedMarkerLatLong = anchor.latLong
             wakeAnchorSeeded = true
@@ -237,6 +246,7 @@ internal fun rememberNavigateLocationUiState(
             indicatorFixFreshMaxAgeMs = signal.lastFixFreshMaxAgeMs
             indicatorLocationAvailable = signal.isLocationAvailable
             indicatorUnavailableSinceElapsedMs = signal.unavailableSinceElapsedMs
+            indicatorWatchGpsOnlyActive = signal.watchGpsOnlyActive
             indicatorWatchGpsDegraded = signal.watchGpsOnlyActive && signal.watchGpsDegraded
         }
     }
@@ -449,6 +459,12 @@ internal fun rememberNavigateLocationUiState(
                     } else {
                         0f
                     }
+                val markerSourceMode =
+                    if (indicatorWatchGpsOnlyActive) {
+                        LocationSourceMode.WATCH_GPS
+                    } else {
+                        LocationSourceMode.AUTO_FUSED
+                    }
 
                 val displayLatLong =
                     markerMotionController.onGpsFix(
@@ -464,6 +480,7 @@ internal fun rememberNavigateLocationUiState(
                                 previousAcceptedFixGapMs = previousAcceptedFixGapMs,
                                 expectedGpsIntervalMs = expectedGpsIntervalMs,
                             ),
+                        sourceMode = markerSourceMode,
                     )
                 lastAcceptedLocationFixElapsedMs =
                     fixElapsedMs.takeIf { it > 0L } ?: receivedAtElapsedMs

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionController.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionController.kt
@@ -13,6 +13,27 @@ import kotlin.math.max
 import kotlin.math.sin
 import kotlin.math.sqrt
 
+internal data class MarkerMotionReading(
+    val fixElapsedMs: Long,
+    val accuracyM: Float,
+    val speedMps: Float,
+    val bearingDeg: Float?,
+)
+
+internal data class MarkerMotionSeed(
+    val latLong: LatLong,
+    val reading: MarkerMotionReading,
+    val sourceMode: LocationSourceMode = LocationSourceMode.AUTO_FUSED,
+)
+
+internal data class MarkerMotionGpsFix(
+    val latLong: LatLong,
+    val nowElapsedMs: Long,
+    val reading: MarkerMotionReading,
+    val allowLargeCorrection: Boolean = false,
+    val sourceMode: LocationSourceMode = LocationSourceMode.AUTO_FUSED,
+)
+
 internal class MarkerMotionController(
     private val predictionFreshnessMaxAgeMs: Long,
     private val maxAcceptedFixAgeMs: Long,
@@ -21,305 +42,83 @@ internal class MarkerMotionController(
     private val correctionBlendDurationMs: Long = DEFAULT_CORRECTION_BLEND_DURATION_MS,
     private val predictionTickMs: Long = DEFAULT_PREDICTION_TICK_MS,
 ) {
-    private var lastAcceptedFix: MotionFix? = null
-    private var displayedLatLong: LatLong? = null
-    private var correctionBlend: CorrectionBlend? = null
-    private var smoothedSpeedMps: Float = 0f
-    private var predictionRequiresFreshFix: Boolean = true
-    private var clampedCorrectionStreak: Int = 0
+    private val state = MarkerMotionState()
+    private val fixProcessor =
+        MarkerMotionGpsFixProcessor(
+            state = state,
+            maxAcceptedFixAgeMs = maxAcceptedFixAgeMs,
+            minPredictionSpeedMps = minPredictionSpeedMps,
+            correctionBlendDurationMs = correctionBlendDurationMs,
+        )
 
     fun reset(reason: String = "reset") {
-        lastAcceptedFix = null
-        displayedLatLong = null
-        correctionBlend = null
-        smoothedSpeedMps = 0f
-        predictionRequiresFreshFix = true
-        clampedCorrectionStreak = 0
+        state.lastAcceptedFix = null
+        state.displayedLatLong = null
+        state.correctionBlend = null
+        state.smoothedSpeedMps = 0f
+        state.predictionRequiresFreshFix = true
+        state.clampedCorrectionStreak = 0
         MarkerMotionTelemetry.recordIdle(
             nowElapsedMs = 0L,
             reason = reason,
         )
     }
 
-    fun seedAnchor(
-        latLong: LatLong,
-        fixElapsedMs: Long,
-        accuracyM: Float,
-        speedMps: Float,
-        bearingDeg: Float?,
-        sourceMode: LocationSourceMode = LocationSourceMode.AUTO_FUSED,
-    ) {
-        val sanitizedSpeed = sanitizeSpeed(speedMps)
-        val motionAccuracyM = effectiveMotionAccuracy(accuracyM, sourceMode)
-        smoothedSpeedMps = sanitizedSpeed
-        lastAcceptedFix =
+    fun seedAnchor(seed: MarkerMotionSeed) {
+        val sanitizedSpeed = sanitizeSpeed(seed.reading.speedMps)
+        val motionAccuracyM = effectiveMotionAccuracy(seed.reading.accuracyM, seed.sourceMode)
+        val fixElapsedMs = seed.reading.fixElapsedMs.coerceAtLeast(0L)
+        state.smoothedSpeedMps = sanitizedSpeed
+        state.lastAcceptedFix =
             MotionFix(
-                latLong = latLong,
-                fixElapsedMs = fixElapsedMs.coerceAtLeast(0L),
+                latLong = seed.latLong,
+                fixElapsedMs = fixElapsedMs,
                 accuracyM = motionAccuracyM,
                 speedMps = sanitizedSpeed,
-                bearingDeg = bearingDeg?.let(::normalize360),
+                bearingDeg = seed.reading.bearingDeg?.let(::normalize360),
             )
-        displayedLatLong = latLong
-        correctionBlend = null
-        predictionRequiresFreshFix = true
-        clampedCorrectionStreak = 0
+        state.displayedLatLong = seed.latLong
+        state.correctionBlend = null
+        state.predictionRequiresFreshFix = true
+        state.clampedCorrectionStreak = 0
         MarkerMotionTelemetry.recordSeedAnchor(
-            nowElapsedMs = fixElapsedMs.coerceAtLeast(0L),
+            nowElapsedMs = fixElapsedMs,
             accuracyM = motionAccuracyM,
             speedMps = sanitizedSpeed,
-            bearingDeg = bearingDeg?.let(::normalize360),
+            bearingDeg = seed.reading.bearingDeg?.let(::normalize360),
         )
     }
 
     fun requireFreshFixForPrediction() {
-        predictionRequiresFreshFix = true
-        correctionBlend = null
+        state.predictionRequiresFreshFix = true
+        state.correctionBlend = null
         MarkerMotionTelemetry.recordPredictionBlocked(
             reason = "await_fresh_fix",
-            nowElapsedMs = lastAcceptedFix?.fixElapsedMs ?: 0L,
+            nowElapsedMs = state.lastAcceptedFix?.fixElapsedMs ?: 0L,
             fixAgeMs = null,
-            accuracyM = lastAcceptedFix?.accuracyM,
-            speedMps = lastAcceptedFix?.speedMps,
-            bearingDeg = lastAcceptedFix?.bearingDeg,
+            accuracyM = state.lastAcceptedFix?.accuracyM,
+            speedMps = state.lastAcceptedFix?.speedMps,
+            bearingDeg = state.lastAcceptedFix?.bearingDeg,
         )
     }
 
     fun suggestedPredictionTickMs(): Long = predictionTickMs
 
-    fun onGpsFix(
-        latLong: LatLong,
-        nowElapsedMs: Long,
-        fixElapsedMs: Long,
-        accuracyM: Float,
-        rawSpeedMps: Float,
-        rawBearingDeg: Float?,
-        allowLargeCorrection: Boolean = false,
-        sourceMode: LocationSourceMode = LocationSourceMode.AUTO_FUSED,
-    ): LatLong {
-        val currentDisplayed = displayedLatLong
-        val sanitizedAccuracy = effectiveMotionAccuracy(accuracyM, sourceMode)
-        val reliableFixElapsedMs =
-            fixElapsedMs
-                .takeIf { it > 0L }
-                ?.coerceAtMost(nowElapsedMs)
-                ?: nowElapsedMs
-        val fixAgeMs = (nowElapsedMs - reliableFixElapsedMs).coerceAtLeast(0L)
-
-        if (currentDisplayed != null && fixAgeMs > maxAcceptedFixAgeMs) {
-            MarkerMotionTelemetry.recordPredictionBlocked(
-                reason = "stale_fix",
-                nowElapsedMs = nowElapsedMs,
-                fixAgeMs = fixAgeMs,
-                accuracyM = sanitizedAccuracy,
-                speedMps = rawSpeedMps.takeIf { it.isFinite() },
-                bearingDeg = rawBearingDeg?.takeIf { it.isFinite() },
-            )
-            return currentDisplayed
-        }
-
-        val previousFix = lastAcceptedFix
-        if (
-            previousFix != null &&
-            isDuplicateMotionFix(
-                previousFix = previousFix,
-                candidate = latLong,
-                candidateFixElapsedMs = reliableFixElapsedMs,
-                candidateAccuracyM = sanitizedAccuracy,
-            )
-        ) {
-            MarkerMotionTelemetry.recordPredictionBlocked(
-                reason = "duplicate_fix",
-                nowElapsedMs = nowElapsedMs,
-                fixAgeMs = fixAgeMs,
-                accuracyM = sanitizedAccuracy,
-                speedMps = rawSpeedMps.takeIf { it.isFinite() },
-                bearingDeg = rawBearingDeg?.takeIf { it.isFinite() },
-            )
-            return currentDisplayed ?: previousFix.latLong
-        }
-        val outlierDecision =
-            previousFix?.detectOutlier(
-                candidate = latLong,
-                candidateAccuracyM = sanitizedAccuracy,
-                candidateFixElapsedMs = reliableFixElapsedMs,
-            )
-        if (outlierDecision != null) {
-            correctionBlend = null
-            clampedCorrectionStreak = 0
-            MarkerMotionTelemetry.recordOutlierDropped(
-                nowElapsedMs = nowElapsedMs,
-                fixAgeMs = fixAgeMs,
-                accuracyM = sanitizedAccuracy,
-                jumpMeters = outlierDecision.jumpMeters,
-                impliedSpeedMps = outlierDecision.impliedSpeedMps,
-                dtSec = outlierDecision.dtSec,
-            )
-            return currentDisplayed ?: previousFix.latLong
-        }
-
-        val derivedMotion = previousFix?.deriveMotionTo(target = latLong, targetFixElapsedMs = reliableFixElapsedMs)
-        val resolvedSpeedMps =
-            resolveMotionSpeedMps(
-                rawSpeedMps = rawSpeedMps,
-                derivedSpeedMps = derivedMotion?.speedMps,
-                accuracyM = sanitizedAccuracy,
-            )
-        smoothedSpeedMps =
-            if (smoothedSpeedMps <= 0f) {
-                resolvedSpeedMps
-            } else {
-                SPEED_SMOOTHING_ALPHA * resolvedSpeedMps +
-                    (1f - SPEED_SMOOTHING_ALPHA) * smoothedSpeedMps
-            }
-        val resolvedBearingDeg =
-            resolveMotionBearingDeg(
-                rawBearingDeg = rawBearingDeg,
-                rawSpeedMps = rawSpeedMps,
-                derivedMotion = derivedMotion,
-                fallbackBearingDeg = previousFix?.bearingDeg,
-                resolvedSpeedMps = smoothedSpeedMps,
-            )
-
-        lastAcceptedFix =
-            MotionFix(
-                latLong = latLong,
-                fixElapsedMs = reliableFixElapsedMs,
-                accuracyM = sanitizedAccuracy,
-                speedMps = smoothedSpeedMps,
-                bearingDeg = resolvedBearingDeg,
-            )
-        predictionRequiresFreshFix = false
-
-        if (currentDisplayed == null) {
-            displayedLatLong = latLong
-            correctionBlend = null
-            clampedCorrectionStreak = 0
-            MarkerMotionTelemetry.recordFixAccepted(
-                mode = MarkerMotionMode.FIXED,
-                reason = "initial_fix",
-                nowElapsedMs = nowElapsedMs,
-                fixAgeMs = fixAgeMs,
-                accuracyM = sanitizedAccuracy,
-                speedMps = smoothedSpeedMps,
-                bearingDeg = resolvedBearingDeg,
-                correctionDistanceM = null,
-                blendDurationMs = null,
-            )
-            return latLong
-        }
-
-        val correctionDistanceM = distanceMeters(currentDisplayed, latLong)
-        if (shouldFreezeStationaryJitter(correctionDistanceM, sanitizedAccuracy, smoothedSpeedMps)) {
-            correctionBlend = null
-            clampedCorrectionStreak = 0
-            MarkerMotionTelemetry.recordFixAccepted(
-                mode = MarkerMotionMode.FIXED,
-                reason = "stationary_jitter",
-                nowElapsedMs = nowElapsedMs,
-                fixAgeMs = fixAgeMs,
-                accuracyM = sanitizedAccuracy,
-                speedMps = smoothedSpeedMps,
-                bearingDeg = resolvedBearingDeg,
-                correctionDistanceM = correctionDistanceM,
-                blendDurationMs = null,
-            )
-            return currentDisplayed
-        }
-
-        if (correctionDistanceM <= correctionDeadbandMeters(sanitizedAccuracy, smoothedSpeedMps)) {
-            displayedLatLong = latLong
-            correctionBlend = null
-            clampedCorrectionStreak = 0
-            MarkerMotionTelemetry.recordFixAccepted(
-                mode = MarkerMotionMode.FIXED,
-                reason = "deadband_snap",
-                nowElapsedMs = nowElapsedMs,
-                fixAgeMs = fixAgeMs,
-                accuracyM = sanitizedAccuracy,
-                speedMps = smoothedSpeedMps,
-                bearingDeg = resolvedBearingDeg,
-                correctionDistanceM = correctionDistanceM,
-                blendDurationMs = null,
-            )
-            return latLong
-        }
-
-        val useWatchGpsCatchUp =
-            shouldCatchUpSustainedWatchGpsLag(
-                sourceMode = sourceMode,
-                correctionDistanceM = correctionDistanceM,
-                accuracyM = sanitizedAccuracy,
-                speedMps = smoothedSpeedMps,
-            )
-        val correctionTarget =
-            resolveCorrectionTarget(
-                request =
-                    CorrectionTargetRequest(
-                        currentDisplayed = currentDisplayed,
-                        targetLatLong = latLong,
-                        correctionDistanceM = correctionDistanceM,
-                        accuracyM = sanitizedAccuracy,
-                        speedMps = smoothedSpeedMps,
-                        allowLargeCorrection = allowLargeCorrection || useWatchGpsCatchUp,
-                    ),
-            )
-        val visibleTarget = correctionTarget.targetLatLong
-        if (correctionTarget.wasClamped) {
-            clampedCorrectionStreak += 1
-            MarkerMotionTelemetry.recordCorrectionClamped(
-                event =
-                    CorrectionClampTelemetryEvent(
-                        nowElapsedMs = nowElapsedMs,
-                        actualCorrectionDistanceM = correctionDistanceM,
-                        visibleCorrectionDistanceM = correctionTarget.visibleCorrectionDistanceM,
-                        accuracyM = sanitizedAccuracy,
-                        speedMps = smoothedSpeedMps,
-                        bearingDeg = resolvedBearingDeg,
-                    ),
-            )
-        } else {
-            clampedCorrectionStreak = 0
-        }
-        correctionBlend =
-            CorrectionBlend(
-                from = currentDisplayed,
-                to = visibleTarget,
-                startElapsedMs = nowElapsedMs,
-                durationMs = correctionBlendDurationMs,
-            )
-        MarkerMotionTelemetry.recordFixAccepted(
-            mode = MarkerMotionMode.BLEND,
-            reason =
-                when {
-                    useWatchGpsCatchUp -> "watch_gps_catch_up"
-                    correctionTarget.wasClamped -> "correction_clamped"
-                    else -> "gps_correction"
-                },
-            nowElapsedMs = nowElapsedMs,
-            fixAgeMs = fixAgeMs,
-            accuracyM = sanitizedAccuracy,
-            speedMps = smoothedSpeedMps,
-            bearingDeg = resolvedBearingDeg,
-            correctionDistanceM = correctionTarget.visibleCorrectionDistanceM,
-            blendDurationMs = correctionBlendDurationMs,
-        )
-        return currentDisplayed
-    }
+    fun onGpsFix(fix: MarkerMotionGpsFix): LatLong = fixProcessor.onGpsFix(fix)
 
     fun predict(
         nowElapsedMs: Long,
         serviceFreshnessMaxAgeMs: Long,
         watchGpsDegraded: Boolean,
     ): LatLong? {
-        var currentDisplayed = displayedLatLong ?: lastAcceptedFix?.latLong ?: return null
+        var currentDisplayed = state.displayedLatLong ?: state.lastAcceptedFix?.latLong ?: return null
 
-        correctionBlend?.let { blend ->
+        state.correctionBlend?.let { blend ->
             val elapsedMs = (nowElapsedMs - blend.startElapsedMs).coerceAtLeast(0L)
             val fraction = (elapsedMs.toFloat() / blend.durationMs.toFloat()).coerceIn(0f, 1f)
             val blended = lerpLatLong(blend.from, blend.to, fraction)
-            displayedLatLong = blended
-            lastAcceptedFix?.let { fix ->
+            state.displayedLatLong = blended
+            state.lastAcceptedFix?.let { fix ->
                 MarkerMotionTelemetry.recordBlendState(
                     nowElapsedMs = nowElapsedMs,
                     fixAgeMs = (nowElapsedMs - fix.fixElapsedMs).coerceAtLeast(0L),
@@ -332,12 +131,12 @@ internal class MarkerMotionController(
             if (fraction < 1f) {
                 return blended
             }
-            correctionBlend = null
+            state.correctionBlend = null
             currentDisplayed = blended
         }
 
-        if (watchGpsDegraded || predictionRequiresFreshFix) {
-            val fix = lastAcceptedFix
+        if (watchGpsDegraded || state.predictionRequiresFreshFix) {
+            val fix = state.lastAcceptedFix
             MarkerMotionTelemetry.recordPredictionBlocked(
                 reason = if (watchGpsDegraded) "degraded_gps" else "await_fresh_fix",
                 nowElapsedMs = nowElapsedMs,
@@ -349,7 +148,7 @@ internal class MarkerMotionController(
             return currentDisplayed
         }
 
-        val fix = lastAcceptedFix ?: return currentDisplayed
+        val fix = state.lastAcceptedFix ?: return currentDisplayed
         val freshnessMaxAgeMs =
             minOf(
                 predictionFreshnessMaxAgeMs,
@@ -434,8 +233,356 @@ internal class MarkerMotionController(
         if (distanceMeters(currentDisplayed, predicted) < PREDICTION_RENDER_EPSILON_M) {
             return currentDisplayed
         }
-        displayedLatLong = predicted
+        state.displayedLatLong = predicted
         return predicted
+    }
+}
+
+@Suppress("TooManyFunctions")
+private class MarkerMotionGpsFixProcessor(
+    private val state: MarkerMotionState,
+    private val maxAcceptedFixAgeMs: Long,
+    private val minPredictionSpeedMps: Float,
+    private val correctionBlendDurationMs: Long,
+) {
+    fun onGpsFix(fix: MarkerMotionGpsFix): LatLong {
+        val context = buildGpsFixContext(fix)
+        return rejectGpsFix(context) ?: acceptGpsFix(context)
+    }
+
+    private fun buildGpsFixContext(fix: MarkerMotionGpsFix): GpsFixContext {
+        val reliableFixElapsedMs =
+            fix.reading.fixElapsedMs
+                .takeIf { it > 0L }
+                ?.coerceAtMost(fix.nowElapsedMs)
+                ?: fix.nowElapsedMs
+        return GpsFixContext(
+            fix = fix,
+            timing =
+                GpsFixTiming(
+                    reliableFixElapsedMs = reliableFixElapsedMs,
+                    fixAgeMs = (fix.nowElapsedMs - reliableFixElapsedMs).coerceAtLeast(0L),
+                ),
+            accuracyM = effectiveMotionAccuracy(fix.reading.accuracyM, fix.sourceMode),
+            currentDisplayed = state.displayedLatLong,
+            previousFix = state.lastAcceptedFix,
+        )
+    }
+
+    private fun rejectGpsFix(context: GpsFixContext): LatLong? =
+        when {
+            isStaleGpsFix(context) -> rejectBlockedGpsFix(context, "stale_fix", context.currentDisplayed)
+            else -> rejectDuplicateGpsFix(context) ?: rejectOutlierGpsFix(context)
+        }
+
+    private fun isStaleGpsFix(context: GpsFixContext): Boolean {
+        val hasDisplayedMarker = context.currentDisplayed != null
+        val fixIsTooOld = context.timing.fixAgeMs > maxAcceptedFixAgeMs
+        return hasDisplayedMarker && fixIsTooOld
+    }
+
+    private fun rejectBlockedGpsFix(
+        context: GpsFixContext,
+        reason: String,
+        displayLatLong: LatLong?,
+    ): LatLong? {
+        recordBlockedGpsFix(context, reason)
+        return displayLatLong
+    }
+
+    private fun rejectDuplicateGpsFix(context: GpsFixContext): LatLong? {
+        val previousFix = context.previousFix ?: return null
+        val isDuplicate =
+            isDuplicateMotionFix(
+                previousFix = previousFix,
+                candidate = context.fix.latLong,
+                candidateFixElapsedMs = context.timing.reliableFixElapsedMs,
+                candidateAccuracyM = context.accuracyM,
+            )
+        return if (isDuplicate) {
+            rejectBlockedGpsFix(
+                context = context,
+                reason = "duplicate_fix",
+                displayLatLong = context.currentDisplayed ?: previousFix.latLong,
+            )
+        } else {
+            null
+        }
+    }
+
+    private fun rejectOutlierGpsFix(context: GpsFixContext): LatLong? {
+        val previousFix = context.previousFix
+        val outlierDecision =
+            previousFix?.detectOutlier(
+                candidate = context.fix.latLong,
+                candidateAccuracyM = context.accuracyM,
+                candidateFixElapsedMs = context.timing.reliableFixElapsedMs,
+            )
+        return if (previousFix != null && outlierDecision != null) {
+            state.correctionBlend = null
+            state.clampedCorrectionStreak = 0
+            MarkerMotionTelemetry.recordOutlierDropped(
+                nowElapsedMs = context.fix.nowElapsedMs,
+                fixAgeMs = context.timing.fixAgeMs,
+                accuracyM = context.accuracyM,
+                jumpMeters = outlierDecision.jumpMeters,
+                impliedSpeedMps = outlierDecision.impliedSpeedMps,
+                dtSec = outlierDecision.dtSec,
+            )
+            context.currentDisplayed ?: previousFix.latLong
+        } else {
+            null
+        }
+    }
+
+    private fun recordBlockedGpsFix(
+        context: GpsFixContext,
+        reason: String,
+    ) {
+        MarkerMotionTelemetry.recordPredictionBlocked(
+            reason = reason,
+            nowElapsedMs = context.fix.nowElapsedMs,
+            fixAgeMs = context.timing.fixAgeMs,
+            accuracyM = context.accuracyM,
+            speedMps =
+                context.fix.reading.speedMps
+                    .takeIf { it.isFinite() },
+            bearingDeg =
+                context.fix.reading.bearingDeg
+                    ?.takeIf { it.isFinite() },
+        )
+    }
+
+    private fun acceptGpsFix(context: GpsFixContext): LatLong {
+        val motion = resolveAcceptedMotion(context)
+        state.lastAcceptedFix =
+            MotionFix(
+                latLong = context.fix.latLong,
+                fixElapsedMs = context.timing.reliableFixElapsedMs,
+                accuracyM = context.accuracyM,
+                speedMps = motion.speedMps,
+                bearingDeg = motion.bearingDeg,
+            )
+        state.predictionRequiresFreshFix = false
+        return applyAcceptedGpsFix(context, motion)
+    }
+
+    private fun resolveAcceptedMotion(context: GpsFixContext): ResolvedMotion {
+        val derivedMotion =
+            context.previousFix?.deriveMotionTo(
+                target = context.fix.latLong,
+                targetFixElapsedMs = context.timing.reliableFixElapsedMs,
+            )
+        val resolvedSpeedMps =
+            resolveMotionSpeedMps(
+                rawSpeedMps = context.fix.reading.speedMps,
+                derivedSpeedMps = derivedMotion?.speedMps,
+                accuracyM = context.accuracyM,
+            )
+        state.smoothedSpeedMps = smoothMotionSpeed(resolvedSpeedMps)
+        return ResolvedMotion(
+            speedMps = state.smoothedSpeedMps,
+            bearingDeg =
+                resolveMotionBearingDeg(
+                    rawBearingDeg = context.fix.reading.bearingDeg,
+                    rawSpeedMps = context.fix.reading.speedMps,
+                    derivedMotion = derivedMotion,
+                    fallbackBearingDeg = context.previousFix?.bearingDeg,
+                    resolvedSpeedMps = state.smoothedSpeedMps,
+                ),
+        )
+    }
+
+    private fun smoothMotionSpeed(resolvedSpeedMps: Float): Float =
+        if (state.smoothedSpeedMps <= 0f) {
+            resolvedSpeedMps
+        } else {
+            SPEED_SMOOTHING_ALPHA * resolvedSpeedMps +
+                (1f - SPEED_SMOOTHING_ALPHA) * state.smoothedSpeedMps
+        }
+
+    private fun applyAcceptedGpsFix(
+        context: GpsFixContext,
+        motion: ResolvedMotion,
+    ): LatLong =
+        context.currentDisplayed
+            ?.let { currentDisplayed ->
+                val correction =
+                    CorrectionContext(
+                        currentDisplayed = currentDisplayed,
+                        correctionDistanceM = distanceMeters(currentDisplayed, context.fix.latLong),
+                    )
+                acceptCorrection(context, motion, correction)
+            }
+            ?: acceptInitialFix(context, motion)
+
+    private fun acceptInitialFix(
+        context: GpsFixContext,
+        motion: ResolvedMotion,
+    ): LatLong {
+        state.displayedLatLong = context.fix.latLong
+        state.correctionBlend = null
+        state.clampedCorrectionStreak = 0
+        recordFixAccepted(
+            context = context,
+            motion = motion,
+            event =
+                FixAcceptedTelemetry(
+                    mode = MarkerMotionMode.FIXED,
+                    reason = "initial_fix",
+                    correctionDistanceM = null,
+                    blendDurationMs = null,
+                ),
+        )
+        return context.fix.latLong
+    }
+
+    private fun acceptCorrection(
+        context: GpsFixContext,
+        motion: ResolvedMotion,
+        correction: CorrectionContext,
+    ): LatLong =
+        when {
+            shouldFreezeStationaryJitter(correction.correctionDistanceM, context.accuracyM, motion.speedMps) ->
+                acceptStationaryJitter(context, motion, correction)
+            correction.correctionDistanceM <= correctionDeadbandMeters(context.accuracyM, motion.speedMps) ->
+                acceptDeadbandSnap(context, motion, correction)
+            else -> startCorrectionBlend(context, motion, correction)
+        }
+
+    private fun acceptStationaryJitter(
+        context: GpsFixContext,
+        motion: ResolvedMotion,
+        correction: CorrectionContext,
+    ): LatLong {
+        state.correctionBlend = null
+        state.clampedCorrectionStreak = 0
+        recordFixAccepted(
+            context = context,
+            motion = motion,
+            event =
+                FixAcceptedTelemetry(
+                    mode = MarkerMotionMode.FIXED,
+                    reason = "stationary_jitter",
+                    correctionDistanceM = correction.correctionDistanceM,
+                    blendDurationMs = null,
+                ),
+        )
+        return correction.currentDisplayed
+    }
+
+    private fun acceptDeadbandSnap(
+        context: GpsFixContext,
+        motion: ResolvedMotion,
+        correction: CorrectionContext,
+    ): LatLong {
+        state.displayedLatLong = context.fix.latLong
+        state.correctionBlend = null
+        state.clampedCorrectionStreak = 0
+        recordFixAccepted(
+            context = context,
+            motion = motion,
+            event =
+                FixAcceptedTelemetry(
+                    mode = MarkerMotionMode.FIXED,
+                    reason = "deadband_snap",
+                    correctionDistanceM = correction.correctionDistanceM,
+                    blendDurationMs = null,
+                ),
+        )
+        return context.fix.latLong
+    }
+
+    private fun startCorrectionBlend(
+        context: GpsFixContext,
+        motion: ResolvedMotion,
+        correction: CorrectionContext,
+    ): LatLong {
+        val useWatchGpsCatchUp = shouldCatchUpSustainedWatchGpsLag(context, motion, correction)
+        val correctionTarget =
+            resolveCorrectionTarget(
+                request =
+                    CorrectionTargetRequest(
+                        currentDisplayed = correction.currentDisplayed,
+                        targetLatLong = context.fix.latLong,
+                        correctionDistanceM = correction.correctionDistanceM,
+                        accuracyM = context.accuracyM,
+                        speedMps = motion.speedMps,
+                        allowLargeCorrection = context.fix.allowLargeCorrection || useWatchGpsCatchUp,
+                    ),
+            )
+        updateClampTelemetry(context, motion, correction, correctionTarget)
+        state.correctionBlend =
+            CorrectionBlend(
+                from = correction.currentDisplayed,
+                to = correctionTarget.targetLatLong,
+                startElapsedMs = context.fix.nowElapsedMs,
+                durationMs = correctionBlendDurationMs,
+            )
+        recordFixAccepted(
+            context = context,
+            motion = motion,
+            event =
+                FixAcceptedTelemetry(
+                    mode = MarkerMotionMode.BLEND,
+                    reason = correctionReason(useWatchGpsCatchUp, correctionTarget.wasClamped),
+                    correctionDistanceM = correctionTarget.visibleCorrectionDistanceM,
+                    blendDurationMs = correctionBlendDurationMs,
+                ),
+        )
+        return correction.currentDisplayed
+    }
+
+    private fun updateClampTelemetry(
+        context: GpsFixContext,
+        motion: ResolvedMotion,
+        correction: CorrectionContext,
+        correctionTarget: CorrectionTargetDecision,
+    ) {
+        if (correctionTarget.wasClamped) {
+            state.clampedCorrectionStreak += 1
+            MarkerMotionTelemetry.recordCorrectionClamped(
+                event =
+                    CorrectionClampTelemetryEvent(
+                        nowElapsedMs = context.fix.nowElapsedMs,
+                        actualCorrectionDistanceM = correction.correctionDistanceM,
+                        visibleCorrectionDistanceM = correctionTarget.visibleCorrectionDistanceM,
+                        accuracyM = context.accuracyM,
+                        speedMps = motion.speedMps,
+                        bearingDeg = motion.bearingDeg,
+                    ),
+            )
+        } else {
+            state.clampedCorrectionStreak = 0
+        }
+    }
+
+    private fun correctionReason(
+        useWatchGpsCatchUp: Boolean,
+        wasClamped: Boolean,
+    ): String =
+        when {
+            useWatchGpsCatchUp -> "watch_gps_catch_up"
+            wasClamped -> "correction_clamped"
+            else -> "gps_correction"
+        }
+
+    private fun recordFixAccepted(
+        context: GpsFixContext,
+        motion: ResolvedMotion,
+        event: FixAcceptedTelemetry,
+    ) {
+        MarkerMotionTelemetry.recordFixAccepted(
+            mode = event.mode,
+            reason = event.reason,
+            nowElapsedMs = context.fix.nowElapsedMs,
+            fixAgeMs = context.timing.fixAgeMs,
+            accuracyM = context.accuracyM,
+            speedMps = motion.speedMps,
+            bearingDeg = motion.bearingDeg,
+            correctionDistanceM = event.correctionDistanceM,
+            blendDurationMs = event.blendDurationMs,
+        )
     }
 
     private fun MotionFix.detectOutlier(
@@ -446,7 +593,6 @@ internal class MarkerMotionController(
         val dtMs = (candidateFixElapsedMs - fixElapsedMs).coerceAtLeast(0L)
         if (dtMs < OUTLIER_MIN_WINDOW_MS) return null
         val dtSec = dtMs / 1000f
-        if (dtSec <= 0f) return null
 
         val jumpMeters = distanceMeters(latLong, candidate)
         val impliedSpeedMps = jumpMeters / dtSec
@@ -536,16 +682,18 @@ internal class MarkerMotionController(
     }
 
     private fun shouldCatchUpSustainedWatchGpsLag(
-        sourceMode: LocationSourceMode,
-        correctionDistanceM: Float,
-        accuracyM: Float,
-        speedMps: Float,
+        context: GpsFixContext,
+        motion: ResolvedMotion,
+        correction: CorrectionContext,
     ): Boolean {
-        if (sourceMode != LocationSourceMode.WATCH_GPS) return false
-        if (clampedCorrectionStreak < WATCH_GPS_CATCH_UP_CLAMP_STREAK) return false
-        if (accuracyM > WATCH_GPS_CATCH_UP_MAX_ACCURACY_M) return false
-        if (speedMps < WATCH_GPS_CATCH_UP_MIN_SPEED_MPS) return false
-        return correctionDistanceM >= WATCH_GPS_CATCH_UP_MIN_LAG_M
+        val isWatchGps = context.fix.sourceMode == LocationSourceMode.WATCH_GPS
+        val hasRepeatedClamp = state.clampedCorrectionStreak >= WATCH_GPS_CATCH_UP_CLAMP_STREAK
+        val hasUsableMotion =
+            context.accuracyM <= WATCH_GPS_CATCH_UP_MAX_ACCURACY_M &&
+                motion.speedMps >= WATCH_GPS_CATCH_UP_MIN_SPEED_MPS
+        val hasVisibleLag = correction.correctionDistanceM >= WATCH_GPS_CATCH_UP_MIN_LAG_M
+        val isWatchLagCandidate = isWatchGps && hasRepeatedClamp
+        return isWatchLagCandidate && hasUsableMotion && hasVisibleLag
     }
 
     private fun resolveMotionSpeedMps(
@@ -567,19 +715,23 @@ internal class MarkerMotionController(
                 ?.takeIf { it in DERIVED_WALKING_SPEED_MIN_MPS..DERIVED_WALKING_SPEED_MAX_MPS }
                 ?.coerceAtMost(DERIVED_WALKING_SPEED_CAP_MPS)
 
-        if (
-            trustedRawSpeed != null &&
-            trustedWalkingDerivedSpeed != null &&
-            trustedRawSpeed <= LOW_RAW_SPEED_OVERRIDE_MAX_MPS &&
-            trustedWalkingDerivedSpeed >= trustedRawSpeed + LOW_RAW_SPEED_OVERRIDE_GAIN_MPS
-        ) {
-            return trustedWalkingDerivedSpeed
+        return when {
+            shouldPreferWalkingDerivedSpeed(trustedRawSpeed, trustedWalkingDerivedSpeed) ->
+                trustedWalkingDerivedSpeed ?: 0f
+            trustedRawSpeed != null -> trustedRawSpeed
+            trustedWalkingDerivedSpeed != null -> trustedWalkingDerivedSpeed
+            else -> 0f
         }
-        if (trustedRawSpeed != null) return trustedRawSpeed
-        if (trustedWalkingDerivedSpeed != null) {
-            return trustedWalkingDerivedSpeed
-        }
-        return 0f
+    }
+
+    private fun shouldPreferWalkingDerivedSpeed(
+        rawSpeedMps: Float?,
+        walkingDerivedSpeedMps: Float?,
+    ): Boolean {
+        if (rawSpeedMps == null || walkingDerivedSpeedMps == null) return false
+        val rawLooksLow = rawSpeedMps <= LOW_RAW_SPEED_OVERRIDE_MAX_MPS
+        val derivedPullsAhead = walkingDerivedSpeedMps >= rawSpeedMps + LOW_RAW_SPEED_OVERRIDE_GAIN_MPS
+        return rawLooksLow && derivedPullsAhead
     }
 
     private fun resolveMotionBearingDeg(
@@ -589,22 +741,28 @@ internal class MarkerMotionController(
         fallbackBearingDeg: Float?,
         resolvedSpeedMps: Float,
     ): Float? {
-        if (
+        val rawBearingIsUsable =
             rawBearingDeg != null &&
-            rawBearingDeg.isFinite() &&
-            max(sanitizeSpeed(rawSpeedMps), resolvedSpeedMps) >= GPS_BEARING_MIN_SPEED_MPS
-        ) {
-            return normalize360(rawBearingDeg)
+                rawBearingDeg.isFinite() &&
+                max(sanitizeSpeed(rawSpeedMps), resolvedSpeedMps) >= GPS_BEARING_MIN_SPEED_MPS
+        val derivedBearingIsUsable =
+            derivedMotion?.bearingDeg != null &&
+                max(derivedMotion.speedMps, resolvedSpeedMps) >= minPredictionSpeedMps
+        return when {
+            rawBearingIsUsable -> normalize360(rawBearingDeg)
+            derivedBearingIsUsable -> derivedMotion.bearingDeg
+            else -> fallbackBearingDeg?.let(::normalize360)
         }
-        if (
-            derivedMotion != null &&
-            derivedMotion.bearingDeg != null &&
-            max(derivedMotion.speedMps, resolvedSpeedMps) >= minPredictionSpeedMps
-        ) {
-            return derivedMotion.bearingDeg
-        }
-        return fallbackBearingDeg?.let(::normalize360)
     }
+}
+
+private class MarkerMotionState {
+    var lastAcceptedFix: MotionFix? = null
+    var displayedLatLong: LatLong? = null
+    var correctionBlend: CorrectionBlend? = null
+    var smoothedSpeedMps: Float = 0f
+    var predictionRequiresFreshFix: Boolean = true
+    var clampedCorrectionStreak: Int = 0
 }
 
 private data class MotionFix(
@@ -613,6 +771,36 @@ private data class MotionFix(
     val accuracyM: Float,
     val speedMps: Float,
     val bearingDeg: Float?,
+)
+
+private data class GpsFixTiming(
+    val reliableFixElapsedMs: Long,
+    val fixAgeMs: Long,
+)
+
+private data class GpsFixContext(
+    val fix: MarkerMotionGpsFix,
+    val timing: GpsFixTiming,
+    val accuracyM: Float,
+    val currentDisplayed: LatLong?,
+    val previousFix: MotionFix?,
+)
+
+private data class ResolvedMotion(
+    val speedMps: Float,
+    val bearingDeg: Float?,
+)
+
+private data class CorrectionContext(
+    val currentDisplayed: LatLong,
+    val correctionDistanceM: Float,
+)
+
+private data class FixAcceptedTelemetry(
+    val mode: MarkerMotionMode,
+    val reason: String,
+    val correctionDistanceM: Float?,
+    val blendDurationMs: Long?,
 )
 
 private data class CorrectionBlend(
@@ -697,9 +885,10 @@ private fun isDuplicateMotionFix(
     candidateAccuracyM: Float,
 ): Boolean {
     val fixTimeDeltaMs = candidateFixElapsedMs - previousFix.fixElapsedMs
-    if (fixTimeDeltaMs > DUPLICATE_FIX_TIME_EPSILON_MS) return false
-    if (abs(previousFix.accuracyM - candidateAccuracyM) > DUPLICATE_FIX_ACCURACY_EPSILON_M) return false
-    return distanceMeters(previousFix.latLong, candidate) <= DUPLICATE_FIX_DISTANCE_EPSILON_M
+    val isSameTime = fixTimeDeltaMs <= DUPLICATE_FIX_TIME_EPSILON_MS
+    val isSameAccuracy = abs(previousFix.accuracyM - candidateAccuracyM) <= DUPLICATE_FIX_ACCURACY_EPSILON_M
+    val isSamePosition = distanceMeters(previousFix.latLong, candidate) <= DUPLICATE_FIX_DISTANCE_EPSILON_M
+    return isSameTime && isSameAccuracy && isSamePosition
 }
 
 private fun sanitizeSpeed(speedMps: Float): Float {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionController.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionController.kt
@@ -1,7 +1,11 @@
 package com.glancemap.glancemapwearos.presentation.features.navigate.motion
 
+import com.glancemap.glancemapwearos.core.service.location.config.WATCH_GPS_ACCURACY_FLOOR_M
+import com.glancemap.glancemapwearos.core.service.location.config.WATCH_GPS_ACCURACY_FLOOR_TOLERANCE_M
+import com.glancemap.glancemapwearos.core.service.location.policy.LocationSourceMode
 import com.glancemap.glancemapwearos.presentation.features.navigate.moveLatLong
 import org.mapsforge.core.model.LatLong
+import kotlin.math.abs
 import kotlin.math.asin
 import kotlin.math.atan2
 import kotlin.math.cos
@@ -22,6 +26,7 @@ internal class MarkerMotionController(
     private var correctionBlend: CorrectionBlend? = null
     private var smoothedSpeedMps: Float = 0f
     private var predictionRequiresFreshFix: Boolean = true
+    private var clampedCorrectionStreak: Int = 0
 
     fun reset(reason: String = "reset") {
         lastAcceptedFix = null
@@ -29,6 +34,7 @@ internal class MarkerMotionController(
         correctionBlend = null
         smoothedSpeedMps = 0f
         predictionRequiresFreshFix = true
+        clampedCorrectionStreak = 0
         MarkerMotionTelemetry.recordIdle(
             nowElapsedMs = 0L,
             reason = reason,
@@ -41,23 +47,26 @@ internal class MarkerMotionController(
         accuracyM: Float,
         speedMps: Float,
         bearingDeg: Float?,
+        sourceMode: LocationSourceMode = LocationSourceMode.AUTO_FUSED,
     ) {
         val sanitizedSpeed = sanitizeSpeed(speedMps)
+        val motionAccuracyM = effectiveMotionAccuracy(accuracyM, sourceMode)
         smoothedSpeedMps = sanitizedSpeed
         lastAcceptedFix =
             MotionFix(
                 latLong = latLong,
                 fixElapsedMs = fixElapsedMs.coerceAtLeast(0L),
-                accuracyM = sanitizeAccuracy(accuracyM),
+                accuracyM = motionAccuracyM,
                 speedMps = sanitizedSpeed,
                 bearingDeg = bearingDeg?.let(::normalize360),
             )
         displayedLatLong = latLong
         correctionBlend = null
         predictionRequiresFreshFix = true
+        clampedCorrectionStreak = 0
         MarkerMotionTelemetry.recordSeedAnchor(
             nowElapsedMs = fixElapsedMs.coerceAtLeast(0L),
-            accuracyM = sanitizeAccuracy(accuracyM),
+            accuracyM = motionAccuracyM,
             speedMps = sanitizedSpeed,
             bearingDeg = bearingDeg?.let(::normalize360),
         )
@@ -86,9 +95,10 @@ internal class MarkerMotionController(
         rawSpeedMps: Float,
         rawBearingDeg: Float?,
         allowLargeCorrection: Boolean = false,
+        sourceMode: LocationSourceMode = LocationSourceMode.AUTO_FUSED,
     ): LatLong {
         val currentDisplayed = displayedLatLong
-        val sanitizedAccuracy = sanitizeAccuracy(accuracyM)
+        val sanitizedAccuracy = effectiveMotionAccuracy(accuracyM, sourceMode)
         val reliableFixElapsedMs =
             fixElapsedMs
                 .takeIf { it > 0L }
@@ -109,6 +119,25 @@ internal class MarkerMotionController(
         }
 
         val previousFix = lastAcceptedFix
+        if (
+            previousFix != null &&
+            isDuplicateMotionFix(
+                previousFix = previousFix,
+                candidate = latLong,
+                candidateFixElapsedMs = reliableFixElapsedMs,
+                candidateAccuracyM = sanitizedAccuracy,
+            )
+        ) {
+            MarkerMotionTelemetry.recordPredictionBlocked(
+                reason = "duplicate_fix",
+                nowElapsedMs = nowElapsedMs,
+                fixAgeMs = fixAgeMs,
+                accuracyM = sanitizedAccuracy,
+                speedMps = rawSpeedMps.takeIf { it.isFinite() },
+                bearingDeg = rawBearingDeg?.takeIf { it.isFinite() },
+            )
+            return currentDisplayed ?: previousFix.latLong
+        }
         val outlierDecision =
             previousFix?.detectOutlier(
                 candidate = latLong,
@@ -117,6 +146,7 @@ internal class MarkerMotionController(
             )
         if (outlierDecision != null) {
             correctionBlend = null
+            clampedCorrectionStreak = 0
             MarkerMotionTelemetry.recordOutlierDropped(
                 nowElapsedMs = nowElapsedMs,
                 fixAgeMs = fixAgeMs,
@@ -164,6 +194,7 @@ internal class MarkerMotionController(
         if (currentDisplayed == null) {
             displayedLatLong = latLong
             correctionBlend = null
+            clampedCorrectionStreak = 0
             MarkerMotionTelemetry.recordFixAccepted(
                 mode = MarkerMotionMode.FIXED,
                 reason = "initial_fix",
@@ -181,6 +212,7 @@ internal class MarkerMotionController(
         val correctionDistanceM = distanceMeters(currentDisplayed, latLong)
         if (shouldFreezeStationaryJitter(correctionDistanceM, sanitizedAccuracy, smoothedSpeedMps)) {
             correctionBlend = null
+            clampedCorrectionStreak = 0
             MarkerMotionTelemetry.recordFixAccepted(
                 mode = MarkerMotionMode.FIXED,
                 reason = "stationary_jitter",
@@ -198,6 +230,7 @@ internal class MarkerMotionController(
         if (correctionDistanceM <= correctionDeadbandMeters(sanitizedAccuracy, smoothedSpeedMps)) {
             displayedLatLong = latLong
             correctionBlend = null
+            clampedCorrectionStreak = 0
             MarkerMotionTelemetry.recordFixAccepted(
                 mode = MarkerMotionMode.FIXED,
                 reason = "deadband_snap",
@@ -212,6 +245,13 @@ internal class MarkerMotionController(
             return latLong
         }
 
+        val useWatchGpsCatchUp =
+            shouldCatchUpSustainedWatchGpsLag(
+                sourceMode = sourceMode,
+                correctionDistanceM = correctionDistanceM,
+                accuracyM = sanitizedAccuracy,
+                speedMps = smoothedSpeedMps,
+            )
         val correctionTarget =
             resolveCorrectionTarget(
                 request =
@@ -221,11 +261,12 @@ internal class MarkerMotionController(
                         correctionDistanceM = correctionDistanceM,
                         accuracyM = sanitizedAccuracy,
                         speedMps = smoothedSpeedMps,
-                        allowLargeCorrection = allowLargeCorrection,
+                        allowLargeCorrection = allowLargeCorrection || useWatchGpsCatchUp,
                     ),
             )
         val visibleTarget = correctionTarget.targetLatLong
         if (correctionTarget.wasClamped) {
+            clampedCorrectionStreak += 1
             MarkerMotionTelemetry.recordCorrectionClamped(
                 event =
                     CorrectionClampTelemetryEvent(
@@ -237,6 +278,8 @@ internal class MarkerMotionController(
                         bearingDeg = resolvedBearingDeg,
                     ),
             )
+        } else {
+            clampedCorrectionStreak = 0
         }
         correctionBlend =
             CorrectionBlend(
@@ -247,7 +290,12 @@ internal class MarkerMotionController(
             )
         MarkerMotionTelemetry.recordFixAccepted(
             mode = MarkerMotionMode.BLEND,
-            reason = if (correctionTarget.wasClamped) "correction_clamped" else "gps_correction",
+            reason =
+                when {
+                    useWatchGpsCatchUp -> "watch_gps_catch_up"
+                    correctionTarget.wasClamped -> "correction_clamped"
+                    else -> "gps_correction"
+                },
             nowElapsedMs = nowElapsedMs,
             fixAgeMs = fixAgeMs,
             accuracyM = sanitizedAccuracy,
@@ -487,6 +535,19 @@ internal class MarkerMotionController(
         )
     }
 
+    private fun shouldCatchUpSustainedWatchGpsLag(
+        sourceMode: LocationSourceMode,
+        correctionDistanceM: Float,
+        accuracyM: Float,
+        speedMps: Float,
+    ): Boolean {
+        if (sourceMode != LocationSourceMode.WATCH_GPS) return false
+        if (clampedCorrectionStreak < WATCH_GPS_CATCH_UP_CLAMP_STREAK) return false
+        if (accuracyM > WATCH_GPS_CATCH_UP_MAX_ACCURACY_M) return false
+        if (speedMps < WATCH_GPS_CATCH_UP_MIN_SPEED_MPS) return false
+        return correctionDistanceM >= WATCH_GPS_CATCH_UP_MIN_LAG_M
+    }
+
     private fun resolveMotionSpeedMps(
         rawSpeedMps: Float,
         derivedSpeedMps: Float?,
@@ -500,19 +561,23 @@ internal class MarkerMotionController(
             derivedSpeedMps
                 ?.takeIf { it.isFinite() }
                 ?.coerceAtLeast(0f)
+        val trustedWalkingDerivedSpeed =
+            trustedDerivedSpeed
+                ?.takeIf { accuracyM <= DERIVED_WALKING_SPEED_MAX_ACCURACY_M }
+                ?.takeIf { it in DERIVED_WALKING_SPEED_MIN_MPS..DERIVED_WALKING_SPEED_MAX_MPS }
+                ?.coerceAtMost(DERIVED_WALKING_SPEED_CAP_MPS)
 
         if (
             trustedRawSpeed != null &&
-            trustedDerivedSpeed != null &&
+            trustedWalkingDerivedSpeed != null &&
             trustedRawSpeed <= LOW_RAW_SPEED_OVERRIDE_MAX_MPS &&
-            accuracyM <= DERIVED_SPEED_MAX_ACCURACY_M &&
-            trustedDerivedSpeed >= trustedRawSpeed + LOW_RAW_SPEED_OVERRIDE_GAIN_MPS
+            trustedWalkingDerivedSpeed >= trustedRawSpeed + LOW_RAW_SPEED_OVERRIDE_GAIN_MPS
         ) {
-            return trustedDerivedSpeed
+            return trustedWalkingDerivedSpeed
         }
         if (trustedRawSpeed != null) return trustedRawSpeed
-        if (trustedDerivedSpeed != null && accuracyM <= DERIVED_SPEED_MAX_ACCURACY_M) {
-            return trustedDerivedSpeed
+        if (trustedWalkingDerivedSpeed != null) {
+            return trustedWalkingDerivedSpeed
         }
         return 0f
     }
@@ -604,6 +669,39 @@ private fun sanitizeAccuracy(accuracyM: Float): Float {
     return accuracyM.coerceAtLeast(0f)
 }
 
+private fun effectiveMotionAccuracy(
+    accuracyM: Float,
+    sourceMode: LocationSourceMode,
+): Float {
+    val sanitizedAccuracy = sanitizeAccuracy(accuracyM)
+    if (
+        sourceMode == LocationSourceMode.WATCH_GPS &&
+        isKnownWatchGpsAccuracyFloor(sanitizedAccuracy)
+    ) {
+        return WATCH_GPS_FLOOR_MOTION_ACCURACY_M
+    }
+    return sanitizedAccuracy
+}
+
+private fun isKnownWatchGpsAccuracyFloor(
+    accuracyM: Float,
+): Boolean {
+    if (!accuracyM.isFinite()) return false
+    return abs(accuracyM - WATCH_GPS_ACCURACY_FLOOR_M) <= WATCH_GPS_ACCURACY_FLOOR_TOLERANCE_M
+}
+
+private fun isDuplicateMotionFix(
+    previousFix: MotionFix,
+    candidate: LatLong,
+    candidateFixElapsedMs: Long,
+    candidateAccuracyM: Float,
+): Boolean {
+    val fixTimeDeltaMs = candidateFixElapsedMs - previousFix.fixElapsedMs
+    if (fixTimeDeltaMs > DUPLICATE_FIX_TIME_EPSILON_MS) return false
+    if (abs(previousFix.accuracyM - candidateAccuracyM) > DUPLICATE_FIX_ACCURACY_EPSILON_M) return false
+    return distanceMeters(previousFix.latLong, candidate) <= DUPLICATE_FIX_DISTANCE_EPSILON_M
+}
+
 private fun sanitizeSpeed(speedMps: Float): Float {
     if (!speedMps.isFinite()) return 0f
     return speedMps.coerceAtLeast(0f)
@@ -657,20 +755,31 @@ private fun lerpLatLong(
 
 private const val EARTH_RADIUS_METERS = 6_371_000.0
 private const val DEFAULT_UNKNOWN_ACCURACY_M = 99f
-private const val DEFAULT_MAX_PREDICTION_ACCURACY_M = 25f
-private const val DEFAULT_MIN_PREDICTION_SPEED_MPS = 0.7f
+private const val DEFAULT_MAX_PREDICTION_ACCURACY_M = 45f
+private const val WATCH_GPS_FLOOR_MOTION_ACCURACY_M = 18f
+private const val DEFAULT_MIN_PREDICTION_SPEED_MPS = 0.35f
 private const val DEFAULT_CORRECTION_BLEND_DURATION_MS = 350L
 private const val DEFAULT_PREDICTION_TICK_MS = 250L
 private const val PREDICTION_START_DELAY_MS = 150L
 private const val PREDICTION_SPEED_SCALE = 0.9f
 private const val MIN_PREDICTION_DISTANCE_M = 0.35f
 private const val PREDICTION_RENDER_EPSILON_M = 0.25f
+private const val DUPLICATE_FIX_TIME_EPSILON_MS = 250L
+private const val DUPLICATE_FIX_DISTANCE_EPSILON_M = 0.25f
+private const val DUPLICATE_FIX_ACCURACY_EPSILON_M = 0.1f
+private const val WATCH_GPS_CATCH_UP_CLAMP_STREAK = 2
+private const val WATCH_GPS_CATCH_UP_MIN_LAG_M = 60f
+private const val WATCH_GPS_CATCH_UP_MIN_SPEED_MPS = 2.0f
+private const val WATCH_GPS_CATCH_UP_MAX_ACCURACY_M = 25f
 private const val SPEED_SMOOTHING_ALPHA = 0.35f
-private const val GPS_BEARING_MIN_SPEED_MPS = 1.0f
+private const val GPS_BEARING_MIN_SPEED_MPS = 0.45f
 private const val DERIVED_MOTION_MIN_WINDOW_MS = 900L
-private const val DERIVED_SPEED_MAX_ACCURACY_M = 18f
+private const val DERIVED_WALKING_SPEED_MAX_ACCURACY_M = 45f
+private const val DERIVED_WALKING_SPEED_MIN_MPS = 0.25f
+private const val DERIVED_WALKING_SPEED_MAX_MPS = 2.4f
+private const val DERIVED_WALKING_SPEED_CAP_MPS = 1.8f
 private const val LOW_RAW_SPEED_OVERRIDE_MAX_MPS = 0.75f
-private const val LOW_RAW_SPEED_OVERRIDE_GAIN_MPS = 0.45f
+private const val LOW_RAW_SPEED_OVERRIDE_GAIN_MPS = 0.2f
 private const val OUTLIER_MIN_WINDOW_MS = 1_000L
 private const val MIN_OUTLIER_JUMP_M = 24f
 private const val OUTLIER_JUMP_MARGIN_M = 10f

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionTelemetry.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionTelemetry.kt
@@ -425,6 +425,7 @@ private fun reasonLabel(reason: String?): String? =
         "too_close" -> "tiny"
         "between_fixes" -> "between"
         "degraded_gps" -> "gps weak"
+        "watch_gps_catch_up" -> "watch catch up"
         "reset" -> "reset"
         "interactive_start" -> "screen wake"
         "tracking_stopped" -> "track off"

--- a/app/src/main/res/raw/keep_wear_capability.xml
+++ b/app/src/main/res/raw/keep_wear_capability.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@array/android_wear_capabilities" />

--- a/app/src/test/java/com/glancemap/glancemapwearos/core/service/location/LocationActivityClassifierTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/core/service/location/LocationActivityClassifierTest.kt
@@ -32,7 +32,7 @@ class LocationActivityClassifierTest {
         assertEquals(
             LocationActivityState.ACTIVE,
             classifier.evaluate(
-                nowElapsedMs = 8_999L,
+                nowElapsedMs = 15_999L,
                 speedMps = 0.1f,
                 hasEnterWindowHistory = true,
                 enterDisplacementMeters = 2f,
@@ -44,7 +44,7 @@ class LocationActivityClassifierTest {
         assertEquals(
             LocationActivityState.STATIONARY,
             classifier.evaluate(
-                nowElapsedMs = 9_000L,
+                nowElapsedMs = 16_000L,
                 speedMps = 0.1f,
                 hasEnterWindowHistory = true,
                 enterDisplacementMeters = 2f,
@@ -93,7 +93,7 @@ class LocationActivityClassifierTest {
         assertEquals(
             LocationActivityState.ACTIVE,
             classifier.evaluate(
-                nowElapsedMs = 13_999L,
+                nowElapsedMs = 20_999L,
                 speedMps = 0.1f,
                 hasEnterWindowHistory = true,
                 enterDisplacementMeters = 2f,
@@ -105,12 +105,39 @@ class LocationActivityClassifierTest {
         assertEquals(
             LocationActivityState.STATIONARY,
             classifier.evaluate(
-                nowElapsedMs = 14_000L,
+                nowElapsedMs = 21_000L,
                 speedMps = 0.1f,
                 hasEnterWindowHistory = true,
                 enterDisplacementMeters = 2f,
                 hasExitWindowHistory = false,
                 exitDisplacementMeters = 0f,
+            ),
+        )
+    }
+
+    @Test
+    fun staysActiveForWalkingDisplacementEvenWhenProviderSpeedIsZero() {
+        val classifier = LocationActivityClassifier()
+        classifier.reset(LocationActivityState.ACTIVE)
+
+        classifier.evaluate(
+            nowElapsedMs = 1_000L,
+            speedMps = 0f,
+            hasEnterWindowHistory = true,
+            enterDisplacementMeters = 12f,
+            hasExitWindowHistory = true,
+            exitDisplacementMeters = 12f,
+        )
+
+        assertEquals(
+            LocationActivityState.ACTIVE,
+            classifier.evaluate(
+                nowElapsedMs = 30_000L,
+                speedMps = 0f,
+                hasEnterWindowHistory = true,
+                enterDisplacementMeters = 12f,
+                hasExitWindowHistory = true,
+                exitDisplacementMeters = 12f,
             ),
         )
     }
@@ -135,7 +162,7 @@ class LocationActivityClassifierTest {
         assertEquals(
             LocationActivityState.STATIONARY,
             classifier.evaluate(
-                nowElapsedMs = 4_999L,
+                nowElapsedMs = 2_999L,
                 speedMps = 0.8f,
                 hasEnterWindowHistory = true,
                 enterDisplacementMeters = 1f,
@@ -147,12 +174,42 @@ class LocationActivityClassifierTest {
         assertEquals(
             LocationActivityState.ACTIVE,
             classifier.evaluate(
-                nowElapsedMs = 5_000L,
+                nowElapsedMs = 3_000L,
                 speedMps = 0.8f,
                 hasEnterWindowHistory = true,
                 enterDisplacementMeters = 1f,
                 hasExitWindowHistory = true,
                 exitDisplacementMeters = 25f,
+            ),
+        )
+    }
+
+    @Test
+    fun exitsStationaryFromWalkingDisplacementEvenWhenProviderSpeedIsZero() {
+        val classifier = LocationActivityClassifier()
+        classifier.reset(LocationActivityState.STATIONARY)
+
+        assertEquals(
+            LocationActivityState.STATIONARY,
+            classifier.evaluate(
+                nowElapsedMs = 1_000L,
+                speedMps = 0f,
+                hasEnterWindowHistory = true,
+                enterDisplacementMeters = 1f,
+                hasExitWindowHistory = true,
+                exitDisplacementMeters = 12f,
+            ),
+        )
+
+        assertEquals(
+            LocationActivityState.ACTIVE,
+            classifier.evaluate(
+                nowElapsedMs = 3_000L,
+                speedMps = 0f,
+                hasEnterWindowHistory = true,
+                enterDisplacementMeters = 1f,
+                hasExitWindowHistory = true,
+                exitDisplacementMeters = 12f,
             ),
         )
     }
@@ -190,7 +247,7 @@ class LocationActivityClassifierTest {
         assertEquals(
             LocationActivityState.ACTIVE,
             classifier.evaluate(
-                nowElapsedMs = 17_999L,
+                nowElapsedMs = 24_999L,
                 speedMps = 0.1f,
                 hasEnterWindowHistory = true,
                 enterDisplacementMeters = 5f,
@@ -203,7 +260,7 @@ class LocationActivityClassifierTest {
         assertEquals(
             LocationActivityState.STATIONARY,
             classifier.evaluate(
-                nowElapsedMs = 18_000L,
+                nowElapsedMs = 25_000L,
                 speedMps = 0.1f,
                 hasEnterWindowHistory = true,
                 enterDisplacementMeters = 5f,
@@ -216,7 +273,7 @@ class LocationActivityClassifierTest {
         assertEquals(
             LocationActivityState.STATIONARY,
             classifier.evaluate(
-                nowElapsedMs = 20_000L,
+                nowElapsedMs = 27_000L,
                 speedMps = 0.95f,
                 hasEnterWindowHistory = true,
                 enterDisplacementMeters = 20f,
@@ -227,7 +284,7 @@ class LocationActivityClassifierTest {
         assertEquals(
             LocationActivityState.STATIONARY,
             classifier.evaluate(
-                nowElapsedMs = 23_999L,
+                nowElapsedMs = 28_999L,
                 speedMps = 0.95f,
                 hasEnterWindowHistory = true,
                 enterDisplacementMeters = 20f,
@@ -240,7 +297,7 @@ class LocationActivityClassifierTest {
         assertEquals(
             LocationActivityState.ACTIVE,
             classifier.evaluate(
-                nowElapsedMs = 24_000L,
+                nowElapsedMs = 29_000L,
                 speedMps = 0.95f,
                 hasEnterWindowHistory = true,
                 enterDisplacementMeters = 20f,

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionControllerTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionControllerTest.kt
@@ -552,6 +552,34 @@ class MarkerMotionControllerTest {
     }
 }
 
+@Suppress("LongParameterList")
+private fun MarkerMotionController.onGpsFix(
+    latLong: LatLong,
+    nowElapsedMs: Long,
+    fixElapsedMs: Long,
+    accuracyM: Float,
+    rawSpeedMps: Float,
+    rawBearingDeg: Float?,
+    allowLargeCorrection: Boolean = false,
+    sourceMode: LocationSourceMode = LocationSourceMode.AUTO_FUSED,
+): LatLong =
+    onGpsFix(
+        fix =
+            MarkerMotionGpsFix(
+                latLong = latLong,
+                nowElapsedMs = nowElapsedMs,
+                reading =
+                    MarkerMotionReading(
+                        fixElapsedMs = fixElapsedMs,
+                        accuracyM = accuracyM,
+                        speedMps = rawSpeedMps,
+                        bearingDeg = rawBearingDeg,
+                    ),
+                allowLargeCorrection = allowLargeCorrection,
+                sourceMode = sourceMode,
+            ),
+    )
+
 private fun distanceMeters(
     from: LatLong,
     to: LatLong,

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionControllerTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionControllerTest.kt
@@ -1,5 +1,6 @@
 package com.glancemap.glancemapwearos.presentation.features.navigate.motion
 
+import com.glancemap.glancemapwearos.core.service.location.policy.LocationSourceMode
 import com.glancemap.glancemapwearos.presentation.features.navigate.moveLatLong
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -57,7 +58,7 @@ class MarkerMotionControllerTest {
             latLong = base,
             nowElapsedMs = 20_000L,
             fixElapsedMs = 20_000L,
-            accuracyM = 32f,
+            accuracyM = 70f,
             rawSpeedMps = 1.5f,
             rawBearingDeg = 90f,
         )
@@ -73,6 +74,97 @@ class MarkerMotionControllerTest {
         val snapshot = MarkerMotionTelemetry.latestSnapshot()
         assertEquals(MarkerMotionMode.FIXED, snapshot.mode)
         assertEquals("bad_accuracy", snapshot.reason)
+    }
+
+    @Test
+    fun predictsCautiousWalkingFromModerateAccuracyWhenProviderSpeedIsZero() {
+        MarkerMotionTelemetry.clear()
+        val controller = MarkerMotionController(predictionFreshnessMaxAgeMs = 4_500L, maxAcceptedFixAgeMs = 6_000L)
+        val base = LatLong(48.8566, 2.3522)
+        val walkingFix = moveLatLong(base, bearing = 90f, distanceMeters = 8f)
+
+        controller.onGpsFix(
+            latLong = base,
+            nowElapsedMs = 30_000L,
+            fixElapsedMs = 30_000L,
+            accuracyM = 38f,
+            rawSpeedMps = 0f,
+            rawBearingDeg = null,
+        )
+        controller.onGpsFix(
+            latLong = walkingFix,
+            nowElapsedMs = 38_000L,
+            fixElapsedMs = 38_000L,
+            accuracyM = 38f,
+            rawSpeedMps = 0f,
+            rawBearingDeg = null,
+        )
+
+        val predicted =
+            controller.predict(
+                nowElapsedMs = 39_000L,
+                serviceFreshnessMaxAgeMs = 4_500L,
+                watchGpsDegraded = false,
+            ) ?: walkingFix
+
+        assertTrue(distanceMeters(walkingFix, predicted) > 0.4f)
+        assertTrue(predicted.longitude > walkingFix.longitude)
+        assertEquals(MarkerMotionMode.PREDICT, MarkerMotionTelemetry.latestSnapshot().mode)
+    }
+
+    @Test
+    fun predictsFromKnownWatchGpsAccuracyFloorWhenRawMotionIsAvailable() {
+        MarkerMotionTelemetry.clear()
+        val controller = MarkerMotionController(predictionFreshnessMaxAgeMs = 4_500L, maxAcceptedFixAgeMs = 6_000L)
+        val base = LatLong(48.8566, 2.3522)
+
+        controller.onGpsFix(
+            latLong = base,
+            nowElapsedMs = 24_000L,
+            fixElapsedMs = 24_000L,
+            accuracyM = 125f,
+            rawSpeedMps = 1.5f,
+            rawBearingDeg = 90f,
+            sourceMode = LocationSourceMode.WATCH_GPS,
+        )
+
+        val predicted =
+            controller.predict(
+                nowElapsedMs = 25_000L,
+                serviceFreshnessMaxAgeMs = 4_500L,
+                watchGpsDegraded = false,
+            ) ?: base
+
+        assertTrue(distanceMeters(base, predicted) > 0.6f)
+        assertTrue(predicted.longitude > base.longitude)
+        assertEquals(MarkerMotionMode.PREDICT, MarkerMotionTelemetry.latestSnapshot().mode)
+    }
+
+    @Test
+    fun autoFusedAccuracyFloorStillBlocksPrediction() {
+        MarkerMotionTelemetry.clear()
+        val controller = MarkerMotionController(predictionFreshnessMaxAgeMs = 4_500L, maxAcceptedFixAgeMs = 6_000L)
+        val base = LatLong(48.8566, 2.3522)
+
+        controller.onGpsFix(
+            latLong = base,
+            nowElapsedMs = 26_000L,
+            fixElapsedMs = 26_000L,
+            accuracyM = 125f,
+            rawSpeedMps = 1.5f,
+            rawBearingDeg = 90f,
+            sourceMode = LocationSourceMode.AUTO_FUSED,
+        )
+
+        val predicted =
+            controller.predict(
+                nowElapsedMs = 27_000L,
+                serviceFreshnessMaxAgeMs = 4_500L,
+                watchGpsDegraded = false,
+            ) ?: base
+
+        assertTrue(distanceMeters(base, predicted) < 0.2f)
+        assertEquals("bad_accuracy", MarkerMotionTelemetry.latestSnapshot().reason)
     }
 
     @Test
@@ -145,6 +237,55 @@ class MarkerMotionControllerTest {
     }
 
     @Test
+    fun duplicateFixDoesNotRestartCorrectionBlend() {
+        MarkerMotionTelemetry.clear()
+        val controller = MarkerMotionController(predictionFreshnessMaxAgeMs = 4_500L, maxAcceptedFixAgeMs = 6_000L)
+        val base = LatLong(48.8566, 2.3522)
+        val target = moveLatLong(base, bearing = 90f, distanceMeters = 20f)
+
+        controller.onGpsFix(
+            latLong = base,
+            nowElapsedMs = 45_000L,
+            fixElapsedMs = 45_000L,
+            accuracyM = 8f,
+            rawSpeedMps = 4f,
+            rawBearingDeg = 90f,
+        )
+        controller.onGpsFix(
+            latLong = target,
+            nowElapsedMs = 47_000L,
+            fixElapsedMs = 47_000L,
+            accuracyM = 10f,
+            rawSpeedMps = 4f,
+            rawBearingDeg = 90f,
+        )
+        val duplicateDisplay =
+            controller.onGpsFix(
+                latLong = target,
+                nowElapsedMs = 47_050L,
+                fixElapsedMs = 47_080L,
+                accuracyM = 10f,
+                rawSpeedMps = 0f,
+                rawBearingDeg = 90f,
+            )
+
+        assertTrue(distanceMeters(duplicateDisplay, base) < 0.5f)
+        assertEquals(2, MarkerMotionTelemetry.summary().acceptedFixes)
+        assertEquals(1, MarkerMotionTelemetry.summary().blendStarts)
+        assertEquals("duplicate_fix", MarkerMotionTelemetry.latestSnapshot().reason)
+
+        val settled =
+            controller.predict(
+                nowElapsedMs = 47_400L,
+                serviceFreshnessMaxAgeMs = 4_500L,
+                watchGpsDegraded = false,
+            ) ?: target
+
+        assertTrue(distanceMeters(settled, target) < 2f)
+        assertEquals(1, MarkerMotionTelemetry.summary().blendStarts)
+    }
+
+    @Test
     fun dropsOutlierJump() {
         MarkerMotionTelemetry.clear()
         val controller = MarkerMotionController(predictionFreshnessMaxAgeMs = 4_500L, maxAcceptedFixAgeMs = 6_000L)
@@ -173,6 +314,39 @@ class MarkerMotionControllerTest {
         assertTrue(distanceMeters(first, second) < 0.5f)
         val summary = MarkerMotionTelemetry.summary()
         assertEquals(1, summary.outlierDrops)
+        assertEquals("outlier_drop", MarkerMotionTelemetry.latestSnapshot().reason)
+    }
+
+    @Test
+    fun knownWatchGpsAccuracyFloorDoesNotHideOutlierJump() {
+        MarkerMotionTelemetry.clear()
+        val controller = MarkerMotionController(predictionFreshnessMaxAgeMs = 4_500L, maxAcceptedFixAgeMs = 6_000L)
+        val base = LatLong(48.8566, 2.3522)
+        val outlier = moveLatLong(base, bearing = 45f, distanceMeters = 120f)
+
+        val first =
+            controller.onGpsFix(
+                latLong = base,
+                nowElapsedMs = 55_000L,
+                fixElapsedMs = 55_000L,
+                accuracyM = 125f,
+                rawSpeedMps = 1f,
+                rawBearingDeg = 90f,
+                sourceMode = LocationSourceMode.WATCH_GPS,
+            )
+        val second =
+            controller.onGpsFix(
+                latLong = outlier,
+                nowElapsedMs = 56_500L,
+                fixElapsedMs = 56_500L,
+                accuracyM = 125f,
+                rawSpeedMps = 0.5f,
+                rawBearingDeg = 45f,
+                sourceMode = LocationSourceMode.WATCH_GPS,
+            )
+
+        assertTrue(distanceMeters(first, second) < 0.5f)
+        assertEquals(1, MarkerMotionTelemetry.summary().outlierDrops)
         assertEquals("outlier_drop", MarkerMotionTelemetry.latestSnapshot().reason)
     }
 
@@ -211,6 +385,64 @@ class MarkerMotionControllerTest {
         assertTrue(distanceMeters(initialDisplay, settled) < 20f)
         assertTrue(distanceMeters(settled, farTarget) > 10f)
         assertEquals(1, MarkerMotionTelemetry.summary().clampedCorrections)
+    }
+
+    @Test
+    fun watchGpsSustainedBikeLagCatchesUpAfterRepeatedClamps() {
+        MarkerMotionTelemetry.clear()
+        val controller = MarkerMotionController(predictionFreshnessMaxAgeMs = 4_500L, maxAcceptedFixAgeMs = 6_000L)
+        val base = LatLong(48.8566, 2.3522)
+        val firstLaggedTarget = moveLatLong(base, bearing = 90f, distanceMeters = 54f)
+        val secondLaggedTarget = moveLatLong(base, bearing = 90f, distanceMeters = 108f)
+        val catchUpTarget = moveLatLong(base, bearing = 90f, distanceMeters = 162f)
+
+        controller.onGpsFix(
+            latLong = base,
+            nowElapsedMs = 100_000L,
+            fixElapsedMs = 100_000L,
+            accuracyM = 125f,
+            rawSpeedMps = 6f,
+            rawBearingDeg = 90f,
+            sourceMode = LocationSourceMode.WATCH_GPS,
+        )
+        controller.onGpsFix(
+            latLong = firstLaggedTarget,
+            nowElapsedMs = 103_000L,
+            fixElapsedMs = 103_000L,
+            accuracyM = 125f,
+            rawSpeedMps = 6f,
+            rawBearingDeg = 90f,
+            sourceMode = LocationSourceMode.WATCH_GPS,
+        )
+        controller.onGpsFix(
+            latLong = secondLaggedTarget,
+            nowElapsedMs = 106_000L,
+            fixElapsedMs = 106_000L,
+            accuracyM = 125f,
+            rawSpeedMps = 6f,
+            rawBearingDeg = 90f,
+            sourceMode = LocationSourceMode.WATCH_GPS,
+        )
+        controller.onGpsFix(
+            latLong = catchUpTarget,
+            nowElapsedMs = 109_000L,
+            fixElapsedMs = 109_000L,
+            accuracyM = 125f,
+            rawSpeedMps = 6f,
+            rawBearingDeg = 90f,
+            sourceMode = LocationSourceMode.WATCH_GPS,
+        )
+        assertEquals("watch_gps_catch_up", MarkerMotionTelemetry.latestSnapshot().reason)
+
+        val settled =
+            controller.predict(
+                nowElapsedMs = 109_400L,
+                serviceFreshnessMaxAgeMs = 4_500L,
+                watchGpsDegraded = false,
+            ) ?: base
+
+        assertTrue(distanceMeters(settled, catchUpTarget) < 2f)
+        assertEquals(2, MarkerMotionTelemetry.summary().clampedCorrections)
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,8 +34,8 @@ android.r8.strictFullModeForKeepRules=false
 # Play versioning.
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
-glanceMapVersionName=1.0.2
-glanceMapWearVersionCode=1002
+glanceMapVersionName=1.0.3
+glanceMapWearVersionCode=1003
 glanceMapPhoneVersionCode=2002
 
 # Elevate theme build-time sync (download -> generated assets -> packaged in APK)


### PR DESCRIPTION
## Summary
- Tune the location activity classifier for walking-first behavior with longer stationary entry, quicker active exit, and lower speed/distance thresholds
- Improve marker motion handling for watch GPS with source-aware accuracy, duplicate fix filtering, sustained lag catch-up, and cautious walking prediction from moderate accuracy fixes
- Add telemetry labeling for watch GPS catch-up and keep the wear capability resource from being stripped

## Testing
- `./gradlew :app:testDebugUnitTest --tests com.glancemap.glancemapwearos.presentation.features.navigate.motion.MarkerMotionControllerTest --no-daemon --console=plain`
- `./gradlew :app:testDebugUnitTest --tests com.glancemap.glancemapwearos.core.service.location.LocationActivityClassifierTest --no-daemon --console=plain`
- `./gradlew :app:testDebugUnitTest --tests 'com.glancemap.glancemapwearos.core.service.location.*' --no-daemon --console=plain`
- `./gradlew :app:compileDebugKotlin --no-daemon --console=plain`
- `git diff --check`