### PR TITLE
Update Android SDK setup action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ concurrency:
 jobs:
   quality:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     steps:
       - name: Checkout
@@ -36,7 +34,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Install Android SDK packages
         run: sdkmanager "platforms;android-36" "build-tools;36.0.0"


### PR DESCRIPTION
## Summary
- update `android-actions/setup-android` from v3 to v4
- remove the temporary Node 24 force environment variable now that the action itself uses Node 24

## Testing
- Workflow-only change; CI on this PR is the verification.