### PR TITLE
Document Play native symbol warning

### DIFF
--- a/docs/GOOGLE_PLAY_NATIVE_SYMBOLS.md
+++ b/docs/GOOGLE_PLAY_NATIVE_SYMBOLS.md
@@ -1,0 +1,84 @@
+# Google Play Native Debug Symbols
+
+Last reviewed: 2026-04-30
+
+Google Play can show this warning when an uploaded App Bundle contains `.so`
+native libraries:
+
+> This App Bundle contains native code, and you've not uploaded debug symbols.
+
+The warning is about native crash symbolication in Android vitals. It does not
+block release submission, but symbols make native crashes easier to read.
+
+## Current GlanceMap Status
+
+Both shipped app modules already opt in to native symbol packaging for release
+builds:
+
+- `app/build.gradle.kts`
+- `glancemapcompanionapp/build.gradle.kts`
+
+Each release build type sets:
+
+```kotlin
+ndk {
+    debugSymbolLevel = "SYMBOL_TABLE"
+}
+```
+
+This matches the Android Gradle Plugin guidance for App Bundles. For AAB
+uploads, Gradle includes native debug symbols automatically when the bundled
+native libraries still contain symbol metadata.
+
+## Why Play Can Still Warn
+
+The current companion release-style bundle includes one native library from the
+AndroidX/Compose graphics stack:
+
+```text
+libandroidx.graphics.path.so
+```
+
+A local release-style benchmark bundle showed Gradle attempting to extract
+native symbols, but the upstream library is already stripped:
+
+```text
+Unable to extract native debug metadata from .../libandroidx.graphics.path.so because the native debug metadata has already been stripped.
+```
+
+When a third-party native library has already been stripped before it reaches
+the app build, GlanceMap cannot generate the missing symbols from it. In that
+case Play may keep showing the warning even though the Gradle configuration is
+correct.
+
+## Release Checklist
+
+Before uploading a new AAB:
+
+1. Build the signed release App Bundle from Android Studio or Gradle.
+2. If Gradle creates a native symbols zip, upload it in Play Console together
+   with the AAB:
+
+   ```text
+   <module>/build/outputs/native-debug-symbols/release/native-debug-symbols.zip
+   ```
+
+3. If no zip is created and the only native-symbol extraction warning is for
+   `libandroidx.graphics.path.so`, treat the Play Console warning as known and
+   non-blocking.
+4. Do not exclude `libandroidx.graphics.path.so` just to silence the warning
+   unless the app has been tested thoroughly without it. It is owned by the
+   AndroidX graphics stack and may be loaded by Compose/graphics code paths.
+
+## Verification Commands
+
+For a local release-style check that does not need the private release keystore:
+
+```bash
+./gradlew :glancemapcompanionapp:bundleBenchmark --info --no-daemon --console=plain
+unzip -l glancemapcompanionapp/build/outputs/bundle/benchmark/glancemapcompanionapp-benchmark.aab | rg 'lib/|native-debug'
+find glancemapcompanionapp/build/outputs/native-debug-symbols -type f
+```
+
+The real release artifact should still be built with the signed `release`
+variant for Play.

--- a/docs/GOOGLE_PLAY_RELEASE_PRIVACY_CHECKLIST.md
+++ b/docs/GOOGLE_PLAY_RELEASE_PRIVACY_CHECKLIST.md
@@ -9,6 +9,7 @@ This checklist is a repo-side release aid for GlanceMap. It is not the public pr
 - Developer Program Policy: https://support.google.com/googleplay/android-developer/answer/16070163?hl=en
 - Data safety form help: https://support.google.com/googleplay/android-developer/answer/10787469?hl=en
 - Sensitive permissions and APIs: https://support.google.com/googleplay/android-developer/answer/16558241?hl=en
+- Native debug symbols: https://developer.android.com/build/include-native-symbols
 
 ## Useful Play definitions
 
@@ -61,6 +62,10 @@ Repo-specific inference:
 6. Re-review whether user-initiated diagnostics export changes your Data safety answers, especially for crash logs, app info, and any location-related telemetry captured in support files.
 7. Re-review whether any user-selected or location-derived bounding box requests to third-party services should be reflected in your Play disclosures for the exact shipped flow.
 8. Do not claim stronger security than the app actually provides. In particular, the current local phone-to-watch Wi-Fi transfer is token-protected but uses local HTTP, not end-to-end encrypted internet transport.
+9. If Play Console shows the native debug symbols warning, check
+   `docs/GOOGLE_PLAY_NATIVE_SYMBOLS.md`. The current Gradle release config
+   already enables `SYMBOL_TABLE`; Play may still warn when the only bundled
+   native library is the already-stripped AndroidX `libandroidx.graphics.path.so`.
 
 ## Practical submission note
 


### PR DESCRIPTION
## Summary
- document the Play Console native debug symbols warning
- record that release builds already enable `SYMBOL_TABLE`
- explain the current AndroidX `libandroidx.graphics.path.so` stripped-symbol limitation and when the warning is non-blocking

## Verification
- `./gradlew :glancemapcompanionapp:bundleBenchmark --info --no-daemon --console=plain`
- confirmed the benchmark AAB contains `libandroidx.graphics.path.so`
- confirmed no native debug symbols zip was generated because the upstream library is already stripped