### PR TITLE
Bump watch version code

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ android.r8.strictFullModeForKeepRules=false
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
 glanceMapVersionName=1.0.4
-glanceMapWearVersionCode=1005
+glanceMapWearVersionCode=1006
 glanceMapPhoneVersionCode=2005
 
 # Elevate theme build-time sync (download -> generated assets -> packaged in APK)


### PR DESCRIPTION
## Summary
- bump the Wear OS app Play version code from 1005 to 1006
- leave companion version code and shared version name unchanged

## Testing
- `./gradlew :app:processDebugMainManifest --no-daemon --console=plain`