### PR TITLE
Bump Play version codes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,8 +35,8 @@ android.r8.strictFullModeForKeepRules=false
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
 glanceMapVersionName=1.0.4
-glanceMapWearVersionCode=1006
-glanceMapPhoneVersionCode=2005
+glanceMapWearVersionCode=1007
+glanceMapPhoneVersionCode=2006
 
 # Elevate theme build-time sync (download -> generated assets -> packaged in APK)
 elevateThemeVersion=5.6


### PR DESCRIPTION
## Summary

- Bump the Wear OS Play version code from 1006 to 1007.
- Bump the phone companion Play version code from 2005 to 2006.

## Validation

- `git diff --check`

This keeps the shared visible version name at `1.0.4` and only advances the upload counters for the next closed-test release.