### PR TITLE
Bump Wear version code

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ android.r8.strictFullModeForKeepRules=false
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
 glanceMapVersionName=1.0.4
-glanceMapWearVersionCode=1008
+glanceMapWearVersionCode=1009
 glanceMapPhoneVersionCode=2007
 
 # Elevate theme build-time sync (download -> generated assets -> packaged in APK)


### PR DESCRIPTION
## Summary

- Bump the Wear OS Play version code from 1008 to 1009.
- Leave the phone companion Play version code at 2007.

## Validation

- `git diff --check`

This keeps the shared visible version name at `1.0.4` and avoids reusing the burned Wear artifact version code.