### PR TITLE
Improve DEM download resilience

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/core/maps/Dem3CoverageUtils.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/core/maps/Dem3CoverageUtils.kt
@@ -84,7 +84,7 @@ object Dem3CoverageUtils {
                 0
             } else {
                 requiredTileIds.count { tileId ->
-                    tileFileCandidates(demRoot, tileId).any { it.exists() && it.isFile }
+                    tileCoverageCandidates(demRoot, tileId).any { it.exists() && it.isFile }
                 }
             }
 
@@ -151,6 +151,13 @@ object Dem3CoverageUtils {
                         demChanged = true
                     }
                 }
+            missingTileMarkerCandidates(demRoot, tileId)
+                .toSet()
+                .forEach { marker ->
+                    if (marker.exists() && marker.delete()) {
+                        demChanged = true
+                    }
+                }
         }
 
         if (demChanged) {
@@ -213,6 +220,23 @@ object Dem3CoverageUtils {
             File(File(demRoot, folder), "$upperTileId.hgt"),
             File(demRoot, "$upperTileId.hgt.zip"),
             File(demRoot, "$upperTileId.hgt"),
+        )
+    }
+
+    private fun tileCoverageCandidates(
+        demRoot: File,
+        tileId: String,
+    ): List<File> = tileFileCandidates(demRoot, tileId) + missingTileMarkerCandidates(demRoot, tileId)
+
+    fun missingTileMarkerCandidates(
+        demRoot: File,
+        tileId: String,
+    ): List<File> {
+        val upperTileId = tileId.uppercase(Locale.ROOT)
+        val folder = upperTileId.substring(0, 3)
+        return listOf(
+            File(File(demRoot, folder), "$upperTileId.hgt.missing"),
+            File(demRoot, "$upperTileId.hgt.missing"),
         )
     }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/core/maps/DemSignatureStore.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/core/maps/DemSignatureStore.kt
@@ -64,7 +64,10 @@ object DemSignatureStore {
             .forEach { file ->
                 if (!file.isFile) return@forEach
                 val lowerName = file.name.lowercase(Locale.ROOT)
-                val isDem = lowerName.endsWith(".hgt") || lowerName.endsWith(".hgt.zip")
+                val isDem =
+                    lowerName.endsWith(".hgt") ||
+                        lowerName.endsWith(".hgt.zip") ||
+                        lowerName.endsWith(".hgt.missing")
                 if (!isDem) return@forEach
 
                 count += 1

--- a/app/src/main/java/com/glancemap/glancemapwearos/core/service/diagnostics/DemDownloadDiagnostics.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/core/service/diagnostics/DemDownloadDiagnostics.kt
@@ -1,0 +1,85 @@
+package com.glancemap.glancemapwearos.core.service.diagnostics
+
+import java.util.ArrayDeque
+
+internal data class DemDownloadSummary(
+    val eventCount: Int,
+    val droppedLineCount: Int,
+    val maxBufferedLines: Int,
+    val startedCount: Int,
+    val completedCount: Int,
+    val downloadedCount: Int,
+    val skippedCount: Int,
+    val missingCount: Int,
+    val failedCount: Int,
+    val resumeAttemptCount: Int,
+    val resumeRestartCount: Int,
+    val validationFailureCount: Int,
+    val networkUnavailableCount: Int,
+)
+
+internal object DemDownloadDiagnostics {
+    private const val TAG = "DemDownload"
+    private const val MAX_LINES = 1200
+
+    private val lock = Any()
+    private val lines = ArrayDeque<String>()
+    private var droppedLines: Int = 0
+
+    fun clear() {
+        synchronized(lock) {
+            lines.clear()
+            droppedLines = 0
+        }
+    }
+
+    fun snapshotLines(): List<String> = synchronized(lock) { lines.toList() }
+
+    fun droppedLineCount(): Int = synchronized(lock) { droppedLines }
+
+    fun maxBufferedLines(): Int = MAX_LINES
+
+    fun summary(): DemDownloadSummary =
+        synchronized(lock) {
+            DemDownloadSummary(
+                eventCount = lines.size,
+                droppedLineCount = droppedLines,
+                maxBufferedLines = MAX_LINES,
+                startedCount = lines.count { it.startsWith("event=start ") },
+                completedCount = lines.count { it.startsWith("event=complete ") },
+                downloadedCount = lines.count { it.startsWith("event=tile_downloaded ") },
+                skippedCount = lines.count { it.startsWith("event=tile_skipped ") },
+                missingCount = lines.count { it.startsWith("event=tile_missing ") },
+                failedCount = lines.count { it.startsWith("event=tile_failed ") },
+                resumeAttemptCount = lines.count { it.startsWith("event=tile_resume_attempt ") },
+                resumeRestartCount = lines.count { it.startsWith("event=tile_resume_restart ") },
+                validationFailureCount = lines.count { it.startsWith("event=tile_validation_failed ") },
+                networkUnavailableCount = lines.count { it.contains(" networkUnavailable=true") },
+            )
+        }
+
+    fun record(
+        event: String,
+        detail: String = "",
+    ) {
+        val line =
+            buildString {
+                append("event=").append(event)
+                if (detail.isNotBlank()) {
+                    append(' ').append(detail)
+                }
+            }
+        push(line)
+        DebugTelemetry.log(TAG, line)
+    }
+
+    private fun push(line: String) {
+        synchronized(lock) {
+            lines.addLast(line)
+            while (lines.size > MAX_LINES) {
+                lines.removeFirst()
+                droppedLines += 1
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/glancemap/glancemapwearos/core/service/diagnostics/DiagnosticsExporter.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/core/service/diagnostics/DiagnosticsExporter.kt
@@ -226,6 +226,9 @@ object DiagnosticsExporter {
                 kotlin.math.abs(captureDurationMs - bufferedSpanMs) > SESSION_DURATION_MISMATCH_THRESHOLD_MS
         val energyLines = EnergyDiagnostics.snapshotLines()
         val energyDroppedLines = EnergyDiagnostics.droppedLineCount()
+        val demDownloadSummary = DemDownloadDiagnostics.summary()
+        val demDownloadLines = DemDownloadDiagnostics.snapshotLines()
+        val demDownloadDroppedLines = DemDownloadDiagnostics.droppedLineCount()
         val markerMotionSummary = MarkerMotionTelemetry.summary()
         val markerMotionSnapshot = MarkerMotionTelemetry.latestSnapshot()
         val mapHotPathSummary = MapHotPathDiagnostics.summary()
@@ -238,6 +241,7 @@ object DiagnosticsExporter {
         val fieldMarkerDroppedLines = FieldMarkerDiagnostics.droppedLineCount()
         val telemetryTruncated = captureSession.droppedLines > 0
         val energyTruncated = energyDroppedLines > 0
+        val demDownloadTruncated = demDownloadDroppedLines > 0
         val mapHotPathTruncated = mapHotPathDroppedLines > 0
         val gnssTruncated = gnssDroppedLines > 0
         val fieldMarkerTruncated = fieldMarkerDroppedLines > 0
@@ -392,6 +396,10 @@ object DiagnosticsExporter {
             writer.appendLine("energyBufferMaxLines=${EnergyDiagnostics.maxBufferedLines()}")
             writer.appendLine("energyDroppedLines=$energyDroppedLines")
             writer.appendLine("energyTruncated=$energyTruncated")
+            writer.appendLine("demDownloadBufferedLines=${demDownloadLines.size}")
+            writer.appendLine("demDownloadBufferMaxLines=${DemDownloadDiagnostics.maxBufferedLines()}")
+            writer.appendLine("demDownloadDroppedLines=$demDownloadDroppedLines")
+            writer.appendLine("demDownloadTruncated=$demDownloadTruncated")
             writer.appendLine("markerMotionAcceptedFixes=${markerMotionSummary.acceptedFixes}")
             writer.appendLine("markerMotionPredictionUpdates=${markerMotionSummary.predictionUpdates}")
             writer.appendLine("markerMotionBlendStarts=${markerMotionSummary.blendStarts}")
@@ -413,6 +421,7 @@ object DiagnosticsExporter {
                 "anyCaptureBufferTruncated=${
                     telemetryTruncated ||
                         energyTruncated ||
+                        demDownloadTruncated ||
                         mapHotPathTruncated ||
                         gnssTruncated ||
                         fieldMarkerTruncated
@@ -634,6 +643,29 @@ object DiagnosticsExporter {
                 writer.appendLine("No energy diagnostics samples yet.")
             } else {
                 energyLines.forEach { line -> writer.appendLine(line) }
+            }
+            writer.appendLine()
+            writer.appendLine("DEM Download Summary")
+            writer.appendLine("eventCount=${demDownloadSummary.eventCount}")
+            writer.appendLine("bufferMaxLines=${demDownloadSummary.maxBufferedLines}")
+            writer.appendLine("droppedLines=${demDownloadSummary.droppedLineCount}")
+            writer.appendLine("truncated=$demDownloadTruncated")
+            writer.appendLine("startedCount=${demDownloadSummary.startedCount}")
+            writer.appendLine("completedCount=${demDownloadSummary.completedCount}")
+            writer.appendLine("downloadedCount=${demDownloadSummary.downloadedCount}")
+            writer.appendLine("skippedCount=${demDownloadSummary.skippedCount}")
+            writer.appendLine("missingCount=${demDownloadSummary.missingCount}")
+            writer.appendLine("failedCount=${demDownloadSummary.failedCount}")
+            writer.appendLine("resumeAttemptCount=${demDownloadSummary.resumeAttemptCount}")
+            writer.appendLine("resumeRestartCount=${demDownloadSummary.resumeRestartCount}")
+            writer.appendLine("validationFailureCount=${demDownloadSummary.validationFailureCount}")
+            writer.appendLine("networkUnavailableCount=${demDownloadSummary.networkUnavailableCount}")
+            writer.appendLine()
+            writer.appendLine("DEM Download Events")
+            if (demDownloadLines.isEmpty()) {
+                writer.appendLine("No DEM download events captured yet.")
+            } else {
+                demDownloadLines.forEach { line -> writer.appendLine(line) }
             }
             writer.appendLine()
             writer.appendLine("GNSS Summary")

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.DemSupport.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.DemSupport.kt
@@ -5,6 +5,7 @@ import java.io.FileNotFoundException
 import java.io.IOException
 import java.net.ConnectException
 import java.net.NoRouteToHostException
+import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.util.Locale
@@ -65,6 +66,7 @@ internal fun isRetryableDemDownloadFailure(throwable: Throwable?): Boolean {
     if (throwable is DemInvalidTileException) return false
     if (throwable is ZipException) return false
     if (throwable is DemResumeRejectedException) return true
+    if (throwable is SocketException) return true
     if (hasDirectDemOfflineCause(throwable) || hasDemTimeoutCause(throwable)) return true
 
     val message = throwable.message.orEmpty().lowercase(Locale.ROOT)
@@ -77,6 +79,7 @@ internal fun isRetryableDemDownloadFailure(throwable: Throwable?): Boolean {
         message.contains("broken pipe") ||
         message.contains("connection closed") ||
         message.contains("connection refused") ||
+        message.contains("software caused connection abort") ||
         message.contains("http 408") ||
         message.contains("http 429") ||
         message.contains("timed out") ||

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.DemSupport.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.DemSupport.kt
@@ -1,14 +1,27 @@
 package com.glancemap.glancemapwearos.presentation.features.maps.theme
 
+import java.io.File
 import java.io.FileNotFoundException
+import java.io.IOException
 import java.net.ConnectException
 import java.net.NoRouteToHostException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.util.Locale
+import java.util.zip.ZipException
+import java.util.zip.ZipFile
+import kotlin.math.sqrt
 
 internal const val DEM_NO_INTERNET_MESSAGE =
     "No internet on watch. Connect Wi-Fi or phone internet, then retry DEM download."
+
+internal class DemInvalidTileException(
+    message: String,
+) : IOException(message)
+
+internal class DemResumeRejectedException(
+    message: String,
+) : IOException(message)
 
 internal fun classifyDemFailureAsNetworkUnavailable(
     throwable: Throwable,
@@ -49,6 +62,9 @@ internal fun buildDemFailureMessage(
 internal fun isRetryableDemDownloadFailure(throwable: Throwable?): Boolean {
     if (throwable == null) return false
     if (throwable is FileNotFoundException) return false
+    if (throwable is DemInvalidTileException) return false
+    if (throwable is ZipException) return false
+    if (throwable is DemResumeRejectedException) return true
     if (hasDirectDemOfflineCause(throwable) || hasDemTimeoutCause(throwable)) return true
 
     val message = throwable.message.orEmpty().lowercase(Locale.ROOT)
@@ -59,8 +75,58 @@ internal fun isRetryableDemDownloadFailure(throwable: Throwable?): Boolean {
         message.contains("unexpected end of stream") ||
         message.contains("connection reset") ||
         message.contains("broken pipe") ||
+        message.contains("connection closed") ||
+        message.contains("connection refused") ||
+        message.contains("http 408") ||
+        message.contains("http 429") ||
         message.contains("timed out") ||
         message.contains("timeout")
+}
+
+internal fun validateDemTileFile(file: File) {
+    if (!file.exists() || !file.isFile) {
+        throw DemInvalidTileException("DEM tile was not saved.")
+    }
+    if (file.length() <= 0L) {
+        throw DemInvalidTileException("DEM tile is empty.")
+    }
+
+    if (file.name.endsWith(".zip", ignoreCase = true)) {
+        validateDemZip(file)
+    } else if (!isPlausibleHgtByteSize(file.length())) {
+        throw DemInvalidTileException("DEM tile has invalid HGT size: ${file.length()} bytes.")
+    }
+}
+
+private fun validateDemZip(file: File) {
+    val hgtEntries =
+        ZipFile(file).use { zip ->
+            zip
+                .entries()
+                .asSequence()
+                .filter { entry ->
+                    !entry.isDirectory && entry.name.endsWith(".hgt", ignoreCase = true)
+                }.toList()
+        }
+
+    if (hgtEntries.isEmpty()) {
+        throw DemInvalidTileException("DEM ZIP does not contain an HGT file.")
+    }
+
+    val firstInvalidSize =
+        hgtEntries
+            .mapNotNull { entry -> entry.size.takeIf { it > 0L } }
+            .firstOrNull { size -> !isPlausibleHgtByteSize(size) }
+    if (firstInvalidSize != null) {
+        throw DemInvalidTileException("DEM ZIP contains invalid HGT size: $firstInvalidSize bytes.")
+    }
+}
+
+private fun isPlausibleHgtByteSize(size: Long): Boolean {
+    if (size <= 0L || size % Short.SIZE_BYTES != 0L) return false
+    val sampleCount = size / Short.SIZE_BYTES
+    val rowLen = sqrt(sampleCount.toDouble()).toInt()
+    return rowLen * rowLen.toLong() == sampleCount && rowLen in 1201..3601
 }
 
 private fun hasDirectDemOfflineCause(throwable: Throwable): Boolean {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.kt
@@ -25,6 +25,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileNotFoundException
+import java.io.FileOutputStream
+import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URI
 import java.util.Locale
@@ -75,6 +77,7 @@ class ThemeViewModel(
         private const val DEM_TILE_RETRY_BASE_DELAY_MS = 1_500L
         private const val DEM_INTERNET_WAIT_TIMEOUT_MS = 8_000L
         private const val DEM_INTERNET_RECHECK_MS = 500L
+        private const val HTTP_REQUESTED_RANGE_NOT_SATISFIABLE = 416
     }
 
     private val appContext: Context = context.applicationContext
@@ -394,9 +397,20 @@ class ThemeViewModel(
             val localDir = File(outputRoot, folder).apply { mkdirs() }
             val localFile = File(localDir, fileName)
             if (localFile.exists()) {
-                skipped += 1
-                processedTiles = processed
-                continue
+                val existingValid =
+                    runCatching {
+                        validateDemTileFile(localFile)
+                        true
+                    }.getOrElse { error ->
+                        Log.w(TAG, "Deleting invalid existing DEM tile ${localFile.absolutePath}", error)
+                        localFile.delete()
+                        false
+                    }
+                if (existingValid) {
+                    skipped += 1
+                    processedTiles = processed
+                    continue
+                }
             }
 
             val url = "$DEM3_BASE_URL/$folder/$fileName"
@@ -478,8 +492,8 @@ class ThemeViewModel(
         url: String,
         target: File,
     ) {
-        val tmp = File(target.parentFile, "${target.name}.tmp")
-        if (tmp.exists()) tmp.delete()
+        val part = File(target.parentFile, ".${target.name}.part")
+        val resumeOffset = part.takeIf { it.exists() && it.isFile }?.length()?.coerceAtLeast(0L) ?: 0L
 
         val connection =
             (URI(url).toURL().openConnection() as HttpURLConnection).apply {
@@ -488,28 +502,61 @@ class ThemeViewModel(
                 requestMethod = "GET"
                 instanceFollowRedirects = true
                 setRequestProperty("User-Agent", DEM3_USER_AGENT)
+                if (resumeOffset > 0L) {
+                    setRequestProperty("Range", "bytes=$resumeOffset-")
+                }
             }
 
         try {
             val code = connection.responseCode
             if (code == HttpURLConnection.HTTP_NOT_FOUND) {
+                if (part.exists()) part.delete()
                 throw FileNotFoundException("HTTP 404 for $url")
+            }
+            if (code == HTTP_REQUESTED_RANGE_NOT_SATISFIABLE && resumeOffset > 0L) {
+                if (part.exists()) part.delete()
+                throw DemResumeRejectedException("DEM server rejected partial resume for $url")
             }
             if (code !in 200..299) {
                 throw IllegalStateException("HTTP $code for $url")
             }
 
+            val append = resumeOffset > 0L && code == HttpURLConnection.HTTP_PARTIAL
+            if (resumeOffset > 0L && code == HttpURLConnection.HTTP_OK && part.exists()) {
+                Log.w(TAG, "DEM server ignored Range for $url; restarting tile download.")
+                part.delete()
+            }
+
+            val startingBytes = if (append) resumeOffset else 0L
+            val expectedTotalBytes =
+                connection.contentLengthLong
+                    .takeIf { it > 0L }
+                    ?.let { contentLength -> startingBytes + contentLength }
+
             connection.inputStream.use { input ->
-                tmp.outputStream().use { out -> input.copyTo(out) }
+                FileOutputStream(part, append).use { out ->
+                    input.copyTo(out)
+                    out.flush()
+                    runCatching { out.fd.sync() }
+                }
+            }
+
+            if (expectedTotalBytes != null && part.length() != expectedTotalBytes) {
+                throw IOException("INCOMPLETE_DEM_TILE: expected=$expectedTotalBytes got=${part.length()}")
             }
 
             if (target.exists()) target.delete()
-            if (!tmp.renameTo(target)) {
+            if (!part.renameTo(target)) {
                 throw IllegalStateException("Failed moving temp DEM file to ${target.absolutePath}")
+            }
+            try {
+                validateDemTileFile(target)
+            } catch (error: Exception) {
+                target.delete()
+                throw error
             }
         } finally {
             connection.disconnect()
-            if (tmp.exists() && !target.exists()) tmp.delete()
         }
     }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.glancemap.glancemapwearos.core.maps.Dem3CoverageUtils
 import com.glancemap.glancemapwearos.core.maps.DemSignatureStore
+import com.glancemap.glancemapwearos.core.service.diagnostics.DemDownloadDiagnostics
 import com.glancemap.glancemapwearos.data.repository.maps.theme.ThemeRepository
 import com.glancemap.glancemapwearos.data.repository.maps.theme.ThemeRepositoryImpl
 import com.glancemap.glancemapwearos.domain.model.maps.theme.ThemeListItem
@@ -44,6 +45,7 @@ data class DemDownloadUiState(
     val processedTiles: Int = 0,
     val downloadedTiles: Int = 0,
     val skippedTiles: Int = 0,
+    val missingTiles: Int = 0,
     val failedTiles: Int = 0,
     val networkUnavailable: Boolean = false,
     val statusMessage: String = "",
@@ -55,6 +57,7 @@ private data class DemDownloadResult(
     val processedTiles: Int,
     val downloadedTiles: Int,
     val skippedTiles: Int,
+    val missingTiles: Int,
     val failedTiles: Int,
     val networkUnavailable: Boolean,
     val statusMessage: String,
@@ -62,7 +65,13 @@ private data class DemDownloadResult(
 
 private data class DemTileDownloadOutcome(
     val success: Boolean,
+    val missingUpstream: Boolean,
     val networkUnavailable: Boolean,
+)
+
+private data class DemDownloadAttemptResult(
+    val bytesWritten: Long,
+    val resumedFromBytes: Long,
 )
 
 class ThemeViewModel(
@@ -257,6 +266,10 @@ class ThemeViewModel(
 
         viewModelScope.launch {
             if (mapPath.isNullOrBlank()) {
+                DemDownloadDiagnostics.record(
+                    event = "start_rejected",
+                    detail = "reason=no_map_selected",
+                )
                 _demDownloadUiState.value =
                     DemDownloadUiState(
                         activeMapPath = null,
@@ -268,6 +281,10 @@ class ThemeViewModel(
 
             val selectedMapFile = File(mapPath)
             if (!selectedMapFile.exists()) {
+                DemDownloadDiagnostics.record(
+                    event = "start_rejected",
+                    detail = "reason=map_missing path=${mapPath.demDiagValue()}",
+                )
                 _demDownloadUiState.value =
                     DemDownloadUiState(
                         activeMapPath = null,
@@ -285,6 +302,10 @@ class ThemeViewModel(
                 )
 
             if (!waitForWatchInternetConnection()) {
+                DemDownloadDiagnostics.record(
+                    event = "start_rejected",
+                    detail = "reason=no_internet path=${mapPath.demDiagValue()}",
+                )
                 _demDownloadUiState.value =
                     DemDownloadUiState(
                         isDownloading = false,
@@ -314,6 +335,7 @@ class ThemeViewModel(
                         processedTiles = result.processedTiles,
                         downloadedTiles = result.downloadedTiles,
                         skippedTiles = result.skippedTiles,
+                        missingTiles = result.missingTiles,
                         failedTiles = result.failedTiles,
                         networkUnavailable = result.networkUnavailable,
                         statusMessage = result.statusMessage,
@@ -348,22 +370,41 @@ class ThemeViewModel(
             Dem3CoverageUtils
                 .requiredTileIdsForMap(selectedMapFile)
                 ?.sorted()
-                ?: return DemDownloadResult(
-                    totalTiles = 0,
-                    processedTiles = 0,
-                    downloadedTiles = 0,
-                    skippedTiles = 0,
-                    failedTiles = 0,
-                    networkUnavailable = false,
-                    statusMessage = "Failed reading selected map area.",
-                )
+                ?: run {
+                    DemDownloadDiagnostics.record(
+                        event = "complete",
+                        detail = "status=map_area_failed path=${selectedMapFile.absolutePath.demDiagValue()}",
+                    )
+                    return DemDownloadResult(
+                        totalTiles = 0,
+                        processedTiles = 0,
+                        downloadedTiles = 0,
+                        skippedTiles = 0,
+                        missingTiles = 0,
+                        failedTiles = 0,
+                        networkUnavailable = false,
+                        statusMessage = "Failed reading selected map area.",
+                    )
+                }
+
+        DemDownloadDiagnostics.record(
+            event = "start",
+            detail =
+                "path=${selectedMapFile.absolutePath.demDiagValue()} totalTiles=${tileIds.size} " +
+                    "firstTile=${tileIds.firstOrNull().orEmpty()} lastTile=${tileIds.lastOrNull().orEmpty()}",
+        )
 
         if (tileIds.isEmpty()) {
+            DemDownloadDiagnostics.record(
+                event = "complete",
+                detail = "status=no_tiles path=${selectedMapFile.absolutePath.demDiagValue()}",
+            )
             return DemDownloadResult(
                 totalTiles = 0,
                 processedTiles = 0,
                 downloadedTiles = 0,
                 skippedTiles = 0,
+                missingTiles = 0,
                 failedTiles = 0,
                 networkUnavailable = false,
                 statusMessage = "No DEM tiles required for this map.",
@@ -375,6 +416,7 @@ class ThemeViewModel(
 
         var downloaded = 0
         var skipped = 0
+        var missing = 0
         var failed = 0
         var processedTiles = 0
         var networkUnavailable = false
@@ -389,6 +431,7 @@ class ThemeViewModel(
                     processedTiles = processed,
                     downloadedTiles = downloaded,
                     skippedTiles = skipped,
+                    missingTiles = missing,
                     failedTiles = failed,
                     statusMessage = "Downloading...",
                 )
@@ -409,6 +452,10 @@ class ThemeViewModel(
                 if (existingValid) {
                     skipped += 1
                     processedTiles = processed
+                    DemDownloadDiagnostics.record(
+                        event = "tile_skipped",
+                        detail = "tile=$tileId index=$processed total=${tileIds.size} reason=already_valid",
+                    )
                     continue
                 }
             }
@@ -425,8 +472,24 @@ class ThemeViewModel(
             processedTiles = processed
             if (outcome.success) {
                 downloaded += 1
+                DemDownloadDiagnostics.record(
+                    event = "tile_downloaded",
+                    detail = "tile=$tileId index=$processed total=${tileIds.size}",
+                )
+            } else if (outcome.missingUpstream) {
+                missing += 1
+                DemDownloadDiagnostics.record(
+                    event = "tile_missing",
+                    detail = "tile=$tileId index=$processed total=${tileIds.size} reason=upstream_404",
+                )
             } else {
                 failed += 1
+                DemDownloadDiagnostics.record(
+                    event = "tile_failed",
+                    detail =
+                        "tile=$tileId index=$processed total=${tileIds.size} " +
+                            "networkUnavailable=${outcome.networkUnavailable}",
+                )
                 if (outcome.networkUnavailable) {
                     networkUnavailable = true
                     break
@@ -434,8 +497,9 @@ class ThemeViewModel(
             }
         }
 
-        if (downloaded > 0) {
+        if (downloaded > 0 || missing > 0) {
             DemSignatureStore.markDirty(appContext)
+            Dem3CoverageUtils.clearCaches()
         }
 
         val remaining = (tileIds.size - processedTiles).coerceAtLeast(0)
@@ -443,6 +507,7 @@ class ThemeViewModel(
             buildDemSummaryMessage(
                 downloaded = downloaded,
                 skipped = skipped,
+                missing = missing,
                 failed = failed,
                 remaining = remaining,
             )
@@ -454,11 +519,20 @@ class ThemeViewModel(
                     DEM_NO_INTERNET_MESSAGE
                 else -> summary
             }
+        DemDownloadDiagnostics.record(
+            event = "complete",
+            detail =
+                "status=${if (failed == 0 && !networkUnavailable) "ready" else "partial"} " +
+                    "total=${tileIds.size} processed=$processedTiles downloaded=$downloaded skipped=$skipped " +
+                    "missing=$missing failed=$failed remaining=$remaining networkUnavailable=$networkUnavailable " +
+                    "message=${finalMessage.demDiagValue()}",
+        )
         return DemDownloadResult(
             totalTiles = tileIds.size,
             processedTiles = processedTiles,
             downloadedTiles = downloaded,
             skippedTiles = skipped,
+            missingTiles = missing,
             failedTiles = failed,
             networkUnavailable = networkUnavailable,
             statusMessage = finalMessage,
@@ -468,22 +542,19 @@ class ThemeViewModel(
     private fun buildDemSummaryMessage(
         downloaded: Int,
         skipped: Int,
+        missing: Int,
         failed: Int,
         remaining: Int,
     ): String =
         when {
-            failed == 0 && downloaded > 0 && skipped == 0 ->
-                "DEM ready: $downloaded tile(s) downloaded."
-            failed == 0 && downloaded > 0 && skipped > 0 ->
-                "DEM ready: $downloaded downloaded, $skipped already on watch."
-            failed == 0 && downloaded == 0 && skipped > 0 ->
-                "DEM already available ($skipped tile(s) already on watch)."
+            failed == 0 && (downloaded > 0 || skipped > 0 || missing > 0) ->
+                "DEM download successful."
             downloaded == 0 && skipped == 0 && failed > 0 ->
-                "DEM download failed ($failed tile(s))."
+                "DEM download failed."
             remaining > 0 ->
-                "DEM partial: $downloaded downloaded, $skipped on watch, $failed failed, $remaining remaining."
+                "DEM download incomplete. Retry to finish."
             else ->
-                "DEM partial: $downloaded downloaded, $skipped on watch, $failed failed."
+                "DEM download incomplete."
         }
 
     private fun getDemOutputRoot(): File = Dem3CoverageUtils.demRootDir(appContext)
@@ -491,9 +562,16 @@ class ThemeViewModel(
     private fun downloadFile(
         url: String,
         target: File,
-    ) {
+    ): DemDownloadAttemptResult {
         val part = File(target.parentFile, ".${target.name}.part")
         val resumeOffset = part.takeIf { it.exists() && it.isFile }?.length()?.coerceAtLeast(0L) ?: 0L
+        val tileName = target.name.removeSuffix(".hgt.zip").removeSuffix(".hgt")
+        if (resumeOffset > 0L) {
+            DemDownloadDiagnostics.record(
+                event = "tile_resume_attempt",
+                detail = "tile=$tileName partialBytes=$resumeOffset url=${url.demDiagValue()}",
+            )
+        }
 
         val connection =
             (URI(url).toURL().openConnection() as HttpURLConnection).apply {
@@ -511,19 +589,36 @@ class ThemeViewModel(
             val code = connection.responseCode
             if (code == HttpURLConnection.HTTP_NOT_FOUND) {
                 if (part.exists()) part.delete()
+                DemDownloadDiagnostics.record(
+                    event = "tile_http",
+                    detail = "tile=$tileName code=$code action=missing url=${url.demDiagValue()}",
+                )
+                createMissingDemMarker(target)
                 throw FileNotFoundException("HTTP 404 for $url")
             }
             if (code == HTTP_REQUESTED_RANGE_NOT_SATISFIABLE && resumeOffset > 0L) {
                 if (part.exists()) part.delete()
+                DemDownloadDiagnostics.record(
+                    event = "tile_resume_rejected",
+                    detail = "tile=$tileName code=$code partialBytes=$resumeOffset url=${url.demDiagValue()}",
+                )
                 throw DemResumeRejectedException("DEM server rejected partial resume for $url")
             }
             if (code !in 200..299) {
+                DemDownloadDiagnostics.record(
+                    event = "tile_http",
+                    detail = "tile=$tileName code=$code action=fail url=${url.demDiagValue()}",
+                )
                 throw IllegalStateException("HTTP $code for $url")
             }
 
             val append = resumeOffset > 0L && code == HttpURLConnection.HTTP_PARTIAL
             if (resumeOffset > 0L && code == HttpURLConnection.HTTP_OK && part.exists()) {
                 Log.w(TAG, "DEM server ignored Range for $url; restarting tile download.")
+                DemDownloadDiagnostics.record(
+                    event = "tile_resume_restart",
+                    detail = "tile=$tileName reason=range_ignored partialBytes=$resumeOffset url=${url.demDiagValue()}",
+                )
                 part.delete()
             }
 
@@ -542,6 +637,10 @@ class ThemeViewModel(
             }
 
             if (expectedTotalBytes != null && part.length() != expectedTotalBytes) {
+                DemDownloadDiagnostics.record(
+                    event = "tile_incomplete",
+                    detail = "tile=$tileName expectedBytes=$expectedTotalBytes actualBytes=${part.length()}",
+                )
                 throw IOException("INCOMPLETE_DEM_TILE: expected=$expectedTotalBytes got=${part.length()}")
             }
 
@@ -552,9 +651,25 @@ class ThemeViewModel(
             try {
                 validateDemTileFile(target)
             } catch (error: Exception) {
+                DemDownloadDiagnostics.record(
+                    event = "tile_validation_failed",
+                    detail =
+                        "tile=$tileName bytes=${target.length()} " +
+                            "error=${error.javaClass.simpleName} message=${error.message.orEmpty().demDiagValue()}",
+                )
                 target.delete()
                 throw error
             }
+            DemDownloadDiagnostics.record(
+                event = "tile_saved",
+                detail =
+                    "tile=$tileName code=$code bytes=${target.length()} " +
+                        "resumedFromBytes=${if (append) resumeOffset else 0L}",
+            )
+            return DemDownloadAttemptResult(
+                bytesWritten = target.length(),
+                resumedFromBytes = if (append) resumeOffset else 0L,
+            )
         } finally {
             connection.disconnect()
         }
@@ -580,6 +695,7 @@ class ThemeViewModel(
             if (!hasWatchInternetConnection()) {
                 return DemTileDownloadOutcome(
                     success = false,
+                    missingUpstream = false,
                     networkUnavailable = true,
                 )
             }
@@ -596,11 +712,20 @@ class ThemeViewModel(
             if (success) {
                 return DemTileDownloadOutcome(
                     success = true,
+                    missingUpstream = false,
                     networkUnavailable = false,
                 )
             }
 
             val error = lastError
+            if (error != null) {
+                DemDownloadDiagnostics.record(
+                    event = "tile_attempt_failed",
+                    detail =
+                        "processed=$processed total=$total attempt=$attemptNumber " +
+                            "error=${error.javaClass.simpleName} message=${error.message.orEmpty().demDiagValue()}",
+                )
+            }
             if (error != null && error !is FileNotFoundException) {
                 Log.w(
                     TAG,
@@ -612,6 +737,7 @@ class ThemeViewModel(
             if (attemptNumber >= DEM_TILE_MAX_ATTEMPTS || !isRetryableDemDownloadFailure(error)) {
                 return DemTileDownloadOutcome(
                     success = false,
+                    missingUpstream = error is FileNotFoundException,
                     networkUnavailable =
                         error?.let {
                             classifyDemFailureAsNetworkUnavailable(
@@ -627,6 +753,7 @@ class ThemeViewModel(
 
         return DemTileDownloadOutcome(
             success = false,
+            missingUpstream = lastError is FileNotFoundException,
             networkUnavailable =
                 lastError?.let {
                     classifyDemFailureAsNetworkUnavailable(
@@ -642,6 +769,19 @@ class ThemeViewModel(
         val folder = upper.substring(0, 3)
         val file = "$upper.hgt.zip"
         return folder to file
+    }
+
+    private fun createMissingDemMarker(target: File) {
+        val tileId = target.name.removeSuffix(".hgt.zip").removeSuffix(".hgt")
+        val marker =
+            Dem3CoverageUtils
+                .missingTileMarkerCandidates(
+                    demRoot = getDemOutputRoot(),
+                    tileId = tileId,
+                ).firstOrNull { it.parentFile == target.parentFile }
+                ?: File(target.parentFile ?: getDemOutputRoot(), "$tileId.hgt.missing")
+        marker.parentFile?.mkdirs()
+        marker.writeText("missing_upstream\n")
     }
 
     private suspend fun waitForWatchInternetConnection(): Boolean {
@@ -664,3 +804,8 @@ class ThemeViewModel(
         return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
     }
 }
+
+private fun String.demDiagValue(): String =
+    replace(Regex("\\s+"), "_")
+        .replace("|", "_")
+        .take(180)

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/DebuggingSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/DebuggingSettingsScreen.kt
@@ -54,6 +54,7 @@ import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.core.service.diagnostics.CrashDiagnosticsStore
 import com.glancemap.glancemapwearos.core.service.diagnostics.DebugTelemetry
+import com.glancemap.glancemapwearos.core.service.diagnostics.DemDownloadDiagnostics
 import com.glancemap.glancemapwearos.core.service.diagnostics.DiagnosticsEmailHandoff
 import com.glancemap.glancemapwearos.core.service.diagnostics.DiagnosticsExporter
 import com.glancemap.glancemapwearos.core.service.diagnostics.DiagnosticsSettingsSnapshot
@@ -268,6 +269,7 @@ fun DebuggingSettingsScreen(
                         DebugTelemetry.clear()
                         MarkerMotionTelemetry.clear()
                         EnergyDiagnostics.clear()
+                        DemDownloadDiagnostics.clear()
                         FieldMarkerDiagnostics.clear()
                         GnssDiagnostics.clear()
                         MapHotPathDiagnostics.clear()

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModelDemSupportTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModelDemSupportTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
+import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.nio.file.Files
@@ -62,6 +63,11 @@ class ThemeViewModelDemSupportTest {
     @Test
     fun timeoutFailuresRemainRetryable() {
         assertTrue(isRetryableDemDownloadFailure(SocketTimeoutException("Read timed out")))
+    }
+
+    @Test
+    fun socketAbortFailuresAreRetryable() {
+        assertTrue(isRetryableDemDownloadFailure(SocketException("Software caused connection abort")))
     }
 
     @Test

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModelDemSupportTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModelDemSupportTest.kt
@@ -4,8 +4,12 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.File
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 class ThemeViewModelDemSupportTest {
     @Test
@@ -58,5 +62,62 @@ class ThemeViewModelDemSupportTest {
     @Test
     fun timeoutFailuresRemainRetryable() {
         assertTrue(isRetryableDemDownloadFailure(SocketTimeoutException("Read timed out")))
+    }
+
+    @Test
+    fun resumeRejectedFailureIsRetryable() {
+        assertTrue(isRetryableDemDownloadFailure(DemResumeRejectedException("HTTP 416")))
+    }
+
+    @Test
+    fun invalidDemTileFailureIsNotRetryable() {
+        assertFalse(isRetryableDemDownloadFailure(DemInvalidTileException("Bad DEM ZIP")))
+    }
+
+    @Test
+    fun validDemZipPassesValidation() {
+        val file = createTempDemZip(hgtSize = 1201 * 1201 * 2)
+
+        validateDemTileFile(file)
+    }
+
+    @Test(expected = DemInvalidTileException::class)
+    fun zipWithoutHgtEntryFailsValidation() {
+        val file = createTempZipWithEntry(entryName = "readme.txt", payloadSize = 32)
+
+        validateDemTileFile(file)
+    }
+
+    @Test(expected = DemInvalidTileException::class)
+    fun implausibleHgtSizeFailsValidation() {
+        val file = createTempDemZip(hgtSize = 64)
+
+        validateDemTileFile(file)
+    }
+
+    private fun createTempDemZip(hgtSize: Int): File =
+        createTempZipWithEntry(
+            entryName = "N46E006.hgt",
+            payloadSize = hgtSize,
+        )
+
+    private fun createTempZipWithEntry(
+        entryName: String,
+        payloadSize: Int,
+    ): File {
+        val file = Files.createTempFile("dem-validation-test", ".hgt.zip").toFile()
+        ZipOutputStream(file.outputStream().buffered()).use { zip ->
+            zip.putNextEntry(ZipEntry(entryName))
+            val buffer = ByteArray(8192)
+            var remaining = payloadSize
+            while (remaining > 0) {
+                val write = minOf(buffer.size, remaining)
+                zip.write(buffer, 0, write)
+                remaining -= write
+            }
+            zip.closeEntry()
+        }
+        file.deleteOnExit()
+        return file
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ android.r8.strictFullModeForKeepRules=false
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
 glanceMapVersionName=1.0.4
-glanceMapWearVersionCode=1009
+glanceMapWearVersionCode=1010
 glanceMapPhoneVersionCode=2008
 
 # Elevate theme build-time sync (download -> generated assets -> packaged in APK)


### PR DESCRIPTION
## Summary
- Resume interrupted watch DEM downloads from partial files and validate completed DEM tiles.
- Treat upstream 404 DEM tiles as known-missing coverage markers so maps with sea/offshore bounds can become ready.
- Add dedicated DEM download diagnostics and simplify user-facing completion messages.
- Bump Wear version code to 1010.

## Verification
- `./gradlew :app:testDebugUnitTest --tests com.glancemap.glancemapwearos.presentation.features.maps.theme.ThemeViewModelDemSupportTest --no-daemon --console=plain`
- `./gradlew :app:ktlintCheck --no-daemon --console=plain`