### PR TITLE
Fix DEM download CI detekt issues

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.DemDownloadFile.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.DemDownloadFile.kt
@@ -1,0 +1,161 @@
+package com.glancemap.glancemapwearos.presentation.features.maps.theme
+
+import com.glancemap.glancemapwearos.core.service.diagnostics.DemDownloadDiagnostics
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URI
+
+internal data class DemDownloadContext(
+    val url: String,
+    val target: File,
+    val part: File,
+    val tileName: String,
+    val resumeOffset: Long,
+)
+
+internal data class DemDownloadResponse(
+    val code: Int,
+    val append: Boolean,
+    val expectedTotalBytes: Long?,
+)
+
+internal fun downloadDemFile(
+    url: String,
+    target: File,
+    demRoot: File,
+    userAgent: String,
+) {
+    val context = buildDemDownloadContext(url = url, target = target)
+    recordResumeAttempt(context)
+    val connection = openDemConnection(context = context, userAgent = userAgent)
+    try {
+        val response = prepareDemResponse(connection = connection, context = context, demRoot = demRoot)
+        copyDemResponse(connection = connection, context = context, response = response)
+        promoteAndValidateDemPart(context)
+        recordSavedDemTile(context = context, response = response)
+    } finally {
+        connection.disconnect()
+    }
+}
+
+private fun buildDemDownloadContext(
+    url: String,
+    target: File,
+): DemDownloadContext {
+    val part = File(target.parentFile, ".${target.name}.part")
+    return DemDownloadContext(
+        url = url,
+        target = target,
+        part = part,
+        tileName = target.name.removeSuffix(".hgt.zip").removeSuffix(".hgt"),
+        resumeOffset = part.takeIf { it.exists() && it.isFile }?.length()?.coerceAtLeast(0L) ?: 0L,
+    )
+}
+
+private fun recordResumeAttempt(context: DemDownloadContext) {
+    if (context.resumeOffset <= 0L) return
+    DemDownloadDiagnostics.record(
+        event = "tile_resume_attempt",
+        detail =
+            "tile=${context.tileName} partialBytes=${context.resumeOffset} " +
+                "url=${context.url.demDiagValue()}",
+    )
+}
+
+private fun openDemConnection(
+    context: DemDownloadContext,
+    userAgent: String,
+): HttpURLConnection =
+    (URI(context.url).toURL().openConnection() as HttpURLConnection).apply {
+        connectTimeout = DEM_CONNECT_TIMEOUT_MS
+        readTimeout = DEM_READ_TIMEOUT_MS
+        requestMethod = "GET"
+        instanceFollowRedirects = true
+        setRequestProperty("User-Agent", userAgent)
+        if (context.resumeOffset > 0L) {
+            setRequestProperty("Range", "bytes=${context.resumeOffset}-")
+        }
+    }
+
+private fun prepareDemResponse(
+    connection: HttpURLConnection,
+    context: DemDownloadContext,
+    demRoot: File,
+): DemDownloadResponse {
+    val code = connection.responseCode
+    handleDemHttpError(code = code, context = context, demRoot = demRoot)
+    val append = context.resumeOffset > 0L && code == HttpURLConnection.HTTP_PARTIAL
+    if (context.resumeOffset > 0L && code == HttpURLConnection.HTTP_OK && context.part.exists()) {
+        recordDemResumeRestart(context)
+        context.part.delete()
+    }
+    val expectedTotalBytes =
+        connection.contentLengthLong
+            .takeIf { it > 0L }
+            ?.let { contentLength -> (if (append) context.resumeOffset else 0L) + contentLength }
+    return DemDownloadResponse(code = code, append = append, expectedTotalBytes = expectedTotalBytes)
+}
+
+private fun handleDemHttpError(
+    code: Int,
+    context: DemDownloadContext,
+    demRoot: File,
+) {
+    if (code in 200..299) return
+    when (code) {
+        HttpURLConnection.HTTP_NOT_FOUND -> markDemTileMissing(context = context, demRoot = demRoot)
+        HTTP_REQUESTED_RANGE_NOT_SATISFIABLE -> rejectDemResumeIfNeeded(context)
+        else -> recordDemHttpFailure(context = context, code = code)
+    }
+}
+
+private fun markDemTileMissing(
+    context: DemDownloadContext,
+    demRoot: File,
+) {
+    context.part.delete()
+    DemDownloadDiagnostics.record(
+        event = "tile_http",
+        detail = "tile=${context.tileName} code=404 action=missing url=${context.url.demDiagValue()}",
+    )
+    createMissingDemMarker(target = context.target, demRoot = demRoot)
+    throw FileNotFoundException("HTTP 404 for ${context.url}")
+}
+
+private fun rejectDemResumeIfNeeded(context: DemDownloadContext) {
+    if (context.resumeOffset <= 0L) return
+    context.part.delete()
+    DemDownloadDiagnostics.record(
+        event = "tile_resume_rejected",
+        detail =
+            "tile=${context.tileName} code=$HTTP_REQUESTED_RANGE_NOT_SATISFIABLE " +
+                "partialBytes=${context.resumeOffset} url=${context.url.demDiagValue()}",
+    )
+    throw DemResumeRejectedException("DEM server rejected partial resume for ${context.url}")
+}
+
+private fun recordDemHttpFailure(
+    context: DemDownloadContext,
+    code: Int,
+) {
+    DemDownloadDiagnostics.record(
+        event = "tile_http",
+        detail = "tile=${context.tileName} code=$code action=fail url=${context.url.demDiagValue()}",
+    )
+    throw IOException("HTTP $code for ${context.url}")
+}
+
+private fun recordDemResumeRestart(context: DemDownloadContext) {
+    DemDownloadDiagnostics.record(
+        event = "tile_resume_restart",
+        detail =
+            "tile=${context.tileName} reason=range_ignored " +
+                "partialBytes=${context.resumeOffset} url=${context.url.demDiagValue()}",
+    )
+}
+
+private const val DEM_CONNECT_TIMEOUT_MS = 20_000
+private const val DEM_READ_TIMEOUT_MS = 60_000
+private const val HTTP_REQUESTED_RANGE_NOT_SATISFIABLE = 416

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.DemDownloadPersistence.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.DemDownloadPersistence.kt
@@ -1,0 +1,88 @@
+package com.glancemap.glancemapwearos.presentation.features.maps.theme
+
+import com.glancemap.glancemapwearos.core.maps.Dem3CoverageUtils
+import com.glancemap.glancemapwearos.core.service.diagnostics.DemDownloadDiagnostics
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.net.HttpURLConnection
+
+internal fun copyDemResponse(
+    connection: HttpURLConnection,
+    context: DemDownloadContext,
+    response: DemDownloadResponse,
+) {
+    connection.inputStream.use { input ->
+        FileOutputStream(context.part, response.append).use { out ->
+            input.copyTo(out)
+            out.flush()
+            runCatching { out.fd.sync() }
+        }
+    }
+    requireCompleteDemPart(context = context, expectedTotalBytes = response.expectedTotalBytes)
+}
+
+internal fun promoteAndValidateDemPart(context: DemDownloadContext) {
+    context.target.delete()
+    if (!context.part.renameTo(context.target)) {
+        throw IOException("Failed moving temp DEM file to ${context.target.absolutePath}")
+    }
+    runCatching { validateDemTileFile(context.target) }
+        .onFailure { error ->
+            recordDemValidationFailure(context = context, error = error)
+            context.target.delete()
+        }.getOrThrow()
+}
+
+internal fun recordSavedDemTile(
+    context: DemDownloadContext,
+    response: DemDownloadResponse,
+) {
+    val resumedFromBytes = if (response.append) context.resumeOffset else 0L
+    DemDownloadDiagnostics.record(
+        event = "tile_saved",
+        detail =
+            "tile=${context.tileName} code=${response.code} bytes=${context.target.length()} " +
+                "resumedFromBytes=$resumedFromBytes",
+    )
+}
+
+internal fun createMissingDemMarker(
+    target: File,
+    demRoot: File,
+) {
+    val tileId = target.name.removeSuffix(".hgt.zip").removeSuffix(".hgt")
+    val marker =
+        Dem3CoverageUtils
+            .missingTileMarkerCandidates(demRoot = demRoot, tileId = tileId)
+            .firstOrNull { it.parentFile == target.parentFile }
+            ?: File(target.parentFile ?: demRoot, "$tileId.hgt.missing")
+    marker.parentFile?.mkdirs()
+    marker.writeText("missing_upstream\n")
+}
+
+private fun requireCompleteDemPart(
+    context: DemDownloadContext,
+    expectedTotalBytes: Long?,
+) {
+    if (expectedTotalBytes == null || context.part.length() == expectedTotalBytes) return
+    DemDownloadDiagnostics.record(
+        event = "tile_incomplete",
+        detail =
+            "tile=${context.tileName} expectedBytes=$expectedTotalBytes " +
+                "actualBytes=${context.part.length()}",
+    )
+    throw IOException("INCOMPLETE_DEM_TILE: expected=$expectedTotalBytes got=${context.part.length()}")
+}
+
+private fun recordDemValidationFailure(
+    context: DemDownloadContext,
+    error: Throwable,
+) {
+    DemDownloadDiagnostics.record(
+        event = "tile_validation_failed",
+        detail =
+            "tile=${context.tileName} bytes=${context.target.length()} " +
+                "error=${error.javaClass.simpleName} message=${error.message.orEmpty().demDiagValue()}",
+    )
+}

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.DemSupport.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.DemSupport.kt
@@ -62,42 +62,26 @@ internal fun buildDemFailureMessage(
 
 internal fun isRetryableDemDownloadFailure(throwable: Throwable?): Boolean {
     if (throwable == null) return false
-    if (throwable is FileNotFoundException) return false
-    if (throwable is DemInvalidTileException) return false
-    if (throwable is ZipException) return false
-    if (throwable is DemResumeRejectedException) return true
-    if (throwable is SocketException) return true
+    if (isPermanentDemDownloadFailure(throwable)) return false
+    if (throwable is DemResumeRejectedException || throwable is SocketException) return true
     if (hasDirectDemOfflineCause(throwable) || hasDemTimeoutCause(throwable)) return true
 
     val message = throwable.message.orEmpty().lowercase(Locale.ROOT)
-    return message.contains("http 500") ||
-        message.contains("http 502") ||
-        message.contains("http 503") ||
-        message.contains("http 504") ||
-        message.contains("unexpected end of stream") ||
-        message.contains("connection reset") ||
-        message.contains("broken pipe") ||
-        message.contains("connection closed") ||
-        message.contains("connection refused") ||
-        message.contains("software caused connection abort") ||
-        message.contains("http 408") ||
-        message.contains("http 429") ||
-        message.contains("timed out") ||
-        message.contains("timeout")
+    return DEM_RETRYABLE_MESSAGE_PARTS.any(message::contains)
 }
 
 internal fun validateDemTileFile(file: File) {
     if (!file.exists() || !file.isFile) {
-        throw DemInvalidTileException("DEM tile was not saved.")
+        invalidDemTile("DEM tile was not saved.")
     }
     if (file.length() <= 0L) {
-        throw DemInvalidTileException("DEM tile is empty.")
+        invalidDemTile("DEM tile is empty.")
     }
 
     if (file.name.endsWith(".zip", ignoreCase = true)) {
         validateDemZip(file)
     } else if (!isPlausibleHgtByteSize(file.length())) {
-        throw DemInvalidTileException("DEM tile has invalid HGT size: ${file.length()} bytes.")
+        invalidDemTile("DEM tile has invalid HGT size: ${file.length()} bytes.")
     }
 }
 
@@ -113,7 +97,7 @@ private fun validateDemZip(file: File) {
         }
 
     if (hgtEntries.isEmpty()) {
-        throw DemInvalidTileException("DEM ZIP does not contain an HGT file.")
+        invalidDemTile("DEM ZIP does not contain an HGT file.")
     }
 
     val firstInvalidSize =
@@ -121,9 +105,16 @@ private fun validateDemZip(file: File) {
             .mapNotNull { entry -> entry.size.takeIf { it > 0L } }
             .firstOrNull { size -> !isPlausibleHgtByteSize(size) }
     if (firstInvalidSize != null) {
-        throw DemInvalidTileException("DEM ZIP contains invalid HGT size: $firstInvalidSize bytes.")
+        invalidDemTile("DEM ZIP contains invalid HGT size: $firstInvalidSize bytes.")
     }
 }
+
+private fun isPermanentDemDownloadFailure(throwable: Throwable): Boolean =
+    throwable is FileNotFoundException ||
+        throwable is DemInvalidTileException ||
+        throwable is ZipException
+
+private fun invalidDemTile(message: String): Nothing = throw DemInvalidTileException(message)
 
 private fun isPlausibleHgtByteSize(size: Long): Boolean {
     if (size <= 0L || size % Short.SIZE_BYTES != 0L) return false
@@ -131,6 +122,24 @@ private fun isPlausibleHgtByteSize(size: Long): Boolean {
     val rowLen = sqrt(sampleCount.toDouble()).toInt()
     return rowLen * rowLen.toLong() == sampleCount && rowLen in 1201..3601
 }
+
+private val DEM_RETRYABLE_MESSAGE_PARTS =
+    listOf(
+        "http 408",
+        "http 429",
+        "http 500",
+        "http 502",
+        "http 503",
+        "http 504",
+        "unexpected end of stream",
+        "connection reset",
+        "broken pipe",
+        "connection closed",
+        "connection refused",
+        "software caused connection abort",
+        "timed out",
+        "timeout",
+    )
 
 private fun hasDirectDemOfflineCause(throwable: Throwable): Boolean {
     var current: Throwable? = throwable

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.kt
@@ -26,10 +26,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileNotFoundException
-import java.io.FileOutputStream
-import java.io.IOException
-import java.net.HttpURLConnection
-import java.net.URI
 import java.util.Locale
 
 private enum class OverlayPreset {
@@ -69,11 +65,6 @@ private data class DemTileDownloadOutcome(
     val networkUnavailable: Boolean,
 )
 
-private data class DemDownloadAttemptResult(
-    val bytesWritten: Long,
-    val resumedFromBytes: Long,
-)
-
 class ThemeViewModel(
     private val themeRepository: ThemeRepository,
     private val context: Context,
@@ -86,7 +77,6 @@ class ThemeViewModel(
         private const val DEM_TILE_RETRY_BASE_DELAY_MS = 1_500L
         private const val DEM_INTERNET_WAIT_TIMEOUT_MS = 8_000L
         private const val DEM_INTERNET_RECHECK_MS = 500L
-        private const val HTTP_REQUESTED_RANGE_NOT_SATISFIABLE = 416
     }
 
     private val appContext: Context = context.applicationContext
@@ -559,122 +549,6 @@ class ThemeViewModel(
 
     private fun getDemOutputRoot(): File = Dem3CoverageUtils.demRootDir(appContext)
 
-    private fun downloadFile(
-        url: String,
-        target: File,
-    ): DemDownloadAttemptResult {
-        val part = File(target.parentFile, ".${target.name}.part")
-        val resumeOffset = part.takeIf { it.exists() && it.isFile }?.length()?.coerceAtLeast(0L) ?: 0L
-        val tileName = target.name.removeSuffix(".hgt.zip").removeSuffix(".hgt")
-        if (resumeOffset > 0L) {
-            DemDownloadDiagnostics.record(
-                event = "tile_resume_attempt",
-                detail = "tile=$tileName partialBytes=$resumeOffset url=${url.demDiagValue()}",
-            )
-        }
-
-        val connection =
-            (URI(url).toURL().openConnection() as HttpURLConnection).apply {
-                connectTimeout = 20_000
-                readTimeout = 60_000
-                requestMethod = "GET"
-                instanceFollowRedirects = true
-                setRequestProperty("User-Agent", DEM3_USER_AGENT)
-                if (resumeOffset > 0L) {
-                    setRequestProperty("Range", "bytes=$resumeOffset-")
-                }
-            }
-
-        try {
-            val code = connection.responseCode
-            if (code == HttpURLConnection.HTTP_NOT_FOUND) {
-                if (part.exists()) part.delete()
-                DemDownloadDiagnostics.record(
-                    event = "tile_http",
-                    detail = "tile=$tileName code=$code action=missing url=${url.demDiagValue()}",
-                )
-                createMissingDemMarker(target)
-                throw FileNotFoundException("HTTP 404 for $url")
-            }
-            if (code == HTTP_REQUESTED_RANGE_NOT_SATISFIABLE && resumeOffset > 0L) {
-                if (part.exists()) part.delete()
-                DemDownloadDiagnostics.record(
-                    event = "tile_resume_rejected",
-                    detail = "tile=$tileName code=$code partialBytes=$resumeOffset url=${url.demDiagValue()}",
-                )
-                throw DemResumeRejectedException("DEM server rejected partial resume for $url")
-            }
-            if (code !in 200..299) {
-                DemDownloadDiagnostics.record(
-                    event = "tile_http",
-                    detail = "tile=$tileName code=$code action=fail url=${url.demDiagValue()}",
-                )
-                throw IllegalStateException("HTTP $code for $url")
-            }
-
-            val append = resumeOffset > 0L && code == HttpURLConnection.HTTP_PARTIAL
-            if (resumeOffset > 0L && code == HttpURLConnection.HTTP_OK && part.exists()) {
-                Log.w(TAG, "DEM server ignored Range for $url; restarting tile download.")
-                DemDownloadDiagnostics.record(
-                    event = "tile_resume_restart",
-                    detail = "tile=$tileName reason=range_ignored partialBytes=$resumeOffset url=${url.demDiagValue()}",
-                )
-                part.delete()
-            }
-
-            val startingBytes = if (append) resumeOffset else 0L
-            val expectedTotalBytes =
-                connection.contentLengthLong
-                    .takeIf { it > 0L }
-                    ?.let { contentLength -> startingBytes + contentLength }
-
-            connection.inputStream.use { input ->
-                FileOutputStream(part, append).use { out ->
-                    input.copyTo(out)
-                    out.flush()
-                    runCatching { out.fd.sync() }
-                }
-            }
-
-            if (expectedTotalBytes != null && part.length() != expectedTotalBytes) {
-                DemDownloadDiagnostics.record(
-                    event = "tile_incomplete",
-                    detail = "tile=$tileName expectedBytes=$expectedTotalBytes actualBytes=${part.length()}",
-                )
-                throw IOException("INCOMPLETE_DEM_TILE: expected=$expectedTotalBytes got=${part.length()}")
-            }
-
-            if (target.exists()) target.delete()
-            if (!part.renameTo(target)) {
-                throw IllegalStateException("Failed moving temp DEM file to ${target.absolutePath}")
-            }
-            try {
-                validateDemTileFile(target)
-            } catch (error: Exception) {
-                DemDownloadDiagnostics.record(
-                    event = "tile_validation_failed",
-                    detail =
-                        "tile=$tileName bytes=${target.length()} " +
-                            "error=${error.javaClass.simpleName} message=${error.message.orEmpty().demDiagValue()}",
-                )
-                target.delete()
-                throw error
-            }
-            DemDownloadDiagnostics.record(
-                event = "tile_saved",
-                detail =
-                    "tile=$tileName code=$code bytes=${target.length()} " +
-                        "resumedFromBytes=${if (append) resumeOffset else 0L}",
-            )
-            return DemDownloadAttemptResult(
-                bytesWritten = target.length(),
-                resumedFromBytes = if (append) resumeOffset else 0L,
-            )
-        } finally {
-            connection.disconnect()
-        }
-    }
-
     private suspend fun downloadTileWithRetries(
         url: String,
         target: File,
@@ -702,7 +576,12 @@ class ThemeViewModel(
 
             val success =
                 runCatching {
-                    downloadFile(url = url, target = target)
+                    downloadDemFile(
+                        url = url,
+                        target = target,
+                        demRoot = getDemOutputRoot(),
+                        userAgent = DEM3_USER_AGENT,
+                    )
                     true
                 }.getOrElse { error ->
                     lastError = error
@@ -771,19 +650,6 @@ class ThemeViewModel(
         return folder to file
     }
 
-    private fun createMissingDemMarker(target: File) {
-        val tileId = target.name.removeSuffix(".hgt.zip").removeSuffix(".hgt")
-        val marker =
-            Dem3CoverageUtils
-                .missingTileMarkerCandidates(
-                    demRoot = getDemOutputRoot(),
-                    tileId = tileId,
-                ).firstOrNull { it.parentFile == target.parentFile }
-                ?: File(target.parentFile ?: getDemOutputRoot(), "$tileId.hgt.missing")
-        marker.parentFile?.mkdirs()
-        marker.writeText("missing_upstream\n")
-    }
-
     private suspend fun waitForWatchInternetConnection(): Boolean {
         val deadline = SystemClock.elapsedRealtime() + DEM_INTERNET_WAIT_TIMEOUT_MS
         while (SystemClock.elapsedRealtime() < deadline) {
@@ -805,7 +671,7 @@ class ThemeViewModel(
     }
 }
 
-private fun String.demDiagValue(): String =
+internal fun String.demDiagValue(): String =
     replace(Regex("\\s+"), "_")
         .replace("|", "_")
         .take(180)


### PR DESCRIPTION
## Summary
- Move low-level DEM HTTP download/resume code out of ThemeViewModel.
- Split DEM download persistence helpers into a separate file to satisfy Detekt function limits.
- Simplify retry and validation helpers without changing DEM download behavior.

## Verification
- `./gradlew ktlintCheck detekt :app:compileDebugKotlin :glancemapcompanionapp:compileDebugKotlin :app:testDebugUnitTest :glancemapcompanionapp:testDebugUnitTest :app:lintDebug :glancemapcompanionapp:lintDebug --no-daemon --console=plain`