### PR TITLE
Polish companion guidance and permissions

### DIFF
--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RefugesImportDialog.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RefugesImportDialog.kt
@@ -101,12 +101,12 @@ internal fun RefugesImportDialog(
         mutableStateOf(lastRefugesRequest?.bbox.orEmpty())
     }
     var fileNameInput by remember(lastRefugesRequest?.fileName) {
-        mutableStateOf(lastRefugesRequest?.fileName ?: "refuges-info.poi")
+        mutableStateOf(lastRefugesRequest?.fileName ?: "osm-mountain.poi")
     }
     var selectedTypeIds by remember(lastRefugesRequest?.typePointIds) {
         mutableStateOf(lastRefugesRequest?.typePointIds ?: allPointTypeIds)
     }
-    var selectedSource by remember { mutableStateOf(PoiImportSource.REFUGES) }
+    var selectedSource by remember { mutableStateOf(PoiImportSource.OSM) }
     var enrichWithOsm by remember { mutableStateOf(false) }
     var selectedOsmCategoryIds by remember {
         mutableStateOf(defaultOsmPoiCategoryIds())
@@ -585,13 +585,6 @@ internal fun RefugesImportDialog(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         FilterChip(
-                            selected = selectedSource == PoiImportSource.REFUGES,
-                            onClick = {
-                                selectedSource = PoiImportSource.REFUGES
-                            },
-                            label = { Text("Refuges.info") },
-                        )
-                        FilterChip(
                             selected = selectedSource == PoiImportSource.OSM,
                             onClick = {
                                 selectedSource = PoiImportSource.OSM
@@ -599,8 +592,20 @@ internal fun RefugesImportDialog(
                             },
                             label = { Text("OSM") },
                         )
+                        FilterChip(
+                            selected = selectedSource == PoiImportSource.REFUGES,
+                            onClick = {
+                                selectedSource = PoiImportSource.REFUGES
+                            },
+                            label = { Text("Refuges.info") },
+                        )
                     }
                     if (selectedSource == PoiImportSource.REFUGES) {
+                        Spacer(modifier = Modifier.height(6.dp))
+                        Text(
+                            "refuges.info POIs for France, the Alps, and the Pyrenees.",
+                            style = MaterialTheme.typography.bodySmall,
+                        )
                         Spacer(modifier = Modifier.height(6.dp))
                         Row(
                             modifier = Modifier.fillMaxWidth(),

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.Sections.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.Sections.kt
@@ -27,15 +27,28 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.LinkInteractionListener
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import com.glancemap.glancemapcompanionapp.CompanionAdaptiveSpec
 import com.glancemap.glancemapcompanionapp.CompanionWindowClass
 import com.glancemap.glancemapcompanionapp.FileTransferUiState
 import com.glancemap.glancemapcompanionapp.diagnostics.PhoneDebugCaptureState
 import com.glancemap.glancemapcompanionapp.transfer.presentation.TransferTextFormatter
+
+private const val MAPSFORGE_URL = "https://github.com/mapsforge/mapsforge"
 
 @Composable
 internal fun FilePickerDownloadSection(
@@ -63,6 +76,11 @@ internal fun FilePickerDownloadSection(
     val isCompactScreen = adaptive.isCompactScreen
     val downloadButtonHeight = adaptive.downloadButtonHeight
     val downloadSectionMinHeight = downloadButtonHeight + 60.dp
+    val showNotificationNotice =
+        !hasNotificationPermission &&
+            Build.VERSION.SDK_INT >= 33 &&
+            hasBluetoothConnectPermission
+    var showGpxSourcesMenu by remember { mutableStateOf(false) }
     val openUrl: (String) -> Unit = { url ->
         runCatching {
             context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
@@ -82,29 +100,18 @@ internal fun FilePickerDownloadSection(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            if (!hasNotificationPermission && Build.VERSION.SDK_INT >= 33) {
+            if (showNotificationNotice) {
                 Text(
-                    "Notification permission needed for background transfers.",
-                    color = MaterialTheme.colorScheme.error,
+                    "Notifications are off. Transfers still work, but background progress alerts may be hidden.",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     style = MaterialTheme.typography.labelSmall,
                 )
-            }
-            if (!hasBluetoothConnectPermission && Build.VERSION.SDK_INT >= 31) {
-                Text(
-                    "Bluetooth permission needed to detect and pair with watch.",
-                    color = MaterialTheme.colorScheme.error,
-                    style = MaterialTheme.typography.labelSmall,
-                )
-            }
-            if ((!hasNotificationPermission && Build.VERSION.SDK_INT >= 33) ||
-                (!hasBluetoothConnectPermission && Build.VERSION.SDK_INT >= 31)
-            ) {
                 OutlinedButton(
                     onClick = onRequestMissingPermissions,
                     enabled = !uiLocked,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    Text("Grant missing permissions")
+                    Text("Enable notifications")
                 }
             }
 
@@ -134,6 +141,21 @@ internal fun FilePickerDownloadSection(
                         expanded = showMapSourcesMenu,
                         onDismissRequest = { onShowMapSourcesMenuChange(false) },
                     ) {
+                        MapsDropdownIntro(
+                            onOpenMapsforge = {
+                                onShowMapSourcesMenuChange(false)
+                                openUrl(MAPSFORGE_URL)
+                            },
+                        )
+                        HorizontalDivider()
+                        Text(
+                            "Recommended websites to download maps",
+                            style = MaterialTheme.typography.labelMedium,
+                            modifier =
+                                Modifier
+                                    .widthIn(max = 300.dp)
+                                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                        )
                         val orderedCategories =
                             listOf(
                                 "Topographic maps",
@@ -161,13 +183,18 @@ internal fun FilePickerDownloadSection(
                                 DropdownMenuItem(
                                     text = {
                                         Column {
-                                            Text(source.label)
                                             Text(
-                                                source.url,
-                                                style = MaterialTheme.typography.labelSmall,
-                                                maxLines = 1,
-                                                overflow = TextOverflow.Ellipsis,
+                                                source.label,
+                                                color = MaterialTheme.colorScheme.primary,
+                                                textDecoration = TextDecoration.Underline,
                                             )
+                                            source.guidance?.let { guidance ->
+                                                Text(
+                                                    guidance,
+                                                    style = MaterialTheme.typography.labelSmall,
+                                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                )
+                                            }
                                         }
                                     },
                                     onClick = {
@@ -180,17 +207,68 @@ internal fun FilePickerDownloadSection(
                     }
                 }
 
-                DownloadActionButton(
-                    label = "GPX",
-                    buttonHeight = downloadButtonHeight,
-                    iconSize = 22.dp,
-                    onClick = { openUrl("https://www.visugpx.com/") },
-                    enabled = !uiLocked,
+                Box(
                     modifier = Modifier.weight(1f),
-                    icon = {
-                        Icon(Icons.Filled.Timeline, contentDescription = "Download GPX")
-                    },
-                )
+                ) {
+                    DownloadActionButton(
+                        label = "GPX",
+                        buttonHeight = downloadButtonHeight,
+                        iconSize = 22.dp,
+                        onClick = { showGpxSourcesMenu = true },
+                        enabled = !uiLocked,
+                        modifier = Modifier.fillMaxWidth(),
+                        icon = {
+                            Icon(Icons.Filled.Timeline, contentDescription = "Download GPX")
+                        },
+                    )
+                    DropdownMenu(
+                        expanded = showGpxSourcesMenu,
+                        onDismissRequest = { showGpxSourcesMenu = false },
+                    ) {
+                        Text(
+                            "GlanceMap can read and display .gpx tracks.",
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier =
+                                Modifier
+                                    .widthIn(max = 260.dp)
+                                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                        )
+                        Text(
+                            "Download GPX from your favorite website, or create your own route:",
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier =
+                                Modifier
+                                    .widthIn(max = 260.dp)
+                                    .padding(horizontal = 16.dp)
+                                    .padding(bottom = 8.dp),
+                        )
+                        GpxSourceMenuItem(
+                            label = "gpx.studio",
+                            url = "https://gpx.studio/",
+                            onOpen = { url ->
+                                showGpxSourcesMenu = false
+                                openUrl(url)
+                            },
+                        )
+                        GpxSourceMenuItem(
+                            label = "Trackbook",
+                            url = "https://trackbook.com/",
+                            onOpen = { url ->
+                                showGpxSourcesMenu = false
+                                openUrl(url)
+                            },
+                        )
+                        HorizontalDivider()
+                        Text(
+                            "Send routing files to the watch to create GPX routes directly in the watch app.",
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier =
+                                Modifier
+                                    .widthIn(max = 260.dp)
+                                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                        )
+                    }
+                }
 
                 Box(
                     modifier = Modifier.weight(1f),
@@ -283,6 +361,64 @@ internal fun FilePickerDownloadSection(
             }
         }
     }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun GpxSourceMenuItem(
+    label: String,
+    url: String,
+    onOpen: (String) -> Unit,
+) {
+    DropdownMenuItem(
+        text = {
+            Text(
+                label,
+                color = MaterialTheme.colorScheme.primary,
+                textDecoration = TextDecoration.Underline,
+            )
+        },
+        onClick = { onOpen(url) },
+    )
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun MapsDropdownIntro(onOpenMapsforge: () -> Unit) {
+    val linkColor = MaterialTheme.colorScheme.primary
+    val textColor = MaterialTheme.colorScheme.onSurface
+    val textStyle = MaterialTheme.typography.bodySmall.copy(color = textColor)
+    val linkStyles =
+        TextLinkStyles(
+            style =
+                SpanStyle(
+                    color = linkColor,
+                    textDecoration = TextDecoration.Underline,
+                ),
+        )
+    val introText =
+        buildAnnotatedString {
+            append("GlanceMap is powered by ")
+            withLink(
+                LinkAnnotation.Url(
+                    url = MAPSFORGE_URL,
+                    styles = linkStyles,
+                    linkInteractionListener = LinkInteractionListener { onOpenMapsforge() },
+                ),
+            ) {
+                append("Mapsforge")
+            }
+            append(". Compatible map files: .map (v3/v4/v5).")
+        }
+
+    Text(
+        text = introText,
+        style = textStyle,
+        modifier =
+            Modifier
+                .widthIn(max = 300.dp)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+    )
 }
 
 @Composable

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.Support.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.Support.kt
@@ -18,6 +18,7 @@ internal data class ExternalDownloadSource(
     val category: String,
     val label: String,
     val url: String,
+    val guidance: String? = null,
 )
 
 internal data class ThemeLegendLink(
@@ -133,11 +134,11 @@ internal fun markHelpShown(context: Context) {
         .apply()
 }
 
-internal fun hasBluetoothConnectPermission(context: Context): Boolean {
-    if (Build.VERSION.SDK_INT < 31) return true
+internal fun hasNotificationPermission(context: Context): Boolean {
+    if (Build.VERSION.SDK_INT < 33) return true
     return ContextCompat.checkSelfPermission(
         context,
-        Manifest.permission.BLUETOOTH_CONNECT,
+        Manifest.permission.POST_NOTIFICATIONS,
     ) == PackageManager.PERMISSION_GRANTED
 }
 

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.kt
@@ -3,7 +3,6 @@ package com.glancemap.glancemapcompanionapp.filepicker
 import android.Manifest
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.util.Log
@@ -29,7 +28,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -94,18 +92,20 @@ fun FilePickerScreen(viewModel: FileTransferViewModel) {
             listOf(
                 ExternalDownloadSource(
                     category = "Topographic maps",
-                    label = "OpenAndroMaps",
+                    label = "OpenAndroMaps (recommended, worldwide)",
                     url = "https://www.openandromaps.org/en/downloads",
+                    guidance = "Map downloads > select your area > Download V5 Map: Karte/Map.",
                 ),
                 ExternalDownloadSource(
                     category = "Topographic maps",
-                    label = "OpenHiking",
+                    label = "OpenHiking (Europe)",
                     url = "https://www.openhiking.eu/en/downloads/mapsforge-maps",
                 ),
                 ExternalDownloadSource(
                     category = "Non-topographic maps",
                     label = "BBBike",
                     url = "https://extract.bbbike.org/?format=mapsforge-osm.zip",
+                    guidance = "Generate a map for your area, then choose format: Mapsforge OSM.",
                 ),
                 ExternalDownloadSource(
                     category = "Non-topographic maps",
@@ -116,11 +116,6 @@ fun FilePickerScreen(viewModel: FileTransferViewModel) {
                     category = "Non-topographic maps",
                     label = "Alternativas Libres",
                     url = "https://alternativaslibres.org/en/downloads-mf.php",
-                ),
-                ExternalDownloadSource(
-                    category = "Other",
-                    label = "Freizeitkarte",
-                    url = "https://www.freizeitkarte-osm.de/android/en/index.html",
                 ),
             )
         }
@@ -239,19 +234,11 @@ fun FilePickerScreen(viewModel: FileTransferViewModel) {
     // --- Permission Handling ---
     var hasNotificationPermission by remember {
         mutableStateOf(
-            if (Build.VERSION.SDK_INT >= 33) {
-                ContextCompat.checkSelfPermission(
-                    context,
-                    Manifest.permission.POST_NOTIFICATIONS,
-                ) == PackageManager.PERMISSION_GRANTED
-            } else {
-                true
-            },
+            hasNotificationPermission(context),
         )
     }
-    var hasBluetoothConnectPermission by remember {
-        mutableStateOf(hasBluetoothConnectPermission(context))
-    }
+    // Wear OS Data Layer discovery/transfer does not need a user-facing Bluetooth grant.
+    var hasBluetoothConnectPermission by remember { mutableStateOf(true) }
 
     val permissionLauncher =
         rememberLauncherForActivityResult(
@@ -259,8 +246,6 @@ fun FilePickerScreen(viewModel: FileTransferViewModel) {
         ) { permissions ->
             hasNotificationPermission =
                 permissions[Manifest.permission.POST_NOTIFICATIONS] ?: hasNotificationPermission
-            hasBluetoothConnectPermission =
-                permissions[Manifest.permission.BLUETOOTH_CONNECT] ?: hasBluetoothConnectPermission
         }
 
     val saveSingleFileLauncher =
@@ -332,15 +317,8 @@ fun FilePickerScreen(viewModel: FileTransferViewModel) {
         }
 
     val requestMissingPermissions = {
-        val permissionsToRequest = mutableListOf<String>()
         if (Build.VERSION.SDK_INT >= 33 && !hasNotificationPermission) {
-            permissionsToRequest.add(Manifest.permission.POST_NOTIFICATIONS)
-        }
-        if (Build.VERSION.SDK_INT >= 31 && !hasBluetoothConnectPermission) {
-            permissionsToRequest.add(Manifest.permission.BLUETOOTH_CONNECT)
-        }
-        if (permissionsToRequest.isNotEmpty()) {
-            permissionLauncher.launch(permissionsToRequest.toTypedArray())
+            permissionLauncher.launch(arrayOf(Manifest.permission.POST_NOTIFICATIONS))
         }
     }
 
@@ -393,16 +371,8 @@ fun FilePickerScreen(viewModel: FileTransferViewModel) {
                     }
 
                     Lifecycle.Event.ON_RESUME -> {
-                        hasNotificationPermission =
-                            if (Build.VERSION.SDK_INT >= 33) {
-                                ContextCompat.checkSelfPermission(
-                                    context,
-                                    Manifest.permission.POST_NOTIFICATIONS,
-                                ) == PackageManager.PERMISSION_GRANTED
-                            } else {
-                                true
-                            }
-                        hasBluetoothConnectPermission = hasBluetoothConnectPermission(context)
+                        hasNotificationPermission = hasNotificationPermission(context)
+                        hasBluetoothConnectPermission = true
                     }
 
                     Lifecycle.Event.ON_STOP -> {
@@ -449,7 +419,12 @@ fun FilePickerScreen(viewModel: FileTransferViewModel) {
             uiState.progressText.contains("Waiting for watch reconnect", ignoreCase = true)
     val fontScale = LocalDensity.current.fontScale
 
-    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+    BoxWithConstraints(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .windowInsetsPadding(WindowInsets.safeDrawing),
+    ) {
         val windowWidth = maxWidth
         val windowHeight = maxHeight
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ android.r8.strictFullModeForKeepRules=false
 # Bump the matching artifact by 1 for each Play upload.
 glanceMapVersionName=1.0.4
 glanceMapWearVersionCode=1010
-glanceMapPhoneVersionCode=2008
+glanceMapPhoneVersionCode=2009
 
 # Elevate theme build-time sync (download -> generated assets -> packaged in APK)
 elevateThemeVersion=5.6


### PR DESCRIPTION
## Summary
- Clarifies companion permission handling so Bluetooth is not presented as a missing runtime permission and notification access is shown as optional on Android 13+.
- Adds safe-area padding for modern phones with notches and navigation bars.
- Improves companion download dropdowns for maps and GPX, defaults POI import to OSM, and adds concise source guidance.
- Bumps the companion phone version code from 2008 to 2009.

## Validation
- `./gradlew :glancemapcompanionapp:ktlintCheck :glancemapcompanionapp:detekt :glancemapcompanionapp:compileDebugKotlin --no-daemon --console=plain`