### PR TITLE
Bump watch version code

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ android.r8.strictFullModeForKeepRules=false
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
 glanceMapVersionName=1.0.4
-glanceMapWearVersionCode=1010
+glanceMapWearVersionCode=1011
 glanceMapPhoneVersionCode=2009
 
 # Elevate theme build-time sync (download -> generated assets -> packaged in APK)


### PR DESCRIPTION
## Summary
- Bumps the Wear OS app version code from 1010 to 1011.
- Leaves the companion phone version code and shared version name unchanged.

## Validation
- `./gradlew :app:compileDebugKotlin --no-daemon --console=plain`