### PR TITLE
Prepare 1.0.5 release

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/data/repository/maps/theme/ThemeRepository.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/data/repository/maps/theme/ThemeRepository.kt
@@ -12,6 +12,8 @@ data class ThemeSelection(
     val hillShadingEnabled: Boolean,
     // Global map-layer toggle used by renderer DEM color relief overlay.
     val reliefOverlayEnabled: Boolean,
+    // Global map appearance override that renders with a dark Mapsforge style.
+    val nightModeEnabled: Boolean,
 )
 
 interface ThemeRepository {
@@ -44,6 +46,8 @@ interface ThemeRepository {
     suspend fun setHillShadingEnabled(enabled: Boolean)
 
     suspend fun setReliefOverlayEnabled(enabled: Boolean)
+
+    suspend fun setNightModeEnabled(enabled: Boolean)
 
     suspend fun resetToDefaults()
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/data/repository/maps/theme/ThemeRepositoryImpl.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/data/repository/maps/theme/ThemeRepositoryImpl.kt
@@ -25,6 +25,7 @@ class ThemeRepositoryImpl(
         const val DEFAULT_STYLE_ID = "__DEFAULT__"
         const val GLOBAL_HILL_SHADING_ID = "__GLOBAL_HILL_SHADING__"
         const val GLOBAL_RELIEF_OVERLAY_ID = "__GLOBAL_RELIEF_OVERLAY__"
+        const val GLOBAL_NIGHT_MODE_ID = "__GLOBAL_NIGHT_MODE__"
         private const val WINTER_STYLE_ID = "elv-winter"
         private const val WINTER_WHITE_STYLE_ID = "__WINTER_WHITE__"
         private const val VOLUNTARY_DEFAULT_STYLE_ID = "vol-hiking"
@@ -41,6 +42,7 @@ class ThemeRepositoryImpl(
     private val keySelectedThemeId = "selected_theme_id"
     private val keyHillShadingEnabled = "global_hill_shading_enabled"
     private val keyReliefOverlayEnabled = "global_relief_overlay_enabled"
+    private val keyNightModeEnabled = "global_night_mode_enabled"
     private val keyLegacySlopeOverlayEnabled = "global_slope_overlay_enabled"
 
     private val parsedByTheme: Map<String, ParsedStyleMenu> by lazy {
@@ -385,6 +387,10 @@ class ThemeRepositoryImpl(
             .apply()
     }
 
+    override suspend fun setNightModeEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(keyNightModeEnabled, enabled).apply()
+    }
+
     override suspend fun resetToDefaults() {
         val editor =
             prefs
@@ -393,6 +399,7 @@ class ThemeRepositoryImpl(
                 .remove(KEY_LEGACY_SELECTED_STYLE)
                 .remove(keyHillShadingEnabled)
                 .remove(keyReliefOverlayEnabled)
+                .remove(keyNightModeEnabled)
                 .remove(keyLegacySlopeOverlayEnabled)
         parsedByTheme.forEach { (themeId, parsed) ->
             editor.remove(selectedStyleKeyForTheme(themeId))
@@ -497,6 +504,8 @@ class ThemeRepositoryImpl(
 
     private fun hillShadingEnabledOrDefault(): Boolean = prefs.getBoolean(keyHillShadingEnabled, false)
 
+    private fun nightModeEnabledOrDefault(): Boolean = prefs.getBoolean(keyNightModeEnabled, false)
+
     private fun reliefOverlayEnabledOrDefault(): Boolean =
         when {
             prefs.contains(keyReliefOverlayEnabled) -> prefs.getBoolean(keyReliefOverlayEnabled, false)
@@ -539,11 +548,27 @@ class ThemeRepositoryImpl(
 
     private fun getCurrentSelection(): ThemeSelection {
         val selectedThemeId = selectedThemeIdOrDefault()
+        val nightModeEnabled = nightModeEnabledOrDefault()
         val hillShadingPreferenceEnabled = hillShadingEnabledOrDefault()
+        val renderingThemeId = if (nightModeEnabled) THEME_ID_MAPSFORGE else selectedThemeId
         val hillShadingEnabled =
             hillShadingPreferenceEnabled &&
-                themeSupportsNativeHillShading(selectedThemeId)
+                themeSupportsNativeHillShading(renderingThemeId)
         val reliefOverlayEnabled = reliefOverlayEnabledOrDefault()
+        if (nightModeEnabled) {
+            val darkOption =
+                MapsforgeThemeCatalog.optionById(MapsforgeThemeCatalog.DARK_MAPSFORGE_STYLE_ID)
+                    ?: MapsforgeThemeCatalog.defaultOption()
+            return ThemeSelection(
+                themeId = THEME_ID_MAPSFORGE,
+                mapsforgeThemeName = darkOption.themeName,
+                styleId = darkOption.id,
+                enabledOverlayLayerIds = emptyList(),
+                hillShadingEnabled = hillShadingEnabled,
+                reliefOverlayEnabled = reliefOverlayEnabled,
+                nightModeEnabled = true,
+            )
+        }
         if (MapsforgeThemeCatalog.isMapsforgeFamilyTheme(selectedThemeId)) {
             val selectedStyleId = mapsforgeStyleIdOrDefault()
             val mapsforgeOption =
@@ -556,6 +581,7 @@ class ThemeRepositoryImpl(
                 enabledOverlayLayerIds = emptyList(),
                 hillShadingEnabled = hillShadingEnabled,
                 reliefOverlayEnabled = reliefOverlayEnabled,
+                nightModeEnabled = nightModeEnabled,
             )
         }
 
@@ -574,6 +600,7 @@ class ThemeRepositoryImpl(
                 enabledOverlayLayerIds = emptyList(),
                 hillShadingEnabled = hillShadingEnabled,
                 reliefOverlayEnabled = reliefOverlayEnabled,
+                nightModeEnabled = nightModeEnabled,
             )
         val selectedStyle =
             parsed.stylesById[effectiveStyleId] ?: return ThemeSelection(
@@ -583,6 +610,7 @@ class ThemeRepositoryImpl(
                 enabledOverlayLayerIds = emptyList(),
                 hillShadingEnabled = hillShadingEnabled,
                 reliefOverlayEnabled = reliefOverlayEnabled,
+                nightModeEnabled = nightModeEnabled,
             )
         val enabledLayerIds =
             if (selectedStyleId == DEFAULT_STYLE_ID) {
@@ -598,6 +626,7 @@ class ThemeRepositoryImpl(
             enabledOverlayLayerIds = enabledLayerIds,
             hillShadingEnabled = hillShadingEnabled,
             reliefOverlayEnabled = reliefOverlayEnabled,
+            nightModeEnabled = nightModeEnabled,
         )
     }
 
@@ -609,9 +638,16 @@ class ThemeRepositoryImpl(
         val hillShadingEnabled = hillShadingEnabledOrDefault()
         val hillShadingSupported = themeSupportsNativeHillShading(selectedThemeId)
         val reliefOverlayEnabled = reliefOverlayEnabledOrDefault()
+        val nightModeEnabled = nightModeEnabledOrDefault()
         val items = mutableListOf<ThemeListItem>()
 
         items += ThemeListItem.Header("Theme")
+        items +=
+            ThemeListItem.GlobalToggle(
+                id = GLOBAL_NIGHT_MODE_ID,
+                name = "Night mode",
+                enabled = nightModeEnabled,
+            )
         items +=
             ThemeListItem.ThemeOption(
                 id = THEME_ID_ELEVATE,

--- a/app/src/main/java/com/glancemap/glancemapwearos/domain/model/maps/theme/mapsforge/MapsforgeThemeCatalog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/domain/model/maps/theme/mapsforge/MapsforgeThemeCatalog.kt
@@ -22,6 +22,7 @@ object MapsforgeThemeCatalog {
     val LEGACY_HILLSHADING_THEME_ID = "$MAPSFORGE_THEME_PREFIX${MapsforgeThemes.HILLSHADING.name}"
     val DEFAULT_MAPSFORGE_STYLE_ID = "$MAPSFORGE_THEME_PREFIX${MapsforgeThemes.DEFAULT.name}"
     val DEFAULT_MAPSFORGE_THEME_ID = DEFAULT_MAPSFORGE_STYLE_ID
+    val DARK_MAPSFORGE_STYLE_ID = "$MAPSFORGE_THEME_PREFIX${MapsforgeThemes.DARK.name}"
 
     val options: List<MapsforgeThemeOption> =
         listOf(
@@ -46,7 +47,7 @@ object MapsforgeThemeCatalog {
                 label = "Biker",
             ),
             MapsforgeThemeOption(
-                id = "$MAPSFORGE_THEME_PREFIX${MapsforgeThemes.DARK.name}",
+                id = DARK_MAPSFORGE_STYLE_ID,
                 themeName = MapsforgeThemes.DARK.name,
                 label = "Dark",
             ),

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.CacheSupport.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.CacheSupport.kt
@@ -90,11 +90,13 @@ internal fun computeMapRendererMapSignature(mapPath: String?): String? {
 
 internal fun resolveMapRendererDesiredCacheId(
     mapSignature: String?,
+    themeSignature: String,
     demSignature: String?,
     hillShadingEnabled: Boolean,
     elevationLabelsMetric: Boolean,
 ): String {
     val mapPart = mapSignature ?: "MAP:NONE"
+    val themePart = themeSignature.ifBlank { "THEME:UNSET" }
     val demPart =
         if (hillShadingEnabled) {
             demSignature ?: "DEM:NONE"
@@ -102,7 +104,7 @@ internal fun resolveMapRendererDesiredCacheId(
             "DEM:OFF"
         }
     val unitPart = if (elevationLabelsMetric) "UNITS:METRIC" else "UNITS:IMPERIAL"
-    val signature = "$mapPart|$demPart|$unitPart"
+    val signature = "$mapPart|$themePart|$demPart|$unitPart"
 
     val digest = MessageDigest.getInstance("SHA-256").digest(signature.toByteArray(Charsets.UTF_8))
     val shortHex =

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.kt
@@ -417,6 +417,7 @@ class MapRenderer(
         val desiredCacheId =
             resolveMapRendererDesiredCacheId(
                 mapSignature = newMapSignature,
+                themeSignature = currentThemeSignature,
                 demSignature = newDemSignature,
                 hillShadingEnabled = currentHillShadingEnabled,
                 elevationLabelsMetric = currentElevationLabelsMetric,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapViewModel.kt
@@ -594,6 +594,7 @@ class MapViewModel(
                         append(" overlays=").append(selection.enabledOverlayLayerIds.size)
                         append(" hill=").append(selection.hillShadingEnabled)
                         append(" relief=").append(selection.reliefOverlayEnabled)
+                        append(" night=").append(selection.nightModeEnabled)
                         append(" visibleWait=").append(themeApplyResult.requiresVisibleTileWait)
                     },
             )

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.kt
@@ -236,6 +236,10 @@ class ThemeViewModel(
                     Log.d("Theme", "setGlobalToggle: reliefOverlay=$enabled")
                     themeRepository.setReliefOverlayEnabled(enabled)
                 }
+                ThemeRepositoryImpl.GLOBAL_NIGHT_MODE_ID -> {
+                    Log.d("Theme", "setGlobalToggle: nightMode=$enabled")
+                    themeRepository.setNightModeEnabled(enabled)
+                }
             }
         }
     }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.Dialogs.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.Dialogs.kt
@@ -4,16 +4,17 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.wear.compose.material3.AlertDialog
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.Icon
@@ -32,8 +33,10 @@ import com.glancemap.glancemapwearos.presentation.ui.RenameValueDialog
 import org.mapsforge.core.model.LatLong
 
 @Composable
+@Suppress("FunctionNaming")
 internal fun NavigateKeepAppOpenDialog(
     visible: Boolean,
+    @Suppress("UNUSED_PARAMETER")
     helpDialogMaxHeight: Dp,
     onContinue: () -> Unit,
     onDismiss: () -> Unit,
@@ -43,43 +46,71 @@ internal fun NavigateKeepAppOpenDialog(
     AlertDialog(
         visible = true,
         onDismissRequest = onDismiss,
-        title = { Text("Stay open") },
+        title = {
+            Text(
+                text = "Stay open",
+                fontSize = 16.sp,
+                lineHeight = 18.sp,
+            )
+        },
         text = {
             Column(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = helpDialogMaxHeight)
-                        .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
-                Row {
-                    Icon(
-                        imageVector = Icons.Filled.Visibility,
-                        contentDescription = null,
-                    )
-                    Text(" keeps GlanceMap active.")
-                }
-                Row {
-                    Icon(
-                        imageVector = Icons.Filled.VisibilityOff,
-                        contentDescription = null,
-                    )
-                    Text(" lets the watch put the app in the background and remove it from Recent apps.")
-                }
+                KeepAppOpenInfoRow(
+                    imageVector = Icons.Filled.Visibility,
+                    text = "keeps GlanceMap active.",
+                )
+                KeepAppOpenInfoRow(
+                    imageVector = Icons.Filled.VisibilityOff,
+                    text = "lets the watch sleep and removes it from Recents.",
+                )
             }
         },
         confirmButton = {
             Button(onClick = onContinue) {
-                Text("Continue")
+                Text(
+                    text = "Continue",
+                    fontSize = 12.sp,
+                    lineHeight = 14.sp,
+                )
             }
         },
         dismissButton = {
             Button(onClick = onDismiss) {
-                Text("Later")
+                Text(
+                    text = "Later",
+                    fontSize = 12.sp,
+                    lineHeight = 14.sp,
+                )
             }
         },
     )
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun KeepAppOpenInfoRow(
+    imageVector: ImageVector,
+    text: String,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = imageVector,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+        )
+        Text(
+            text = text,
+            fontSize = 12.sp,
+            lineHeight = 14.sp,
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/ui/NavigateOverlaysLayer.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/ui/NavigateOverlaysLayer.kt
@@ -254,7 +254,7 @@ internal fun BoxScope.NavigateOverlaysLayer(
                         modifier =
                             Modifier
                                 .size(zoomIconSize)
-                                .rotate(0f),
+                                .rotate(40f),
                     )
                 }
             }
@@ -297,7 +297,7 @@ internal fun BoxScope.NavigateOverlaysLayer(
                         modifier =
                             Modifier
                                 .size(zoomIconSize)
-                                .rotate(45f),
+                                .rotate(112f),
                     )
                 }
             }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/ui/NavigateOverlaysLayer.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/ui/NavigateOverlaysLayer.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
@@ -247,7 +248,14 @@ internal fun BoxScope.NavigateOverlaysLayer(
                             contentColor = Color.White,
                         ),
                 ) {
-                    Icon(Icons.Default.Add, "Zoom In", Modifier.size(zoomIconSize))
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = "Zoom In",
+                        modifier =
+                            Modifier
+                                .size(zoomIconSize)
+                                .rotate(0f),
+                    )
                 }
             }
         }
@@ -283,7 +291,14 @@ internal fun BoxScope.NavigateOverlaysLayer(
                             contentColor = Color.White,
                         ),
                 ) {
-                    Icon(Icons.Default.Remove, "Zoom Out", Modifier.size(zoomIconSize))
+                    Icon(
+                        imageVector = Icons.Default.Remove,
+                        contentDescription = "Zoom Out",
+                        modifier =
+                            Modifier
+                                .size(zoomIconSize)
+                                .rotate(45f),
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/ThemeSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/ThemeSettingsScreen.kt
@@ -232,7 +232,9 @@ fun ThemeSettingsScreen(
             if (nightModeToggle?.enabled == true) {
                 item {
                     Text(
-                        text = "Night mode uses Mapsforge Dark. Your normal theme and overlay choices are saved and return when it is off.",
+                        text =
+                            "Night mode uses Mapsforge Dark. Your normal theme and overlay choices " +
+                                "are saved and return when it is off.",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onBackground,
                         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/ThemeSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/ThemeSettingsScreen.kt
@@ -155,6 +155,10 @@ fun ThemeSettingsScreen(
     val themeOptions = themeItems.filterIsInstance<ThemeListItem.ThemeOption>()
     val styleOptions = themeItems.filterIsInstance<ThemeListItem.Style>()
     val overlayOptions = themeItems.filterIsInstance<ThemeListItem.Overlay>()
+    val nightModeToggle =
+        themeItems
+            .filterIsInstance<ThemeListItem.GlobalToggle>()
+            .firstOrNull { it.id == ThemeRepositoryImpl.GLOBAL_NIGHT_MODE_ID }
     val overlayGroups = remember(overlayOptions) { buildOverlayGroups(overlayOptions) }
     val themePickerOptions =
         remember(themeOptions) {
@@ -214,7 +218,28 @@ fun ThemeSettingsScreen(
                 }
             }
 
-            if (themeOptions.isNotEmpty()) {
+            item {
+                SettingsToggleChip(
+                    checked = nightModeToggle?.enabled == true,
+                    onCheckedChanged = { enabled ->
+                        themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_NIGHT_MODE_ID, enabled)
+                    },
+                    label = "Night mode",
+                    secondaryLabel = if (nightModeToggle?.enabled == true) "On" else "Off",
+                )
+            }
+
+            if (nightModeToggle?.enabled == true) {
+                item {
+                    Text(
+                        text = "Night mode uses Mapsforge Dark. Your normal theme and overlay choices are saved and return when it is off.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onBackground,
+                        modifier = Modifier.fillMaxWidth(),
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            } else if (themeOptions.isNotEmpty()) {
                 item {
                     Text(
                         text = "Theme",
@@ -234,7 +259,7 @@ fun ThemeSettingsScreen(
                 }
             }
 
-            if (styleSelectionAvailable) {
+            if (nightModeToggle?.enabled != true && styleSelectionAvailable) {
                 item {
                     SettingsPickerChip(
                         label = "Style",
@@ -245,7 +270,7 @@ fun ThemeSettingsScreen(
                 }
             }
 
-            if (themeOptions.isNotEmpty()) {
+            if (nightModeToggle?.enabled != true && themeOptions.isNotEmpty()) {
                 item {
                     Text(
                         text = "Themes can misread terrain or paths. Verify with local conditions and other sources.",
@@ -257,7 +282,7 @@ fun ThemeSettingsScreen(
                 }
             }
 
-            if (bundledThemeSelected && overlayOptions.isNotEmpty()) {
+            if (nightModeToggle?.enabled != true && bundledThemeSelected && overlayOptions.isNotEmpty()) {
                 item {
                     Text(
                         text = "Overlays (tap group to open)",

--- a/glancemapcompanionapp/src/main/AndroidManifest.xml
+++ b/glancemapcompanionapp/src/main/AndroidManifest.xml
@@ -26,10 +26,6 @@
         android:usesCleartextTraffic="false">
 
         <meta-data
-            android:name="com.google.android.wearable.beta.app"
-            android:resource="@xml/wearable_app_desc" />
-
-        <meta-data
             android:name="com.google.android.gms.wearable.CHANNEL_BUFFER_SIZE"
             android:value="${channelBufferSize}" />
 

--- a/glancemapcompanionapp/src/main/res/xml/wearable_app_desc.xml
+++ b/glancemapcompanionapp/src/main/res/xml/wearable_app_desc.xml
@@ -1,6 +1,0 @@
-<wearableApp package="com.glancemap.glancemapwearos">
-    <unbundled />
-    <capabilities>
-        <capability name="glancemap_wear_app"/>
-    </capabilities>
-</wearableApp>

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,9 +34,9 @@ android.r8.strictFullModeForKeepRules=false
 # Play versioning.
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
-glanceMapVersionName=1.0.4
-glanceMapWearVersionCode=1011
-glanceMapPhoneVersionCode=2009
+glanceMapVersionName=1.0.5
+glanceMapWearVersionCode=1012
+glanceMapPhoneVersionCode=2010
 
 # Elevate theme build-time sync (download -> generated assets -> packaged in APK)
 elevateThemeVersion=5.6


### PR DESCRIPTION
## Summary
- include the active theme in map tile cache keys so night mode/theme switches do not reuse stale rendered tiles
- compact the stay-open dialog so it fits on the watch screen without scrolling
- bump versionName to 1.0.5, Wear versionCode to 1012, and phone versionCode to 2010

## Tests
- ./gradlew :app:compileDebugKotlin :glancemapcompanionapp:compileDebugKotlin --no-daemon --console=plain