### PR TITLE
Fix watch map zoom and theme reload handling

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/GpxInspectionPopup.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/GpxInspectionPopup.kt
@@ -26,7 +26,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -324,12 +328,24 @@ fun GpxInspectionPopupA(
                 ) {
                     Icon(
                         imageVector = Icons.Filled.AddLocation,
-                        contentDescription = "Select point B",
+                        contentDescription = "Add second point B",
                         modifier = Modifier.size(sizing.actionIconSize),
                     )
                     Spacer(Modifier.width(sizing.actionSpacerWidth))
                     Text(
-                        text = "Select B",
+                        text =
+                            buildAnnotatedString {
+                                append("Add 2")
+                                withStyle(
+                                    SpanStyle(
+                                        baselineShift = BaselineShift.Superscript,
+                                        fontSize = MaterialTheme.typography.labelSmall.fontSize,
+                                    ),
+                                ) {
+                                    append("nd")
+                                }
+                                append(" point (B)")
+                            },
                         style = MaterialTheme.typography.labelMedium,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.kt
@@ -122,6 +122,7 @@ class MapRenderer(
     private var rebuildTileCacheRequested: Boolean = false
     private var currentTileCacheId: String = "$CACHE_ID_PREFIX-bootstrap"
     private var skipNextStartupTilePrewarm: Boolean = false
+    private var cleanLayerSwapRequested: Boolean = false
 
     @Volatile private var cacheCleanupInProgress: Boolean = false
     private val tileCacheUpdateCounter = AtomicLong(0L)
@@ -340,8 +341,8 @@ class MapRenderer(
                 destroyHillsRenderConfig()
             }
 
-            // Clear rendered tiles so new theme applies immediately.
-            tileCache.tryPurge()
+            // Clear rendered tiles so the old theme cannot survive the full theme reload.
+            purgeTileCache(reason = "theme_pre_reload")
 
             val newDemSignature = computeDemSignatureOrNull()
             demChanged = newDemSignature != currentDemSignature
@@ -358,6 +359,7 @@ class MapRenderer(
 
             timingStatus = if (demChanged) "full_reload_dem_changed" else "full_reload_theme_changed"
             skipNextStartupTilePrewarm = true
+            cleanLayerSwapRequested = true
             // Older Mapsforge builds showed incomplete viewport rendering when reusing the same
             // MapDataStore across TileRendererLayer theme swaps, so prefer a clean layer rebuild.
             rebuildTileCacheRequested = false
@@ -412,6 +414,7 @@ class MapRenderer(
         var desiredCacheIdForTiming: String? = null
         var cacheRecreated = false
         var warmStartupCache = false
+        var cleanLayerSwap = false
         val newMapSignature = computeMapRendererMapSignature(mapPath)
         val newDemSignature = computeDemSignatureOrNull()
         val desiredCacheId =
@@ -440,7 +443,21 @@ class MapRenderer(
         }
 
         try {
-            val cleared = clearCurrentLayer()
+            cleanLayerSwap = cleanLayerSwapRequested
+            cleanLayerSwapRequested = false
+            val cleared =
+                clearCurrentLayer(
+                    reason =
+                        if (cleanLayerSwap) {
+                            "clean_theme_reload"
+                        } else {
+                            "map_reload"
+                        },
+                )
+            if (cleanLayerSwap && cleared) {
+                purgeTileCache(reason = "theme_after_layer_clear")
+                forceRedraw()
+            }
             if (rebuildTileCacheRequested || desiredCacheId != currentTileCacheId) {
                 recreateTileCache(newCacheId = desiredCacheId)
                 cacheRecreated = true
@@ -454,7 +471,7 @@ class MapRenderer(
                 currentDemSignature = newDemSignature
                 // Explicitly purge cache so disabling a map never leaves stale tiles visible.
                 updateReliefOverlayLayer()
-                tileCache.tryPurge()
+                purgeTileCache(reason = "map_disabled")
                 forceRedraw()
                 return
             }
@@ -468,7 +485,7 @@ class MapRenderer(
                 rebuildTileCacheRequested = true
                 Log.w(TAG, "updateMapLayer: Map file does not exist: $mapPath")
                 updateReliefOverlayLayer()
-                tileCache.tryPurge()
+                purgeTileCache(reason = "missing_map_file")
                 forceRedraw()
                 return
             }
@@ -532,7 +549,7 @@ class MapRenderer(
             currentDemSignature = newDemSignature
             rebuildTileCacheRequested = true
             updateReliefOverlayLayer()
-            tileCache.tryPurge()
+            purgeTileCache(reason = "map_load_error")
             forceRedraw()
         } finally {
             MapHotPathDiagnostics.end(
@@ -544,13 +561,14 @@ class MapRenderer(
                         append(" cacheId=").append(desiredCacheIdForTiming)
                         append(" cacheRecreated=").append(cacheRecreated)
                         append(" warmStartupCache=").append(warmStartupCache)
+                        append(" cleanLayerSwap=").append(cleanLayerSwap)
                     },
             )
         }
     }
 
     fun invalidateTileCache() {
-        tileCache.tryPurge()
+        purgeTileCache(reason = "invalidate")
         forceRedraw()
     }
 
@@ -609,11 +627,12 @@ class MapRenderer(
         lastPublishedReliefOverlayState = null
     }
 
-    private fun clearCurrentLayer(): Boolean {
+    private fun clearCurrentLayer(reason: String = "unspecified"): Boolean {
         var removed = false
         val storeOwnedByCurrentLayer = currentLayer?.mapDataStore === currentStore
 
         currentLayer?.let { layer ->
+            disableLayerTileExpansion(layer, reason)
             removed = mapView.layerManager.layers.remove(layer)
             runCatching { layer.onDestroy() }
                 .onFailure { Log.w(TAG, "clearCurrentLayer: Failed to destroy TileRendererLayer", it) }
@@ -641,6 +660,19 @@ class MapRenderer(
         publishReliefOverlayState(force = true)
 
         return removed
+    }
+
+    private fun disableLayerTileExpansion(
+        layer: TileRendererLayer,
+        reason: String,
+    ) {
+        runCatching {
+            layer.setCacheZoomPlus(0)
+            layer.setCacheZoomMinus(0)
+            layer.setCacheTileMargin(0)
+        }.onFailure { error ->
+            Log.w(TAG, "disableLayerTileExpansion: failed reason=$reason", error)
+        }
     }
 
     private fun forceRedraw() {
@@ -710,6 +742,7 @@ class MapRenderer(
 
     private fun releaseTileRendererLayerForStoreReuse(layer: TileRendererLayer) {
         runCatching {
+            disableLayerTileExpansion(layer, reason = "store_reuse")
             layer.renderThemeFuture?.decrementRefCount()
         }.onFailure { error ->
             Log.w(TAG, "releaseTileRendererLayerForStoreReuse: Failed to release render theme", error)
@@ -838,6 +871,7 @@ class MapRenderer(
         val timingMarker = MapHotPathDiagnostics.begin("mapRenderer.recreateTileCache")
         try {
             runCatching { tileCache.removeObserver(tileCacheObserver) }
+            purgeTileCache(reason = "recreate_before_destroy")
             runCatching { tileCache.destroy() }
                 .onFailure { Log.w(TAG, "recreateTileCache: failed to destroy previous cache", it) }
             currentTileCacheId = newCacheId
@@ -848,6 +882,15 @@ class MapRenderer(
                 marker = timingMarker,
                 detail = "cacheId=$newCacheId",
             )
+        }
+    }
+
+    private fun purgeTileCache(reason: String) {
+        MapHotPathDiagnostics.measure(
+            stage = "mapRenderer.purgeTileCache",
+            detail = "reason=$reason cacheId=$currentTileCacheId",
+        ) {
+            tileCache.tryPurge()
         }
     }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapViewModel.kt
@@ -118,8 +118,8 @@ class MapViewModel(
     private var lastPrewarmedBundledThemeId: String? = null
 
     private var mapHolder: MapHolder? = null
-    private var lastZoomMin: Int? = null
-    private var lastZoomMax: Int? = null
+    private var latestZoomMin: Int? = null
+    private var latestZoomMax: Int? = null
     private var initialMapLoadIndicatorPending: Boolean = true
     private var offlineStartCenterContextKey: String? = null
     private var offlineStartCenterApplied: Boolean = false
@@ -178,15 +178,16 @@ class MapViewModel(
         zoomMin: Int,
         zoomMax: Int,
     ): MapHolder {
+        latestZoomMin = zoomMin
+        latestZoomMax = zoomMax
+
         mapHolder?.let { existing ->
-            if (lastZoomMin != zoomMin) {
-                existing.mapView.setZoomLevelMin(zoomMin.toByte())
-                lastZoomMin = zoomMin
-            }
-            if (lastZoomMax != zoomMax) {
-                existing.mapView.setZoomLevelMax(zoomMax.toByte())
-                lastZoomMax = zoomMax
-            }
+            applyZoomBounds(
+                mapView = existing.mapView,
+                zoomMin = zoomMin,
+                zoomMax = zoomMax,
+                reason = "reuse_holder",
+            )
 
             setMapRenderer(existing.renderer)
             return existing
@@ -201,9 +202,18 @@ class MapViewModel(
                 isFocusable = true
                 isFocusableInTouchMode = true
 
-                setZoomLevelMin(zoomMin.toByte())
-                setZoomLevelMax(zoomMax.toByte())
-                model.mapViewPosition.setZoomLevel(zoomDefault.toByte(), false)
+                applyZoomBounds(
+                    mapView = this,
+                    zoomMin = zoomMin,
+                    zoomMax = zoomMax,
+                    reason = "create_holder",
+                )
+                val normalizedDefault =
+                    zoomDefault.coerceIn(
+                        minOf(zoomMin, zoomMax),
+                        maxOf(zoomMin, zoomMax),
+                    )
+                model.mapViewPosition.setZoomLevel(normalizedDefault.toByte(), false)
 
                 setBuiltInZoomControls(false)
                 mapScaleBar.isVisible = false
@@ -213,8 +223,6 @@ class MapViewModel(
         val holder = MapHolder(mv, renderer)
 
         mapHolder = holder
-        lastZoomMin = zoomMin
-        lastZoomMax = zoomMax
         initialMapLoadIndicatorPending = true
 
         setMapRenderer(renderer)
@@ -230,8 +238,8 @@ class MapViewModel(
         runCatching { mapHolder?.mapView?.destroyAll() }
         mapHolder = null
         mapRenderer = null
-        lastZoomMin = null
-        lastZoomMax = null
+        latestZoomMin = null
+        latestZoomMax = null
         initialMapLoadIndicatorPending = true
         resetOfflineStartCenterTracking()
     }
@@ -325,6 +333,65 @@ class MapViewModel(
             ?.mapViewPosition
             ?.center
             ?: offlineViewportSnapshot?.center
+
+    private fun applyLatestZoomBounds(reason: String) {
+        val zoomMin = latestZoomMin ?: return
+        val zoomMax = latestZoomMax ?: return
+        val mapView = mapHolder?.mapView ?: return
+        applyZoomBounds(
+            mapView = mapView,
+            zoomMin = zoomMin,
+            zoomMax = zoomMax,
+            reason = reason,
+        )
+    }
+
+    private fun applyZoomBounds(
+        mapView: MapView,
+        zoomMin: Int,
+        zoomMax: Int,
+        reason: String,
+    ) {
+        val boundedMin = zoomMin.coerceIn(0, Byte.MAX_VALUE.toInt())
+        val boundedMax = zoomMax.coerceIn(0, Byte.MAX_VALUE.toInt())
+        val effectiveMin = minOf(boundedMin, boundedMax)
+        val effectiveMax = maxOf(boundedMin, boundedMax)
+        val position = mapView.model.mapViewPosition
+        val beforeMin = position.zoomLevelMin.toInt()
+        val beforeMax = position.zoomLevelMax.toInt()
+        val beforeZoom = position.zoomLevel.toInt()
+
+        if (effectiveMin > beforeMax) {
+            if (beforeMax != effectiveMax) {
+                mapView.setZoomLevelMax(effectiveMax.toByte())
+            }
+            if (beforeMin != effectiveMin) {
+                mapView.setZoomLevelMin(effectiveMin.toByte())
+            }
+        } else {
+            if (beforeMin != effectiveMin) {
+                mapView.setZoomLevelMin(effectiveMin.toByte())
+            }
+            if (position.zoomLevelMax.toInt() != effectiveMax) {
+                mapView.setZoomLevelMax(effectiveMax.toByte())
+            }
+        }
+
+        val clampedZoom = beforeZoom.coerceIn(effectiveMin, effectiveMax)
+        if (clampedZoom != beforeZoom) {
+            position.setZoomLevel(clampedZoom.toByte(), false)
+        }
+
+        val afterMin = position.zoomLevelMin.toInt()
+        val afterMax = position.zoomLevelMax.toInt()
+        if (beforeMin != afterMin || beforeMax != afterMax || beforeZoom != clampedZoom) {
+            Log.d(
+                "MapZoom",
+                "applyBounds reason=$reason requested=$zoomMin..$zoomMax effective=$effectiveMin..$effectiveMax " +
+                    "mapViewBefore=$beforeMin..$beforeMax zoom=$beforeZoom mapViewAfter=$afterMin..$afterMax zoom=$clampedZoom",
+            )
+        }
+    }
 
     fun setMapRenderer(renderer: MapRenderer?) {
         mapRenderer = renderer
@@ -573,6 +640,7 @@ class MapViewModel(
 
             val renderer = mapRenderer
             themeApplyResult = applyRendererConfigIfReady()
+            applyLatestZoomBounds(reason = "theme_selection")
             if (awaitVisibleContent &&
                 themeApplyResult.requiresVisibleTileWait &&
                 renderer != null
@@ -726,6 +794,7 @@ class MapViewModel(
                         pendingExternalCacheClear = false
                         renderer.onExternalCachesCleared()
                         renderer.updateMapLayer(selectedMapPath.value)
+                        applyLatestZoomBounds(reason = "external_cache_clear")
                     } else {
                         val tileBaselineVersion =
                             if (showInitialMapLoadIndicator) {
@@ -734,6 +803,7 @@ class MapViewModel(
                                 0L
                             }
                         renderer.updateMapLayer(pendingMapLayerPath)
+                        applyLatestZoomBounds(reason = "map_layer_update")
                         if (showInitialMapLoadIndicator) {
                             renderer.awaitTileCacheUpdateAfter(
                                 baselineVersion = tileBaselineVersion,


### PR DESCRIPTION
## Summary
- Reapply Mapsforge zoom bounds after map layer and theme reloads so big map uploads keep the configured zoom range
- Keep theme changes on the full reload path but add extra cache/layer cleanup to avoid old themed tiles bleeding through
- Rename the GPX inspection action to Add 2nd point (B), with superscript styling

## Verification
- ./gradlew :app:compileDebugKotlin --no-daemon --console=plain