### PR TITLE
Fix watch map CI detekt issues

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.kt
@@ -443,21 +443,7 @@ class MapRenderer(
         }
 
         try {
-            cleanLayerSwap = cleanLayerSwapRequested
-            cleanLayerSwapRequested = false
-            val cleared =
-                clearCurrentLayer(
-                    reason =
-                        if (cleanLayerSwap) {
-                            "clean_theme_reload"
-                        } else {
-                            "map_reload"
-                        },
-                )
-            if (cleanLayerSwap && cleared) {
-                purgeTileCache(reason = "theme_after_layer_clear")
-                forceRedraw()
-            }
+            cleanLayerSwap = consumeCleanLayerSwap()
             if (rebuildTileCacheRequested || desiredCacheId != currentTileCacheId) {
                 recreateTileCache(newCacheId = desiredCacheId)
                 cacheRecreated = true
@@ -510,7 +496,7 @@ class MapRenderer(
                 rebuildTileCacheRequested = true
                 Log.w(TAG, "updateMapLayer: theme is null, cannot render map.")
                 updateReliefOverlayLayer()
-                if (cleared) forceRedraw()
+                forceRedraw()
                 return
             }
 
@@ -565,6 +551,25 @@ class MapRenderer(
                     },
             )
         }
+    }
+
+    private fun consumeCleanLayerSwap(): Boolean {
+        val cleanLayerSwap = cleanLayerSwapRequested
+        cleanLayerSwapRequested = false
+        val cleared =
+            clearCurrentLayer(
+                reason =
+                    if (cleanLayerSwap) {
+                        "clean_theme_reload"
+                    } else {
+                        "map_reload"
+                    },
+            )
+        if (cleanLayerSwap && cleared) {
+            purgeTileCache(reason = "theme_after_layer_clear")
+            forceRedraw()
+        }
+        return cleanLayerSwap
     }
 
     fun invalidateTileCache() {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapViewModel.kt
@@ -335,15 +335,17 @@ class MapViewModel(
             ?: offlineViewportSnapshot?.center
 
     private fun applyLatestZoomBounds(reason: String) {
-        val zoomMin = latestZoomMin ?: return
-        val zoomMax = latestZoomMax ?: return
-        val mapView = mapHolder?.mapView ?: return
-        applyZoomBounds(
-            mapView = mapView,
-            zoomMin = zoomMin,
-            zoomMax = zoomMax,
-            reason = reason,
-        )
+        val zoomMin = latestZoomMin
+        val zoomMax = latestZoomMax
+        val mapView = mapHolder?.mapView
+        if (zoomMin != null && zoomMax != null && mapView != null) {
+            applyZoomBounds(
+                mapView = mapView,
+                zoomMin = zoomMin,
+                zoomMax = zoomMax,
+                reason = reason,
+            )
+        }
     }
 
     private fun applyZoomBounds(
@@ -385,10 +387,12 @@ class MapViewModel(
         val afterMin = position.zoomLevelMin.toInt()
         val afterMax = position.zoomLevelMax.toInt()
         if (beforeMin != afterMin || beforeMax != afterMax || beforeZoom != clampedZoom) {
+            val beforeRange = "$beforeMin..$beforeMax"
+            val afterRange = "$afterMin..$afterMax"
             Log.d(
                 "MapZoom",
                 "applyBounds reason=$reason requested=$zoomMin..$zoomMax effective=$effectiveMin..$effectiveMax " +
-                    "mapViewBefore=$beforeMin..$beforeMax zoom=$beforeZoom mapViewAfter=$afterMin..$afterMax zoom=$clampedZoom",
+                    "mapViewBefore=$beforeRange zoom=$beforeZoom mapViewAfter=$afterRange zoom=$clampedZoom",
             )
         }
     }


### PR DESCRIPTION
## Summary
- Extract clean theme layer-swap cleanup from MapRenderer.updateMapLayer to reduce detekt complexity
- Rewrite zoom-bound reapplication helper to avoid excessive return count
- Split the MapZoom diagnostic log details to satisfy line-length checks

## Verification
- ./gradlew detekt --no-daemon --console=plain
- ./gradlew ktlintCheck detekt :app:compileDebugKotlin :glancemapcompanionapp:compileDebugKotlin :app:testDebugUnitTest :glancemapcompanionapp:testDebugUnitTest :app:lintDebug :glancemapcompanionapp:lintDebug --no-daemon --console=plain