### PR TITLE
Fix companion transfer and POI pickers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,5 +67,6 @@ When structure or behavior changes:
 1. Update relevant file-level comments (if needed).
 2. Update architecture docs in `docs/architecture/`.
 3. Update root `README.md` if setup or module responsibilities changed.
+4. If adding or upgrading third-party dependencies, update `licenses/THIRD_PARTY_NOTICES.md` and `licenses/RUNTIME_DEPENDENCIES_RESOLVED.txt`.
 
 Before making the repository public, follow `docs/PUBLIC_REPO_CHECKLIST.md`.

--- a/app/src/main/java/com/glancemap/glancemapwearos/core/service/transfer/contract/TransferConstants.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/core/service/transfer/contract/TransferConstants.kt
@@ -8,6 +8,8 @@ internal object TransferConstants {
     const val PATH_PREPARE_CHANNEL = TransferDataLayerContract.PATH_PREPARE_CHANNEL
     const val PATH_PING = TransferDataLayerContract.PATH_PING
     const val PATH_PING_RESULT = TransferDataLayerContract.PATH_PING_RESULT
+    const val PATH_CHECK_WIFI_STATUS = TransferDataLayerContract.PATH_CHECK_WIFI_STATUS
+    const val PATH_CHECK_WIFI_STATUS_RESULT = TransferDataLayerContract.PATH_CHECK_WIFI_STATUS_RESULT
     const val PATH_DIAGNOSTICS_EMAIL_REQUEST = TransferDataLayerContract.PATH_DIAGNOSTICS_EMAIL_REQUEST
 
     const val PATH_CHECK_EXISTS = TransferDataLayerContract.PATH_CHECK_EXISTS

--- a/app/src/main/java/com/glancemap/glancemapwearos/core/service/transfer/datalayer/DataLayerMessageRequestHandler.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/core/service/transfer/datalayer/DataLayerMessageRequestHandler.kt
@@ -1,5 +1,7 @@
 package com.glancemap.glancemapwearos.core.service.transfer.datalayer
 
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.net.Uri
 import android.util.Log
 import com.glancemap.glancemapwearos.core.service.DataLayerListenerService
@@ -65,6 +67,11 @@ internal class DataLayerMessageRequestHandler(
 
             TransferConstants.PATH_PING -> {
                 handlePingRequest(messageEvent)
+                return
+            }
+
+            TransferConstants.PATH_CHECK_WIFI_STATUS -> {
+                handleWifiStatusRequest(messageEvent)
                 return
             }
 
@@ -240,6 +247,78 @@ internal class DataLayerMessageRequestHandler(
                 Log.d(TAG, "Ping reply send failed: ${it.message}")
                 TransferDiagnostics.warn("MsgReq", "Ping reply send failed id=$requestId")
             }
+        }
+    }
+
+    private fun handleWifiStatusRequest(messageEvent: MessageEvent) {
+        val sourceNodeId = messageEvent.sourceNodeId
+        val payload = runCatching { JSONObject(String(messageEvent.data, Charsets.UTF_8)) }.getOrNull()
+        if (payload == null) {
+            Log.w(TAG, "Invalid JSON Wi-Fi status request")
+            TransferDiagnostics.warn("MsgReq", "Invalid Wi-Fi status request JSON from node=$sourceNodeId")
+            return
+        }
+
+        val requestId = payload.optString("id", "")
+        if (requestId.isBlank()) {
+            Log.w(TAG, "Missing request id in Wi-Fi status request: $payload")
+            TransferDiagnostics.warn("MsgReq", "Missing Wi-Fi status request id from node=$sourceNodeId")
+            return
+        }
+
+        val (wifiAvailable, reason) = readWifiAvailability()
+        TransferDiagnostics.log(
+            "MsgReq",
+            "Wi-Fi status request id=$requestId wifiAvailable=$wifiAvailable reason=$reason",
+        )
+
+        appScope.launch(Dispatchers.IO) {
+            val reply =
+                JSONObject()
+                    .put("id", requestId)
+                    .put("wifiAvailable", wifiAvailable)
+                    .put("reason", reason)
+
+            runCatching {
+                sendMessage(
+                    sourceNodeId,
+                    TransferConstants.PATH_CHECK_WIFI_STATUS_RESULT,
+                    reply.toString().toByteArray(Charsets.UTF_8),
+                )
+                TransferDiagnostics.log("MsgReq", "Wi-Fi status reply id=$requestId to node=$sourceNodeId")
+            }.onFailure {
+                Log.d(TAG, "Wi-Fi status reply send failed: ${it.message}")
+                TransferDiagnostics.warn("MsgReq", "Wi-Fi status reply send failed id=$requestId")
+            }
+        }
+    }
+
+    private fun readWifiAvailability(): Pair<Boolean, String> {
+        val connectivityManager =
+            service.getSystemService(ConnectivityManager::class.java)
+                ?: return false to "connectivity_manager_missing"
+        val active = connectivityManager.activeNetwork
+        val activeCaps = active?.let { connectivityManager.getNetworkCapabilities(it) }
+        if (activeCaps?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true) {
+            return true to "active_wifi"
+        }
+
+        @Suppress("DEPRECATION")
+        val availableWifi =
+            connectivityManager.allNetworks.any { network ->
+                connectivityManager
+                    .getNetworkCapabilities(network)
+                    ?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+            }
+        return if (availableWifi) {
+            true to "available_wifi"
+        } else {
+            false to
+                if (active == null) {
+                    "no_active_network"
+                } else {
+                    "no_wifi_network"
+                }
         }
     }
 

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -74,10 +74,10 @@ Data may leave your device in the following situations:
 
 ### 1. User-requested downloads from third-party data providers
 
-When you request online POI, routing, elevation, or similar data, the app sends
-the information needed to fulfill that request to the selected provider, such
-as a user-selected geographic area (bounding box), requested tile names, or
-requested files.
+When you request online POI, routing, elevation, map-picker previews, or similar
+data, the app sends the information needed to fulfill that request to the
+selected provider, such as a user-selected geographic area (bounding box),
+requested routing tile names, map display tile coordinates, or requested files.
 
 As with normal internet requests, those providers may also receive standard
 request metadata such as your IP address, request time, and user-agent or
@@ -87,6 +87,7 @@ Providers used by the current app configuration include:
 
 - `refuges.info`
 - `overpass-api.de`
+- `tile.openstreetmap.org`
 - `brouter.de`
 - `download.mapsforge.org`
 

--- a/glancemapcompanionapp/build.gradle.kts
+++ b/glancemapcompanionapp/build.gradle.kts
@@ -161,6 +161,7 @@ dependencies {
     implementation(libs.androidx.documentfile)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.play.services.wearable)
+    implementation(libs.play.services.location)
     implementation(libs.kotlinx.coroutines.play.services)
     implementation(libs.androidx.lifecycle.service)
 
@@ -175,6 +176,10 @@ dependencies {
 
     // Gson for JSON serialization
     implementation(libs.gson)
+
+    // Native map picker
+    implementation(libs.maplibre.android)
+    implementation(libs.okhttp)
 
     // Permissions (Critical for requesting POST_NOTIFICATIONS for the Service)
     implementation(libs.accompanist.permissions)

--- a/glancemapcompanionapp/src/main/AndroidManifest.xml
+++ b/glancemapcompanionapp/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:allowBackup="false"

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/BboxMapPickerDialog.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/BboxMapPickerDialog.kt
@@ -1,0 +1,381 @@
+@file:Suppress("FunctionNaming", "TooManyFunctions")
+
+package com.glancemap.glancemapcompanionapp
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+
+private const val DEFAULT_PICKER_BBOX = "6.00,45.30,6.90,45.90"
+private const val OSM_PICKER_WARNING_AREA_DEGREES = 4.0
+private const val OSM_PICKER_WARNING_LON_SPAN_DEGREES = 2.5
+private const val OSM_PICKER_WARNING_LAT_SPAN_DEGREES = 2.0
+private const val OSM_PICKER_MAX_AREA_DEGREES = 12.0
+private const val OSM_PICKER_MAX_LON_SPAN_DEGREES = 5.0
+private const val OSM_PICKER_MAX_LAT_SPAN_DEGREES = 4.0
+private const val REFUGES_PICKER_MAX_AREA_DEGREES = 120.0
+private const val REFUGES_PICKER_MAX_LON_SPAN_DEGREES = 20.0
+private const val REFUGES_PICKER_MAX_LAT_SPAN_DEGREES = 12.0
+
+@Composable
+internal fun BboxMapPickerDialog(
+    initialBbox: String,
+    selectedSource: PoiImportSource,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    val initialPickerBbox =
+        remember(initialBbox, selectedSource) {
+            resolveInitialPickerBbox(initialBbox, selectedSource)
+        }
+    val hasUsableInitialBbox =
+        remember(initialBbox, selectedSource) {
+            hasUsableInitialPickerBbox(initialBbox, selectedSource)
+        }
+    var centerOnLocation by remember(initialBbox) { mutableStateOf(!hasUsableInitialBbox) }
+    val locationAllowed = rememberMapPickerLocationAllowed(centerOnLocation)
+    val useLocationDefault = centerOnLocation && locationAllowed
+    var selectedBbox by remember(initialPickerBbox) { mutableStateOf(initialPickerBbox) }
+    var mapReady by remember { mutableStateOf(false) }
+    val sizeStatus = describeBboxSize(selectedBbox, selectedSource)
+
+    LaunchedEffect(initialPickerBbox, useLocationDefault) {
+        mapReady = false
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties =
+            DialogProperties(
+                usePlatformDefaultWidth = false,
+                decorFitsSystemWindows = true,
+            ),
+    ) {
+        BboxMapPickerSurface(
+            initialBbox = initialPickerBbox,
+            useLocationDefault = useLocationDefault,
+            state =
+                BboxMapPickerState(
+                    selectedBbox = selectedBbox,
+                    centerOnLocation = centerOnLocation,
+                    mapReady = mapReady,
+                    sizeStatus = sizeStatus,
+                ),
+            actions =
+                BboxMapPickerActions(
+                    onDismiss = onDismiss,
+                    onConfirm = onConfirm,
+                    onReady = { mapReady = true },
+                    onCenterOnLocationChanged = { checked -> centerOnLocation = checked },
+                    onBboxChanged = { bbox -> selectedBbox = bbox },
+                ),
+        )
+    }
+}
+
+private data class BboxMapPickerState(
+    val selectedBbox: String,
+    val centerOnLocation: Boolean,
+    val mapReady: Boolean,
+    val sizeStatus: BboxSizeStatus,
+)
+
+private data class BboxMapPickerActions(
+    val onDismiss: () -> Unit,
+    val onConfirm: (String) -> Unit,
+    val onReady: () -> Unit,
+    val onCenterOnLocationChanged: (Boolean) -> Unit,
+    val onBboxChanged: (String) -> Unit,
+)
+
+private data class BboxMapPickerMapState(
+    val fineControlEnabled: Boolean,
+    val mapReady: Boolean,
+)
+
+@Composable
+private fun BboxMapPickerSurface(
+    initialBbox: String,
+    useLocationDefault: Boolean,
+    state: BboxMapPickerState,
+    actions: BboxMapPickerActions,
+) {
+    var fineControlEnabled by remember { mutableStateOf(false) }
+
+    Surface(
+        shape = MaterialTheme.shapes.large,
+        tonalElevation = 6.dp,
+        modifier =
+            Modifier
+                .fillMaxWidth(0.96f)
+                .fillMaxHeight(0.90f)
+                .heightIn(max = 720.dp),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+        ) {
+            BboxMapPickerHeader()
+            Spacer(modifier = Modifier.height(4.dp))
+            BboxMapPickerControls(
+                centerOnLocation = state.centerOnLocation,
+                fineControlEnabled = fineControlEnabled,
+                onCenterOnLocationChanged = actions.onCenterOnLocationChanged,
+                onFineControlChanged = { checked -> fineControlEnabled = checked },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            MapPickerHelpText(
+                text = "Pan the map, tap to recenter, long-press the center icon to move the area, then resize it.",
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            BboxMapPickerMap(
+                initialBbox = initialBbox,
+                useLocationDefault = useLocationDefault,
+                mapState =
+                    BboxMapPickerMapState(
+                        fineControlEnabled = fineControlEnabled,
+                        mapReady = state.mapReady,
+                    ),
+                actions = actions,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(modifier = Modifier.height(10.dp))
+            BboxMapPickerFooter(
+                selectedBbox = state.selectedBbox,
+                sizeStatus = state.sizeStatus,
+                onDismiss = actions.onDismiss,
+                onConfirm = actions.onConfirm,
+            )
+        }
+    }
+}
+
+@Composable
+private fun BboxMapPickerHeader() {
+    Text(
+        "Pick area",
+        style = MaterialTheme.typography.titleLarge,
+    )
+}
+
+@Composable
+private fun BboxMapPickerMap(
+    initialBbox: String,
+    useLocationDefault: Boolean,
+    mapState: BboxMapPickerMapState,
+    actions: BboxMapPickerActions,
+    modifier: Modifier = Modifier,
+) {
+    val initialBounds = remember(initialBbox) { MapPickerBounds.parseOrNull(initialBbox) ?: defaultPickerBounds() }
+    var pickerView by remember(useLocationDefault, initialBbox) { mutableStateOf<MapLibreBboxPickerView?>(null) }
+
+    Box(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        key(useLocationDefault, initialBbox) {
+            AndroidView(
+                factory = { context ->
+                    MapLibreBboxPickerView(
+                        context = context,
+                        initialBounds = initialBounds,
+                        useLocationDefault = useLocationDefault,
+                        onBoundsChanged = actions.onBboxChanged,
+                        onReady = actions.onReady,
+                    ).also { view -> pickerView = view }
+                },
+                update = { view ->
+                    view.setFineControlEnabled(mapState.fineControlEnabled)
+                },
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+        if (!mapState.mapReady) {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+        if (mapState.mapReady) {
+            MapPickerZoomControls(
+                onZoomIn = { pickerView?.zoomIn() },
+                onZoomOut = { pickerView?.zoomOut() },
+                modifier =
+                    Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(5.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun BboxMapPickerControls(
+    centerOnLocation: Boolean,
+    fineControlEnabled: Boolean,
+    onCenterOnLocationChanged: (Boolean) -> Unit,
+    onFineControlChanged: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        MapPickerControlRow(
+            checked = centerOnLocation,
+            onCheckedChange = onCenterOnLocationChanged,
+            label = "Center on my location",
+            modifier = Modifier.weight(1f),
+        )
+        MapPickerControlRow(
+            checked = fineControlEnabled,
+            onCheckedChange = onFineControlChanged,
+            label = "Fine control",
+        )
+    }
+}
+
+@Composable
+private fun BboxMapPickerFooter(
+    selectedBbox: String,
+    sizeStatus: BboxSizeStatus,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    Text(
+        sizeStatus.label,
+        style = MaterialTheme.typography.bodySmall,
+        color = sizeStatus.color,
+    )
+    Spacer(modifier = Modifier.height(12.dp))
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End,
+    ) {
+        OutlinedButton(onClick = onDismiss) {
+            Text("Cancel")
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Button(
+            onClick = { onConfirm(selectedBbox) },
+            enabled = MapPickerBounds.parseOrNull(selectedBbox) != null && sizeStatus.canConfirm,
+        ) {
+            Text("Use area")
+        }
+    }
+}
+
+private data class BboxSizeStatus(
+    val label: String,
+    val color: Color,
+    val canConfirm: Boolean,
+)
+
+@Composable
+private fun describeBboxSize(
+    bbox: String,
+    selectedSource: PoiImportSource,
+): BboxSizeStatus {
+    val bounds = MapPickerBounds.parseOrNull(bbox)
+    val defaultColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val warningColor = MaterialTheme.colorScheme.tertiary
+    val errorColor = MaterialTheme.colorScheme.error
+    val labelAndColor =
+        when {
+            bounds == null ->
+                Triple("Move or zoom the map to select an area.", defaultColor, false)
+            bounds.isTooLargeForPoiImport(selectedSource) ->
+                Triple("Too large for POI import. Zoom in or pick a smaller area.", errorColor, false)
+            bounds.isLargeForOsm(selectedSource) ->
+                Triple("Large for OSM. It may be slow or fail on dense areas.", warningColor, true)
+            else ->
+                Triple("Area size looks OK. POI count is checked during import.", defaultColor, true)
+        }
+    return BboxSizeStatus(
+        label = labelAndColor.first,
+        color = labelAndColor.second,
+        canConfirm = labelAndColor.third,
+    )
+}
+
+private fun resolveInitialPickerBbox(
+    initialBbox: String,
+    selectedSource: PoiImportSource,
+): String =
+    MapPickerBounds
+        .parseOrNull(initialBbox)
+        ?.takeUnless { it.isTooLargeForPoiImport(selectedSource) }
+        ?.toBboxString()
+        ?: DEFAULT_PICKER_BBOX
+
+private fun hasUsableInitialPickerBbox(
+    initialBbox: String,
+    selectedSource: PoiImportSource,
+): Boolean =
+    MapPickerBounds
+        .parseOrNull(initialBbox)
+        ?.takeUnless { it.isTooLargeForPoiImport(selectedSource) } != null
+
+private fun defaultPickerBounds(): MapPickerBounds =
+    MapPickerBounds.parseOrNull(DEFAULT_PICKER_BBOX) ?: MapPickerBounds.defaultAround(45.6, 6.45)
+
+private fun MapPickerBounds.isTooLargeForPoiImport(selectedSource: PoiImportSource): Boolean =
+    if (selectedSource == PoiImportSource.OSM) {
+        areaDegrees > OSM_PICKER_MAX_AREA_DEGREES ||
+            lonSpan > OSM_PICKER_MAX_LON_SPAN_DEGREES ||
+            latSpan > OSM_PICKER_MAX_LAT_SPAN_DEGREES
+    } else {
+        areaDegrees > REFUGES_PICKER_MAX_AREA_DEGREES ||
+            lonSpan > REFUGES_PICKER_MAX_LON_SPAN_DEGREES ||
+            latSpan > REFUGES_PICKER_MAX_LAT_SPAN_DEGREES
+    }
+
+private fun MapPickerBounds.isLargeForOsm(selectedSource: PoiImportSource): Boolean =
+    selectedSource == PoiImportSource.OSM &&
+        (
+            areaDegrees > OSM_PICKER_WARNING_AREA_DEGREES ||
+                lonSpan > OSM_PICKER_WARNING_LON_SPAN_DEGREES ||
+                latSpan > OSM_PICKER_WARNING_LAT_SPAN_DEGREES
+        )

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/FileTransferViewModel.UriSupport.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/FileTransferViewModel.UriSupport.kt
@@ -131,7 +131,17 @@ internal fun isGeoJsonUri(
     uri: Uri,
 ): Boolean {
     val name = resolveUriDisplayName(context, uri)
-    return name.lowercase().endsWith(".geojson")
+    if (isGeoJsonFileName(name)) return true
+
+    val mimeType = context.contentResolver.getType(uri).orEmpty().lowercase()
+    return mimeType == "application/geo+json" ||
+        mimeType == "application/vnd.geo+json" ||
+        (mimeType == "application/json" && name.lowercase().endsWith(".json"))
+}
+
+internal fun isGeoJsonFileName(fileName: String): Boolean {
+    val lower = fileName.lowercase()
+    return lower.endsWith(".geojson") || lower.endsWith(".geo.json")
 }
 
 internal fun isGpxUri(

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/MapLibrePickerViews.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/MapLibrePickerViews.kt
@@ -1,0 +1,1055 @@
+@file:Suppress("ComplexMethod", "LargeClass", "LongMethod", "MagicNumber", "TooManyFunctions")
+
+package com.glancemap.glancemapcompanionapp
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.PointF
+import android.graphics.RectF
+import android.graphics.Typeface
+import android.location.Location
+import android.view.HapticFeedbackConstants
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewConfiguration
+import android.widget.FrameLayout
+import androidx.core.content.ContextCompat
+import com.google.android.gms.location.LocationServices
+import okhttp3.OkHttpClient
+import org.maplibre.android.MapLibre
+import org.maplibre.android.camera.CameraUpdateFactory
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.geometry.LatLngBounds
+import org.maplibre.android.maps.MapLibreMapOptions
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.maps.Style
+import org.maplibre.android.module.http.HttpRequestUtil
+import java.util.Locale
+import kotlin.math.abs
+import kotlin.math.floor
+import kotlin.math.hypot
+import kotlin.math.max
+import kotlin.math.min
+
+private const val MAP_LATITUDE_LIMIT = 85.0
+private const val MIN_PICKER_SPAN = 0.02
+private const val MAP_PICKER_MIN_ZOOM = 2.0
+private const val MAP_PICKER_MAX_ZOOM = 18.0
+private const val MAP_PICKER_ZOOM_STEP = 1.0
+private const val ROUTING_TILE_DEGREES = 5
+private const val ROUTING_TILE_EPSILON = 1e-9
+private val MAP_PICKER_FALLBACK_COLOR = 0xffeef1f5.toInt()
+private const val OSM_RASTER_STYLE_JSON = """
+{
+  "version": 8,
+  "sources": {
+    "osm": {
+      "type": "raster",
+      "tiles": ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
+      "tileSize": 256,
+      "minzoom": 0,
+      "maxzoom": 19,
+      "attribution": "(C) OpenStreetMap contributors"
+    }
+  },
+  "layers": [
+    {
+      "id": "fallback-background",
+      "type": "background",
+      "paint": {
+        "background-color": "#eef1f5"
+      }
+    },
+    {
+      "id": "osm",
+      "type": "raster",
+      "source": "osm"
+    }
+  ]
+}
+"""
+
+internal data class MapPickerBounds(
+    val west: Double,
+    val south: Double,
+    val east: Double,
+    val north: Double,
+) {
+    val lonSpan: Double = abs(east - west)
+    val latSpan: Double = abs(north - south)
+    val areaDegrees: Double = lonSpan * latSpan
+
+    fun toBboxString(): String =
+        listOf(west, south, east, north)
+            .joinToString(",") { coordinate ->
+                String
+                    .format(Locale.US, "%.5f", coordinate)
+                    .trimEnd('0')
+                    .trimEnd('.')
+            }
+
+    fun center(): LatLng = LatLng((south + north) / 2.0, (west + east) / 2.0)
+
+    fun movedTo(
+        latitude: Double,
+        longitude: Double,
+    ): MapPickerBounds =
+        safe(
+            west = longitude - lonSpan / 2.0,
+            south = latitude - latSpan / 2.0,
+            east = longitude + lonSpan / 2.0,
+            north = latitude + latSpan / 2.0,
+        )
+
+    fun toMapLibreBounds(): LatLngBounds {
+        val renderSouth = south.coerceIn(-MAP_LATITUDE_LIMIT, MAP_LATITUDE_LIMIT)
+        val renderNorth = north.coerceIn(-MAP_LATITUDE_LIMIT, MAP_LATITUDE_LIMIT)
+        return LatLngBounds
+            .Builder()
+            .include(LatLng(renderSouth, west))
+            .include(LatLng(renderNorth, east))
+            .build()
+    }
+
+    companion object {
+        fun parseOrNull(input: String): MapPickerBounds? {
+            val values =
+                input
+                    .split(',')
+                    .map { it.trim().toDoubleOrNull() }
+            val bounds =
+                if (values.size == 4 && values.none { it == null }) {
+                    MapPickerBounds(
+                        west = values[0] ?: 0.0,
+                        south = values[1] ?: 0.0,
+                        east = values[2] ?: 0.0,
+                        north = values[3] ?: 0.0,
+                    )
+                } else {
+                    null
+                }
+
+            return bounds?.takeIf { candidate ->
+                val longitudeValid = candidate.west in -180.0..180.0 && candidate.east in -180.0..180.0
+                val latitudeValid = candidate.south in -90.0..90.0 && candidate.north in -90.0..90.0
+                val ordered = candidate.west < candidate.east && candidate.south < candidate.north
+                longitudeValid && latitudeValid && ordered
+            }
+        }
+
+        fun safe(
+            west: Double,
+            south: Double,
+            east: Double,
+            north: Double,
+            minSpan: Double = MIN_PICKER_SPAN,
+        ): MapPickerBounds {
+            var safeWest = west.coerceIn(-180.0, 180.0)
+            var safeEast = east.coerceIn(-180.0, 180.0)
+            var safeSouth = south.coerceIn(-MAP_LATITUDE_LIMIT, MAP_LATITUDE_LIMIT)
+            var safeNorth = north.coerceIn(-MAP_LATITUDE_LIMIT, MAP_LATITUDE_LIMIT)
+            if (safeWest > safeEast) {
+                val oldWest = safeWest
+                safeWest = safeEast
+                safeEast = oldWest
+            }
+            if (safeSouth > safeNorth) {
+                val oldSouth = safeSouth
+                safeSouth = safeNorth
+                safeNorth = oldSouth
+            }
+            if (safeEast - safeWest < minSpan) {
+                val center = (safeWest + safeEast) / 2.0
+                safeWest = (center - minSpan / 2.0).coerceIn(-180.0, 180.0 - minSpan)
+                safeEast = safeWest + minSpan
+            }
+            if (safeNorth - safeSouth < minSpan) {
+                val center = (safeSouth + safeNorth) / 2.0
+                safeSouth = (center - minSpan / 2.0).coerceIn(-MAP_LATITUDE_LIMIT, MAP_LATITUDE_LIMIT - minSpan)
+                safeNorth = safeSouth + minSpan
+            }
+            return MapPickerBounds(safeWest, safeSouth, safeEast, safeNorth)
+        }
+
+        fun defaultAround(
+            latitude: Double,
+            longitude: Double,
+        ): MapPickerBounds =
+            safe(
+                west = longitude - 0.35,
+                south = latitude - 0.25,
+                east = longitude + 0.35,
+                north = latitude + 0.25,
+            )
+    }
+}
+
+internal class MapLibreBboxPickerView(
+    context: Context,
+    initialBounds: MapPickerBounds,
+    private val useLocationDefault: Boolean,
+    private val onBoundsChanged: (String) -> Unit,
+    onReady: () -> Unit,
+) : BaseMapLibrePickerView(context, onReady) {
+    private var selectedBounds = initialBounds
+    private val overlay =
+        BboxSelectionOverlay(
+            context = context,
+            boundsProvider = { selectedBounds },
+            mapProvider = { map },
+            onBoundsChanged = { bounds ->
+                setSelectedBounds(bounds)
+            },
+        )
+
+    init {
+        addView(
+            overlay,
+            LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT),
+        )
+    }
+
+    fun setFineControlEnabled(enabled: Boolean) {
+        overlay.fineControlEnabled = enabled
+        overlay.invalidate()
+    }
+
+    override fun onStyleReady(map: MapLibreMap) {
+        map.addOnMapClickListener(
+            MapLibreMap.OnMapClickListener { point ->
+                setSelectedBounds(selectedBounds.movedTo(point.latitude, point.longitude))
+                true
+            },
+        )
+        setSelectedBounds(selectedBounds)
+        moveCameraToBounds(selectedBounds, paddingDp = 44)
+        if (useLocationDefault) {
+            centerOnLastKnownLocation()
+        }
+    }
+
+    private fun centerOnLastKnownLocation() {
+        requestLastKnownLocation(context) { location ->
+            val bounds = MapPickerBounds.defaultAround(location.latitude, location.longitude)
+            setSelectedBounds(bounds)
+            moveCameraToBounds(bounds, paddingDp = 44)
+        }
+    }
+
+    private fun setSelectedBounds(bounds: MapPickerBounds) {
+        selectedBounds = bounds
+        overlay.invalidate()
+        onBoundsChanged(bounds.toBboxString())
+    }
+}
+
+internal class MapLibreRoutingTilePickerView(
+    context: Context,
+    private val initialBounds: MapPickerBounds,
+    private val useLocationDefault: Boolean,
+    private val onSelectionChanged: (bbox: String, tiles: List<String>) -> Unit,
+    onReady: () -> Unit,
+) : BaseMapLibrePickerView(context, onReady) {
+    private val selectedTiles = linkedSetOf<RoutingTile>()
+    private val overlay =
+        RoutingTileOverlay(
+            context = context,
+            selectedTilesProvider = { selectedTiles.toSet() },
+            mapProvider = { map },
+        )
+
+    init {
+        selectedTiles += routingTilesForBounds(initialBounds)
+        addView(
+            overlay,
+            LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT),
+        )
+    }
+
+    override fun onStyleReady(map: MapLibreMap) {
+        map.addOnMapClickListener(
+            MapLibreMap.OnMapClickListener { point ->
+                toggleTileAt(point)
+                true
+            },
+        )
+        notifySelection()
+        moveCameraToBounds(selectedBounds() ?: initialBounds, paddingDp = 36)
+        if (useLocationDefault) {
+            centerOnLastKnownLocation()
+        }
+    }
+
+    private fun centerOnLastKnownLocation() {
+        requestLastKnownLocation(context) { location ->
+            val tile = RoutingTile.containing(location.latitude, location.longitude)
+            selectedTiles.clear()
+            selectedTiles += tile
+            overlay.invalidate()
+            notifySelection()
+            moveCameraToBounds(tile.bounds, paddingDp = 36)
+        }
+    }
+
+    private fun toggleTileAt(point: LatLng) {
+        val tile = RoutingTile.containing(point.latitude, point.longitude)
+        if (selectedTiles.contains(tile)) {
+            selectedTiles -= tile
+        } else {
+            selectedTiles += tile
+        }
+        overlay.invalidate()
+        notifySelection()
+    }
+
+    private fun selectedBounds(): MapPickerBounds? {
+        if (selectedTiles.isEmpty()) return null
+        val west = selectedTiles.minOf { it.west }.toDouble()
+        val south = selectedTiles.minOf { it.south }.toDouble()
+        val east = selectedTiles.maxOf { it.east }.toDouble()
+        val north = selectedTiles.maxOf { it.north }.toDouble()
+        return MapPickerBounds(west, south, east, north)
+    }
+
+    private fun notifySelection() {
+        val bounds = selectedBounds()
+        if (bounds == null) {
+            onSelectionChanged("", emptyList())
+            return
+        }
+        onSelectionChanged(
+            bounds.toBboxString(),
+            selectedTiles.map { it.fileName }.sorted(),
+        )
+    }
+}
+
+internal abstract class BaseMapLibrePickerView(
+    context: Context,
+    private val onReady: () -> Unit,
+) : FrameLayout(context) {
+    protected val mapView: MapView
+    protected var map: MapLibreMap? = null
+    private var destroyed = false
+    private var started = false
+    private var readyNotified = false
+
+    init {
+        ensureMapLibreConfigured(context)
+        setBackgroundColor(MAP_PICKER_FALLBACK_COLOR)
+        mapView =
+            MapView(
+                context,
+                MapLibreMapOptions
+                    .createFromAttributes(context)
+                    .textureMode(true)
+                    .translucentTextureSurface(false)
+                    .foregroundLoadColor(MAP_PICKER_FALLBACK_COLOR),
+            )
+        mapView.setBackgroundColor(MAP_PICKER_FALLBACK_COLOR)
+        mapView.onCreate(null)
+        addView(
+            mapView,
+            LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT),
+        )
+        mapView.getMapAsync { loadedMap ->
+            if (destroyed) return@getMapAsync
+            map = loadedMap
+            configureMapCallbacks(loadedMap)
+            loadedMap.setStyle(Style.Builder().fromJson(OSM_RASTER_STYLE_JSON)) {
+                onStyleReady(loadedMap)
+                notifyReady()
+            }
+        }
+    }
+
+    abstract fun onStyleReady(map: MapLibreMap)
+
+    fun zoomIn() {
+        zoomBy(MAP_PICKER_ZOOM_STEP)
+    }
+
+    fun zoomOut() {
+        zoomBy(-MAP_PICKER_ZOOM_STEP)
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        if (!destroyed && !started) {
+            mapView.onStart()
+            mapView.onResume()
+            started = true
+        }
+    }
+
+    override fun onDetachedFromWindow() {
+        if (!destroyed) {
+            if (started) {
+                mapView.onPause()
+                mapView.onStop()
+                started = false
+            }
+            mapView.onDestroy()
+            destroyed = true
+        }
+        super.onDetachedFromWindow()
+    }
+
+    protected fun moveCameraToBounds(
+        bounds: MapPickerBounds,
+        paddingDp: Int,
+    ) {
+        val activeMap = map ?: return
+        mapView.post {
+            if (mapView.width == 0 || mapView.height == 0) {
+                moveCameraToBounds(bounds, paddingDp)
+                return@post
+            }
+            activeMap.moveCamera(
+                CameraUpdateFactory.newLatLngBounds(
+                    bounds.toMapLibreBounds(),
+                    dp(paddingDp),
+                ),
+            )
+        }
+    }
+
+    private fun configureMapCallbacks(activeMap: MapLibreMap) {
+        activeMap.setMinZoomPreference(MAP_PICKER_MIN_ZOOM)
+        activeMap.setMaxZoomPreference(MAP_PICKER_MAX_ZOOM)
+        activeMap.addOnCameraMoveListener(
+            MapLibreMap.OnCameraMoveListener {
+                invalidateOverlays()
+            },
+        )
+        activeMap.addOnCameraIdleListener(
+            MapLibreMap.OnCameraIdleListener {
+                invalidateOverlays()
+            },
+        )
+    }
+
+    private fun zoomBy(delta: Double) {
+        val activeMap = map ?: return
+        val nextZoom =
+            (activeMap.cameraPosition.zoom + delta)
+                .coerceIn(MAP_PICKER_MIN_ZOOM, MAP_PICKER_MAX_ZOOM)
+        activeMap.animateCamera(CameraUpdateFactory.zoomTo(nextZoom))
+    }
+
+    private fun invalidateOverlays() {
+        for (index in 0 until childCount) {
+            getChildAt(index).invalidate()
+        }
+    }
+
+    private fun notifyReady() {
+        if (!readyNotified) {
+            readyNotified = true
+            onReady()
+        }
+    }
+
+    protected fun dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
+}
+
+private class BboxSelectionOverlay(
+    context: Context,
+    private val boundsProvider: () -> MapPickerBounds,
+    private val mapProvider: () -> MapLibreMap?,
+    private val onBoundsChanged: (MapPickerBounds) -> Unit,
+) : View(context) {
+    var fineControlEnabled: Boolean = false
+    private var activeHandle: BboxHandle? = null
+    private var moveDragPending = false
+    private var moveDragActive = false
+    private var downX = 0f
+    private var downY = 0f
+    private var moveStartPoint: LatLng? = null
+    private var moveStartBounds: MapPickerBounds? = null
+    private val touchSlop = ViewConfiguration.get(context).scaledTouchSlop
+    private val moveDragRunnable =
+        Runnable {
+            if (moveDragPending) {
+                moveDragActive = true
+                parent?.requestDisallowInterceptTouchEvent(true)
+                performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+            }
+        }
+    private val strokePaint =
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0xff0b7285.toInt()
+            style = Paint.Style.STROKE
+            strokeWidth = dpFloat(3)
+        }
+    private val fillPaint =
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0x330b7285
+            style = Paint.Style.FILL
+        }
+    private val shadePaint =
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0x1f0a0f14
+            style = Paint.Style.FILL
+        }
+    private val handleFillPaint =
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0xff0b7285.toInt()
+            style = Paint.Style.FILL
+        }
+    private val handleStrokePaint =
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0xffffffff.toInt()
+            style = Paint.Style.STROKE
+            strokeWidth = dpFloat(3)
+        }
+    private val moveHandleFillPaint =
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0xe6ffffff.toInt()
+            style = Paint.Style.FILL
+        }
+    private val moveHandleIcon = ContextCompat.getDrawable(context, R.drawable.ic_drag_pan)?.mutate()
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        val rect = selectionRect()
+        drawOutsideShade(canvas, rect)
+        canvas.drawRect(rect, fillPaint)
+        canvas.drawRect(rect, strokePaint)
+        handlesForRect(rect).forEach { point ->
+            val radius = if (fineControlEnabled) dpFloat(9) else dpFloat(12)
+            drawHandle(canvas, point, radius)
+        }
+        drawMoveHandle(canvas, PointF(rect.centerX(), rect.centerY()))
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        val currentHandle = activeHandle
+        return when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                activeHandle = handleAt(event.x, event.y)
+                if (activeHandle != null) {
+                    true
+                } else {
+                    prepareMoveDrag(event.x, event.y)
+                }
+            }
+
+            MotionEvent.ACTION_MOVE -> {
+                when {
+                    currentHandle != null -> {
+                        updateBoundsFromHandle(currentHandle, event.x, event.y)
+                        true
+                    }
+
+                    moveDragPending -> {
+                        if (moveDragActive) {
+                            updateBoundsFromMoveDrag(event.x, event.y)
+                        } else if (movedBeyondSlop(event.x, event.y)) {
+                            cancelMoveDrag()
+                        }
+                        true
+                    }
+
+                    else -> false
+                }
+            }
+
+            MotionEvent.ACTION_UP,
+            MotionEvent.ACTION_CANCEL,
+            -> {
+                val consumed = activeHandle != null || moveDragPending
+                activeHandle = null
+                cancelMoveDrag()
+                consumed
+            }
+
+            else -> false
+        }
+    }
+
+    private fun prepareMoveDrag(
+        x: Float,
+        y: Float,
+    ): Boolean {
+        val point =
+            mapProvider()
+                ?.projection
+                ?.fromScreenLocation(PointF(x, y))
+        val canMove = moveHandleHitAt(x, y) && point != null
+        if (canMove) {
+            downX = x
+            downY = y
+            moveStartPoint = point
+            moveStartBounds = boundsProvider()
+            moveDragPending = true
+            moveDragActive = false
+            postDelayed(moveDragRunnable, ViewConfiguration.getLongPressTimeout().toLong())
+        }
+        return canMove
+    }
+
+    private fun updateBoundsFromHandle(
+        handle: BboxHandle,
+        x: Float,
+        y: Float,
+    ) {
+        val latLng =
+            mapProvider()
+                ?.projection
+                ?.fromScreenLocation(PointF(x, y))
+                ?: return
+        val current = boundsProvider()
+        val nextBounds =
+            if (handle == BboxHandle.Scale) {
+                current.scaledTo(latLng)
+            } else {
+                current.resizedTo(handle, latLng)
+        }
+        onBoundsChanged(nextBounds)
+    }
+
+    private fun updateBoundsFromMoveDrag(
+        x: Float,
+        y: Float,
+    ) {
+        val startPoint = moveStartPoint
+        val startBounds = moveStartBounds
+        val point =
+            mapProvider()
+                ?.projection
+                ?.fromScreenLocation(PointF(x, y))
+        if (startPoint != null && startBounds != null && point != null) {
+            onBoundsChanged(
+                startBounds.translatedBy(
+                    latitudeDelta = point.latitude - startPoint.latitude,
+                    longitudeDelta = point.longitude - startPoint.longitude,
+                ),
+            )
+        }
+    }
+
+    private fun MapPickerBounds.translatedBy(
+        latitudeDelta: Double,
+        longitudeDelta: Double,
+    ): MapPickerBounds =
+        MapPickerBounds.safe(
+            west = west + longitudeDelta,
+            south = south + latitudeDelta,
+            east = east + longitudeDelta,
+            north = north + latitudeDelta,
+        )
+
+    private fun MapPickerBounds.scaledTo(point: LatLng): MapPickerBounds {
+        val center = center()
+        val lonScale = abs(point.longitude - center.longitude) / max(lonSpan / 2.0, MIN_PICKER_SPAN / 2.0)
+        val latScale = abs(point.latitude - center.latitude) / max(latSpan / 2.0, MIN_PICKER_SPAN / 2.0)
+        val scale = max(max(lonScale, latScale), 0.1)
+        return MapPickerBounds.safe(
+            west = center.longitude - lonSpan * scale / 2.0,
+            south = center.latitude - latSpan * scale / 2.0,
+            east = center.longitude + lonSpan * scale / 2.0,
+            north = center.latitude + latSpan * scale / 2.0,
+        )
+    }
+
+    private fun MapPickerBounds.resizedTo(
+        handle: BboxHandle,
+        point: LatLng,
+    ): MapPickerBounds =
+        MapPickerBounds.safe(
+            west = if (handle.movesWest) point.longitude else west,
+            south = if (handle.movesSouth) point.latitude else south,
+            east = if (handle.movesEast) point.longitude else east,
+            north = if (handle.movesNorth) point.latitude else north,
+        )
+
+    private fun handleAt(
+        x: Float,
+        y: Float,
+    ): BboxHandle? {
+        val rect = selectionRect()
+        val points = handlesForRect(rect)
+        val handles = visibleHandles()
+        val threshold = dpFloat(34)
+        return handles
+            .zip(points)
+            .minByOrNull { (_, point) -> hypot((x - point.x).toDouble(), (y - point.y).toDouble()) }
+            ?.takeIf { (_, point) -> hypot((x - point.x).toDouble(), (y - point.y).toDouble()) <= threshold }
+            ?.first
+    }
+
+    private fun moveHandleHitAt(
+        x: Float,
+        y: Float,
+    ): Boolean {
+        val rect = selectionRect()
+        val center = PointF(rect.centerX(), rect.centerY())
+        return hypot((x - center.x).toDouble(), (y - center.y).toDouble()) <= dpFloat(34)
+    }
+
+    private fun movedBeyondSlop(
+        x: Float,
+        y: Float,
+    ): Boolean = hypot((x - downX).toDouble(), (y - downY).toDouble()) > touchSlop
+
+    private fun cancelMoveDrag() {
+        removeCallbacks(moveDragRunnable)
+        moveDragPending = false
+        moveDragActive = false
+        moveStartPoint = null
+        moveStartBounds = null
+        parent?.requestDisallowInterceptTouchEvent(false)
+    }
+
+    private fun handlesForRect(rect: RectF): List<PointF> =
+        visibleHandles().map { handle ->
+            PointF(
+                when (handle) {
+                    BboxHandle.NorthWest,
+                    BboxHandle.SouthWest,
+                    -> rect.left
+
+                    BboxHandle.NorthEast,
+                    BboxHandle.SouthEast,
+                    BboxHandle.Scale,
+                    -> rect.right
+                },
+                when (handle) {
+                    BboxHandle.NorthWest,
+                    BboxHandle.NorthEast,
+                    -> rect.top
+
+                    BboxHandle.SouthEast,
+                    BboxHandle.SouthWest,
+                    BboxHandle.Scale,
+                    -> rect.bottom
+                },
+            )
+        }
+
+    private fun visibleHandles(): List<BboxHandle> =
+        if (fineControlEnabled) {
+            BBOX_VERTEX_HANDLES
+        } else {
+            listOf(BboxHandle.Scale)
+        }
+
+    private fun selectionRect(): RectF {
+        val bounds = boundsProvider()
+        val activeMap = mapProvider()
+        if (activeMap != null) {
+            val northWest = activeMap.projection.toScreenLocation(LatLng(bounds.north, bounds.west))
+            val southEast = activeMap.projection.toScreenLocation(LatLng(bounds.south, bounds.east))
+            return RectF(
+                min(northWest.x, southEast.x),
+                min(northWest.y, southEast.y),
+                max(northWest.x, southEast.x),
+                max(northWest.y, southEast.y),
+            )
+        }
+        return RectF(width * 0.22f, height * 0.26f, width * 0.78f, height * 0.74f)
+    }
+
+    private fun drawOutsideShade(
+        canvas: Canvas,
+        rect: RectF,
+    ) {
+        canvas.drawRect(0f, 0f, width.toFloat(), rect.top, shadePaint)
+        canvas.drawRect(0f, rect.bottom, width.toFloat(), height.toFloat(), shadePaint)
+        canvas.drawRect(0f, rect.top, rect.left, rect.bottom, shadePaint)
+        canvas.drawRect(rect.right, rect.top, width.toFloat(), rect.bottom, shadePaint)
+    }
+
+    private fun drawHandle(
+        canvas: Canvas,
+        point: PointF,
+        radius: Float,
+    ) {
+        canvas.drawCircle(point.x, point.y, radius, handleFillPaint)
+        canvas.drawCircle(point.x, point.y, radius, handleStrokePaint)
+    }
+
+    private fun drawMoveHandle(
+        canvas: Canvas,
+        point: PointF,
+    ) {
+        val radius = dpFloat(13)
+        canvas.drawCircle(point.x, point.y, radius, moveHandleFillPaint)
+        canvas.drawCircle(point.x, point.y, radius, strokePaint)
+        moveHandleIcon?.let { icon ->
+            val halfSize = dpFloat(9).toInt()
+            icon.setBounds(
+                (point.x - halfSize).toInt(),
+                (point.y - halfSize).toInt(),
+                (point.x + halfSize).toInt(),
+                (point.y + halfSize).toInt(),
+            )
+            icon.draw(canvas)
+        }
+    }
+
+    private fun dpFloat(value: Int): Float = value * resources.displayMetrics.density
+}
+
+private enum class BboxHandle(
+    val movesWest: Boolean = false,
+    val movesSouth: Boolean = false,
+    val movesEast: Boolean = false,
+    val movesNorth: Boolean = false,
+) {
+    Scale,
+    NorthWest(movesWest = true, movesNorth = true),
+    NorthEast(movesEast = true, movesNorth = true),
+    SouthEast(movesEast = true, movesSouth = true),
+    SouthWest(movesWest = true, movesSouth = true),
+}
+
+private val BBOX_VERTEX_HANDLES =
+    listOf(
+        BboxHandle.NorthWest,
+        BboxHandle.NorthEast,
+        BboxHandle.SouthEast,
+        BboxHandle.SouthWest,
+    )
+
+private class RoutingTileOverlay(
+    context: Context,
+    private val selectedTilesProvider: () -> Set<RoutingTile>,
+    private val mapProvider: () -> MapLibreMap?,
+) : View(context) {
+    private val gridPaint =
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0xb8495057.toInt()
+            style = Paint.Style.STROKE
+            strokeWidth = dpFloat(1)
+        }
+    private val selectedFillPaint =
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0x400b7285
+            style = Paint.Style.FILL
+        }
+    private val selectedStrokePaint =
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0xff0b7285.toInt()
+            style = Paint.Style.STROKE
+            strokeWidth = dpFloat(3)
+        }
+    private val labelPaint =
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0xff073b4c.toInt()
+            textSize = 11 * resources.displayMetrics.density
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+            textAlign = Paint.Align.CENTER
+        }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        val activeMap = mapProvider()
+        val selectedTiles = selectedTilesProvider()
+        val visibleTiles =
+            if (activeMap == null) {
+                selectedTiles
+            } else {
+                routingTilesForVisibleMap(activeMap)
+            }
+        (visibleTiles + selectedTiles).forEach { tile ->
+            val rect = tile.screenRect(activeMap) ?: fallbackTileRect(tile, selectedTiles)
+            val selected = selectedTiles.contains(tile)
+            if (selected) {
+                canvas.drawRect(rect, selectedFillPaint)
+                canvas.drawRect(rect, selectedStrokePaint)
+            } else {
+                canvas.drawRect(rect, gridPaint)
+            }
+            drawTileLabel(canvas, rect, tile)
+        }
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean = false
+
+    private fun drawTileLabel(
+        canvas: Canvas,
+        rect: RectF,
+        tile: RoutingTile,
+    ) {
+        if (rect.width() < dpFloat(56) || rect.height() < dpFloat(28)) return
+        val baseline = rect.centerY() - (labelPaint.descent() + labelPaint.ascent()) / 2f
+        canvas.drawText(tile.fileName, rect.centerX(), baseline, labelPaint)
+    }
+
+    private fun routingTilesForVisibleMap(activeMap: MapLibreMap): Set<RoutingTile> {
+        if (width == 0 || height == 0) return emptySet()
+        val points =
+            listOf(
+                activeMap.projection.fromScreenLocation(PointF(0f, 0f)),
+                activeMap.projection.fromScreenLocation(PointF(width.toFloat(), 0f)),
+                activeMap.projection.fromScreenLocation(PointF(0f, height.toFloat())),
+                activeMap.projection.fromScreenLocation(PointF(width.toFloat(), height.toFloat())),
+            )
+        val west = points.minOf { it.longitude }
+        val east = points.maxOf { it.longitude }
+        val south = points.minOf { it.latitude }
+        val north = points.maxOf { it.latitude }
+        return routingTilesForBounds(
+            MapPickerBounds.safe(
+                west = west,
+                south = south,
+                east = east,
+                north = north,
+                minSpan = ROUTING_TILE_DEGREES.toDouble(),
+            ),
+            bufferTiles = 1,
+        )
+    }
+
+    private fun RoutingTile.screenRect(activeMap: MapLibreMap?): RectF? {
+        if (activeMap == null) return null
+        val northWest = activeMap.projection.toScreenLocation(LatLng(north.toDouble(), west.toDouble()))
+        val southEast = activeMap.projection.toScreenLocation(LatLng(south.toDouble(), east.toDouble()))
+        return RectF(
+            min(northWest.x, southEast.x),
+            min(northWest.y, southEast.y),
+            max(northWest.x, southEast.x),
+            max(northWest.y, southEast.y),
+        )
+    }
+
+    private fun fallbackTileRect(
+        tile: RoutingTile,
+        selectedTiles: Set<RoutingTile>,
+    ): RectF {
+        val orderedTiles = selectedTiles.sortedWith(compareBy<RoutingTile> { it.south }.thenBy { it.west })
+        val index = orderedTiles.indexOf(tile).takeIf { it >= 0 } ?: 0
+        val columns = max(1, min(2, orderedTiles.size))
+        val cellWidth = width / columns.toFloat()
+        val cellHeight = height / max(1, (orderedTiles.size + columns - 1) / columns).toFloat()
+        val column = index % columns
+        val row = index / columns
+        return RectF(
+            column * cellWidth + dpFloat(16),
+            row * cellHeight + dpFloat(16),
+            (column + 1) * cellWidth - dpFloat(16),
+            (row + 1) * cellHeight - dpFloat(16),
+        )
+    }
+
+    private fun dpFloat(value: Int): Float = value * resources.displayMetrics.density
+}
+
+private data class RoutingTile(
+    val west: Int,
+    val south: Int,
+) {
+    val east: Int = west + ROUTING_TILE_DEGREES
+    val north: Int = south + ROUTING_TILE_DEGREES
+    val bounds: MapPickerBounds =
+        MapPickerBounds(
+            west = west.toDouble(),
+            south = south.toDouble(),
+            east = east.toDouble(),
+            north = north.toDouble(),
+        )
+    val fileName: String = "${formatTileCoord(west, 'E', 'W')}_${formatTileCoord(south, 'N', 'S')}.rd5"
+
+    companion object {
+        fun containing(
+            latitude: Double,
+            longitude: Double,
+        ): RoutingTile =
+            RoutingTile(
+                west = tileOrigin(longitude).coerceIn(-180, 175),
+                south = tileOrigin(latitude).coerceIn(-85, 85),
+            )
+    }
+}
+
+private fun routingTilesForBounds(
+    bounds: MapPickerBounds,
+    bufferTiles: Int = 0,
+): Set<RoutingTile> {
+    val lonStart = (tileOrigin(bounds.west) - bufferTiles * ROUTING_TILE_DEGREES).coerceAtLeast(-180)
+    val lonEnd = (tileOrigin(bounds.east - ROUTING_TILE_EPSILON) + bufferTiles * ROUTING_TILE_DEGREES).coerceAtMost(175)
+    val latStart = (tileOrigin(bounds.south) - bufferTiles * ROUTING_TILE_DEGREES).coerceAtLeast(-85)
+    val latEnd = (tileOrigin(bounds.north - ROUTING_TILE_EPSILON) + bufferTiles * ROUTING_TILE_DEGREES).coerceAtMost(85)
+    val result = linkedSetOf<RoutingTile>()
+    var lat = latStart
+    while (lat <= latEnd) {
+        var lon = lonStart
+        while (lon <= lonEnd) {
+            result += RoutingTile(lon, lat)
+            lon += ROUTING_TILE_DEGREES
+        }
+        lat += ROUTING_TILE_DEGREES
+    }
+    return result
+}
+
+private fun tileOrigin(coordinate: Double): Int =
+    floor(coordinate / ROUTING_TILE_DEGREES.toDouble()).toInt() * ROUTING_TILE_DEGREES
+
+private fun formatTileCoord(
+    value: Int,
+    positivePrefix: Char,
+    negativePrefix: Char,
+): String {
+    val prefix = if (value < 0) negativePrefix else positivePrefix
+    return "$prefix${abs(value)}"
+}
+
+private fun ensureMapLibreConfigured(context: Context) {
+    if (MapLibreConfiguration.initialized) return
+    synchronized(MapLibreConfiguration) {
+        if (MapLibreConfiguration.initialized) return
+        MapLibre.getInstance(context.applicationContext)
+        val packageName = context.packageName
+        HttpRequestUtil.setOkHttpClient(
+            OkHttpClient
+                .Builder()
+                .addInterceptor { chain ->
+                    chain.proceed(
+                        chain
+                            .request()
+                            .newBuilder()
+                            .header(
+                                "User-Agent",
+                                "GlanceMapCompanion/1 ($packageName)",
+                            )
+                            .build(),
+                    )
+                }
+                .build(),
+        )
+        MapLibreConfiguration.initialized = true
+    }
+}
+
+private object MapLibreConfiguration {
+    var initialized: Boolean = false
+}
+
+@SuppressLint("MissingPermission")
+private fun requestLastKnownLocation(
+    context: Context,
+    onLocation: (Location) -> Unit,
+) {
+    val hasPermission =
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+        ) == PackageManager.PERMISSION_GRANTED
+    if (!hasPermission) return
+    LocationServices
+        .getFusedLocationProviderClient(context)
+        .lastLocation
+        .addOnSuccessListener { location ->
+            if (location != null) {
+                onLocation(location)
+            }
+        }
+}

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/MapPickerControls.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/MapPickerControls.kt
@@ -1,0 +1,96 @@
+@file:Suppress("FunctionNaming")
+
+package com.glancemap.glancemapcompanionapp
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun MapPickerControlRow(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        Checkbox(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+        )
+        Text(
+            label,
+            style = MaterialTheme.typography.labelLarge,
+        )
+    }
+}
+
+@Composable
+internal fun MapPickerHelpText(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun MapPickerZoomControls(
+    onZoomIn: () -> Unit,
+    onZoomOut: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(5.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier,
+    ) {
+        MapPickerZoomButton(label = "+", onClick = onZoomIn)
+        MapPickerZoomButton(label = "-", onClick = onZoomOut)
+    }
+}
+
+@Composable
+private fun MapPickerZoomButton(
+    label: String,
+    onClick: () -> Unit,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.94f),
+        shape = MaterialTheme.shapes.small,
+        tonalElevation = 3.dp,
+        shadowElevation = 3.dp,
+        modifier =
+            Modifier
+                .size(30.dp)
+                .clickable(onClick = onClick),
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.titleSmall,
+            )
+        }
+    }
+}

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/MapPickerLocationPermission.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/MapPickerLocationPermission.kt
@@ -1,0 +1,43 @@
+package com.glancemap.glancemapcompanionapp
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+
+@Composable
+internal fun rememberMapPickerLocationAllowed(requestPermission: Boolean): Boolean {
+    val context = LocalContext.current
+    var allowed by remember {
+        mutableStateOf(context.hasApproximateLocationPermission())
+    }
+    val launcher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestPermission(),
+        ) { granted ->
+            allowed = granted
+        }
+
+    LaunchedEffect(requestPermission, allowed) {
+        if (requestPermission && !allowed) {
+            launcher.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
+        }
+    }
+
+    return allowed
+}
+
+private fun Context.hasApproximateLocationPermission(): Boolean =
+    ContextCompat.checkSelfPermission(
+        this,
+        Manifest.permission.ACCESS_COARSE_LOCATION,
+    ) == PackageManager.PERMISSION_GRANTED

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RefugesImportDialog.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RefugesImportDialog.kt
@@ -108,6 +108,18 @@ internal fun RefugesImportDialog(
     }
     var selectedSource by remember { mutableStateOf(PoiImportSource.OSM) }
     var enrichWithOsm by remember { mutableStateOf(false) }
+    fun selectSource(source: PoiImportSource) {
+        if (selectedSource == source) return
+
+        selectedSource = source
+        if (source == PoiImportSource.OSM) {
+            enrichWithOsm = false
+        }
+        if (!poiImportProgress.isRunning) {
+            viewModel.resetPoiImportProgress()
+        }
+    }
+
     var selectedOsmCategoryIds by remember {
         mutableStateOf(defaultOsmPoiCategoryIds())
     }
@@ -123,6 +135,7 @@ internal fun RefugesImportDialog(
     var mapMenuExpanded by remember { mutableStateOf(false) }
     var watchMenuExpanded by remember { mutableStateOf(false) }
     var areaMethodMenuExpanded by remember { mutableStateOf(false) }
+    var showBboxMapPicker by remember { mutableStateOf(false) }
     var areaMethod by remember { mutableStateOf(PoiAreaMethod.WATCH_MAP) }
     var lastSuggestedPoiFileName by remember { mutableStateOf("") }
     var selectedWatchMapKey by remember(uiState.selectedWatch?.id) {
@@ -135,6 +148,10 @@ internal fun RefugesImportDialog(
         } else {
             watchInstalledMaps.firstOrNull { it.filePath == selectedWatchMapKey }
         }
+    val mapPickerInitialBbox =
+        bboxInput
+            .trim()
+            .ifBlank { selectedMapCandidate?.bbox.orEmpty() }
     val selectedWatchReachable =
         isSelectedWatchReachable(
             selectedWatch = uiState.selectedWatch,
@@ -170,18 +187,21 @@ internal fun RefugesImportDialog(
         when (areaMethod) {
             PoiAreaMethod.WATCH_MAP -> "Auto from watch map"
             PoiAreaMethod.REFUGES_PRESET -> "Choose refuges.info region"
+            PoiAreaMethod.MAP_PICKER -> "Pick on map"
             PoiAreaMethod.MANUAL_BBOX -> "Enter BBox manually"
         }
     val areaMethodDescription =
         when (areaMethod) {
             PoiAreaMethod.WATCH_MAP -> "Use a .map file on the watch to auto-detect the area (BBox)."
             PoiAreaMethod.REFUGES_PRESET -> "Pick a refuges.info region preset to fill the area automatically."
+            PoiAreaMethod.MAP_PICKER -> "Pan and zoom an online map to choose the import rectangle."
             PoiAreaMethod.MANUAL_BBOX -> "Enter your own area rectangle as west,south,east,north."
         }
     val resolvedImportBbox =
         when (areaMethod) {
             PoiAreaMethod.WATCH_MAP -> selectedMapCandidate?.bbox.orEmpty()
             PoiAreaMethod.REFUGES_PRESET,
+            PoiAreaMethod.MAP_PICKER,
             PoiAreaMethod.MANUAL_BBOX,
             -> bboxInput.trim()
         }
@@ -221,6 +241,23 @@ internal fun RefugesImportDialog(
         if (poiImportProgress.isRunning || poiImportProgress.completed) {
             importStatusBringIntoViewRequester.bringIntoView()
         }
+    }
+
+    if (showBboxMapPicker) {
+        BboxMapPickerDialog(
+            initialBbox = mapPickerInitialBbox,
+            selectedSource = selectedSource,
+            onDismiss = { showBboxMapPicker = false },
+            onConfirm = { pickedBbox ->
+                bboxInput = pickedBbox
+                selectedRegionLabel = "Custom"
+                areaMethod = PoiAreaMethod.MAP_PICKER
+                showBboxMapPicker = false
+                if (!poiImportProgress.isRunning) {
+                    viewModel.resetPoiImportProgress()
+                }
+            },
+        )
     }
 
     AlertDialog(
@@ -375,6 +412,15 @@ internal fun RefugesImportDialog(
                                 },
                             )
                             DropdownMenuItem(
+                                text = { Text("Pick on map") },
+                                onClick = {
+                                    areaMethod = PoiAreaMethod.MAP_PICKER
+                                    mapMenuExpanded = false
+                                    regionMenuExpanded = false
+                                    areaMethodMenuExpanded = false
+                                },
+                            )
+                            DropdownMenuItem(
                                 text = { Text("Enter BBox manually") },
                                 onClick = {
                                     areaMethod = PoiAreaMethod.MANUAL_BBOX
@@ -519,33 +565,76 @@ internal fun RefugesImportDialog(
                                 style = MaterialTheme.typography.bodySmall,
                             )
                             Spacer(modifier = Modifier.height(6.dp))
-                            OutlinedButton(
-                                onClick = { regionMenuExpanded = true },
-                                modifier = Modifier.fillMaxWidth(),
-                            ) {
-                                Text(selectedRegionLabel)
-                            }
-                            DropdownMenu(
-                                expanded = regionMenuExpanded,
-                                onDismissRequest = { regionMenuExpanded = false },
-                            ) {
-                                refugesRegionPresets.forEach { preset ->
-                                    DropdownMenuItem(
-                                        text = { Text(preset.label) },
-                                        onClick = {
-                                            selectedRegionLabel = preset.label
-                                            if (preset.bbox.isNotBlank()) {
-                                                bboxInput = preset.bbox
-                                            }
-                                            regionMenuExpanded = false
-                                        },
+                            Box(modifier = Modifier.fillMaxWidth()) {
+                                OutlinedButton(
+                                    onClick = { regionMenuExpanded = true },
+                                    modifier = Modifier.fillMaxWidth(),
+                                ) {
+                                    Text(
+                                        selectedRegionLabel,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
                                     )
+                                }
+                                DropdownMenu(
+                                    expanded = regionMenuExpanded,
+                                    onDismissRequest = { regionMenuExpanded = false },
+                                    modifier = Modifier.heightIn(max = 320.dp),
+                                ) {
+                                    refugesRegionPresets.forEach { preset ->
+                                        DropdownMenuItem(
+                                            text = {
+                                                Text(
+                                                    preset.label,
+                                                    maxLines = 1,
+                                                    overflow = TextOverflow.Ellipsis,
+                                                )
+                                            },
+                                            onClick = {
+                                                selectedRegionLabel = preset.label
+                                                if (preset.bbox.isNotBlank()) {
+                                                    bboxInput = preset.bbox
+                                                }
+                                                regionMenuExpanded = false
+                                            },
+                                        )
+                                    }
                                 }
                             }
                             Spacer(modifier = Modifier.height(6.dp))
                             if (bboxInput.isBlank()) {
                                 Text(
                                     "Select a preset to define area.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                )
+                            } else {
+                                Text(
+                                    "Area BBox: $bboxInput",
+                                    style = MaterialTheme.typography.bodySmall,
+                                )
+                            }
+                        }
+
+                        PoiAreaMethod.MAP_PICKER -> {
+                            OutlinedButton(
+                                onClick = { showBboxMapPicker = true },
+                                modifier = Modifier.fillMaxWidth(),
+                                enabled = !isImportingRefuges,
+                            ) {
+                                Text(
+                                    if (bboxInput.isBlank()) {
+                                        "Open map picker"
+                                    } else {
+                                        "Edit area on map"
+                                    },
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+                            Spacer(modifier = Modifier.height(6.dp))
+                            if (bboxInput.isBlank()) {
+                                Text(
+                                    "No map area selected yet.",
                                     style = MaterialTheme.typography.bodySmall,
                                 )
                             } else {
@@ -587,15 +676,14 @@ internal fun RefugesImportDialog(
                         FilterChip(
                             selected = selectedSource == PoiImportSource.OSM,
                             onClick = {
-                                selectedSource = PoiImportSource.OSM
-                                enrichWithOsm = false
+                                selectSource(PoiImportSource.OSM)
                             },
                             label = { Text("OSM") },
                         )
                         FilterChip(
                             selected = selectedSource == PoiImportSource.REFUGES,
                             onClick = {
-                                selectedSource = PoiImportSource.REFUGES
+                                selectSource(PoiImportSource.REFUGES)
                             },
                             label = { Text("Refuges.info") },
                         )

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RoutingDownloadDialog.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RoutingDownloadDialog.kt
@@ -54,6 +54,7 @@ internal fun RoutingDownloadDialog(
     var mapMenuExpanded by remember { mutableStateOf(false) }
     var watchMenuExpanded by remember { mutableStateOf(false) }
     var areaMethodMenuExpanded by remember { mutableStateOf(false) }
+    var showRoutingTilePicker by remember { mutableStateOf(false) }
     var areaMethod by remember { mutableStateOf(RoutingAreaMethod.WATCH_MAP) }
     var selectedWatchMapKey by remember(uiState.selectedWatch?.id) {
         mutableStateOf(watchInstalledMaps.firstOrNull()?.filePath.orEmpty())
@@ -68,10 +69,15 @@ internal fun RoutingDownloadDialog(
                     ?: watchInstalledMaps.firstOrNull()
             }
         }
+    val routingTilePickerInitialBbox =
+        bboxInput
+            .trim()
+            .ifBlank { selectedRoutingMapCandidate?.bbox.orEmpty() }
     val resolvedRoutingBbox =
         remember(areaMethod, bboxInput, selectedRoutingMapCandidate) {
             when (areaMethod) {
                 RoutingAreaMethod.WATCH_MAP -> selectedRoutingMapCandidate?.bbox.orEmpty()
+                RoutingAreaMethod.TILE_PICKER,
                 RoutingAreaMethod.MANUAL_BBOX -> bboxInput.trim()
             }
         }
@@ -98,11 +104,13 @@ internal fun RoutingDownloadDialog(
     val routingAreaMethodLabel =
         when (areaMethod) {
             RoutingAreaMethod.WATCH_MAP -> "Auto from watch map"
+            RoutingAreaMethod.TILE_PICKER -> "Pick routing tiles"
             RoutingAreaMethod.MANUAL_BBOX -> "Enter BBox manually"
         }
     val routingAreaMethodDescription =
         when (areaMethod) {
             RoutingAreaMethod.WATCH_MAP -> "Use the bbox of a .map already present on the watch."
+            RoutingAreaMethod.TILE_PICKER -> "Tap fixed 5° BRouter tiles on a map."
             RoutingAreaMethod.MANUAL_BBOX -> "Enter west,south,east,north manually."
         }
     val routingWatchIsSelected = uiState.selectedWatch != null
@@ -145,6 +153,21 @@ internal fun RoutingDownloadDialog(
         }
     }
 
+    if (showRoutingTilePicker) {
+        RoutingTilePickerDialog(
+            initialBbox = routingTilePickerInitialBbox,
+            onDismiss = { showRoutingTilePicker = false },
+            onConfirm = { pickedBbox ->
+                bboxInput = pickedBbox
+                areaMethod = RoutingAreaMethod.TILE_PICKER
+                showRoutingTilePicker = false
+                if (!routingDownloadProgress.isRunning) {
+                    viewModel.resetRoutingDownloadProgress()
+                }
+            },
+        )
+    }
+
     AlertDialog(
         onDismissRequest = {
             if (!isDownloadingRouting) onDismiss()
@@ -166,7 +189,8 @@ internal fun RoutingDownloadDialog(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     Text(
-                        "BRouter routing packs (.rd5) are downloaded on the phone, then added to section 2 so you can decide if you want to send them.",
+                        "BRouter routing packs (.rd5) are downloaded on the phone, " +
+                            "then added to section 2 so you can decide if you want to send them.",
                         style = MaterialTheme.typography.bodySmall,
                     )
 
@@ -245,7 +269,8 @@ internal fun RoutingDownloadDialog(
                     }
                     if (uiState.selectedWatch != null && !selectedWatchReachable) {
                         Text(
-                            "${selectedWatchDisconnectedStatusMessage()} You can also switch to manual BBox.",
+                            "${selectedWatchDisconnectedStatusMessage()} " +
+                                "You can also switch to tile picker or manual BBox.",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.error,
                         )
@@ -286,9 +311,18 @@ internal fun RoutingDownloadDialog(
                                 enabled = selectedWatchReachable,
                             )
                             DropdownMenuItem(
+                                text = { Text("Pick routing tiles") },
+                                onClick = {
+                                    areaMethod = RoutingAreaMethod.TILE_PICKER
+                                    mapMenuExpanded = false
+                                    areaMethodMenuExpanded = false
+                                },
+                            )
+                            DropdownMenuItem(
                                 text = { Text("Enter BBox manually") },
                                 onClick = {
                                     areaMethod = RoutingAreaMethod.MANUAL_BBOX
+                                    mapMenuExpanded = false
                                     areaMethodMenuExpanded = false
                                 },
                             )
@@ -353,7 +387,8 @@ internal fun RoutingDownloadDialog(
                             when {
                                 uiState.selectedWatch != null && !selectedWatchReachable -> {
                                     Text(
-                                        "${selectedWatchDisconnectedStatusMessage()} Use manual BBox while the watch is disconnected.",
+                                        "${selectedWatchDisconnectedStatusMessage()} " +
+                                            "Use tile picker or manual BBox while the watch is disconnected.",
                                         style = MaterialTheme.typography.bodySmall,
                                         color = MaterialTheme.colorScheme.error,
                                     )
@@ -397,9 +432,39 @@ internal fun RoutingDownloadDialog(
                             }
                         }
 
+                        RoutingAreaMethod.TILE_PICKER -> {
+                            OutlinedButton(
+                                onClick = { showRoutingTilePicker = true },
+                                modifier = Modifier.fillMaxWidth(),
+                                enabled = !isDownloadingRouting,
+                            ) {
+                                Text(
+                                    if (bboxInput.isBlank()) {
+                                        "Open tile picker"
+                                    } else {
+                                        "Edit routing tiles"
+                                    },
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+                            if (bboxInput.isBlank()) {
+                                Text(
+                                    "No routing tiles selected yet.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                )
+                            } else {
+                                Text(
+                                    "Tile bbox: $bboxInput",
+                                    style = MaterialTheme.typography.bodySmall,
+                                )
+                            }
+                        }
+
                         RoutingAreaMethod.MANUAL_BBOX -> {
                             Text(
-                                "Enter BBox (rectangle) as west,south,east,north (minLon,minLat,maxLon,maxLat). Example: 1.40,42.43,1.79,42.66",
+                                "Enter BBox (rectangle) as west,south,east,north " +
+                                    "(minLon,minLat,maxLon,maxLat). Example: 1.40,42.43,1.79,42.66",
                                 style = MaterialTheme.typography.bodySmall,
                             )
                             OutlinedTextField(
@@ -486,7 +551,8 @@ internal fun RoutingDownloadDialog(
                             }
                             if (routingCompletedSuccessfully) {
                                 Text(
-                                    "Download complete. You can save the routing file(s) on phone or send them to the watch.",
+                                    "Download complete. You can save the routing file(s) " +
+                                        "on phone or send them to the watch.",
                                     style = MaterialTheme.typography.bodySmall,
                                 )
                             }

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RoutingTilePickerDialog.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RoutingTilePickerDialog.kt
@@ -1,0 +1,250 @@
+@file:Suppress("FunctionNaming")
+
+package com.glancemap.glancemapcompanionapp
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.glancemap.glancemapcompanionapp.routing.BRouterTileMath
+
+private const val DEFAULT_ROUTING_PICKER_BBOX = "5.00,43.00,10.00,48.00"
+
+@Composable
+internal fun RoutingTilePickerDialog(
+    initialBbox: String,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    val initialPickerBbox = remember(initialBbox) { resolveInitialRoutingPickerBbox(initialBbox) }
+    val hasUsableInitialBbox = remember(initialBbox) { hasUsableInitialRoutingBbox(initialBbox) }
+    var centerOnLocation by remember(initialBbox) { mutableStateOf(!hasUsableInitialBbox) }
+    val locationAllowed = rememberMapPickerLocationAllowed(centerOnLocation)
+    val useLocationDefault = centerOnLocation && locationAllowed
+    var selectedBbox by remember(initialPickerBbox) { mutableStateOf("") }
+    var selectedTiles by remember(initialPickerBbox) { mutableStateOf(emptyList<String>()) }
+    var mapReady by remember { mutableStateOf(false) }
+
+    LaunchedEffect(initialPickerBbox, useLocationDefault) {
+        mapReady = false
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties =
+            DialogProperties(
+                usePlatformDefaultWidth = false,
+                decorFitsSystemWindows = true,
+            ),
+    ) {
+        RoutingTilePickerSurface(
+            useLocationDefault = useLocationDefault,
+            state = RoutingTilePickerState(selectedBbox, selectedTiles, centerOnLocation, mapReady),
+            actions =
+                RoutingTilePickerActions(
+                    onDismiss = onDismiss,
+                    onConfirm = onConfirm,
+                    onReady = { mapReady = true },
+                    onCenterOnLocationChanged = { checked -> centerOnLocation = checked },
+                    onSelectionChanged = { bbox, tiles ->
+                        selectedBbox = bbox
+                        selectedTiles = tiles
+                    },
+                ),
+            initialBbox = initialPickerBbox,
+        )
+    }
+}
+
+private data class RoutingTilePickerState(
+    val selectedBbox: String,
+    val selectedTiles: List<String>,
+    val centerOnLocation: Boolean,
+    val mapReady: Boolean,
+)
+
+private data class RoutingTilePickerActions(
+    val onDismiss: () -> Unit,
+    val onConfirm: (String) -> Unit,
+    val onReady: () -> Unit,
+    val onCenterOnLocationChanged: (Boolean) -> Unit,
+    val onSelectionChanged: (bbox: String, tiles: List<String>) -> Unit,
+)
+
+@Composable
+private fun RoutingTilePickerSurface(
+    useLocationDefault: Boolean,
+    state: RoutingTilePickerState,
+    actions: RoutingTilePickerActions,
+    initialBbox: String,
+) {
+    Surface(
+        shape = MaterialTheme.shapes.large,
+        tonalElevation = 6.dp,
+        modifier =
+            Modifier
+                .fillMaxWidth(0.96f)
+                .fillMaxHeight(0.90f)
+                .heightIn(max = 720.dp),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+        ) {
+            Text("Pick routing tiles", style = MaterialTheme.typography.titleLarge)
+            Spacer(modifier = Modifier.height(4.dp))
+            MapPickerControlRow(
+                checked = state.centerOnLocation,
+                onCheckedChange = actions.onCenterOnLocationChanged,
+                label = "Center on my location",
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            MapPickerHelpText(
+                text = "Pan the map, then tap tiles to select or remove routing packs.",
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            RoutingTilePickerMap(initialBbox, useLocationDefault, state, actions, Modifier.weight(1f))
+            Spacer(modifier = Modifier.height(10.dp))
+            RoutingTilePickerFooter(state, actions)
+        }
+    }
+}
+
+@Composable
+private fun RoutingTilePickerMap(
+    initialBbox: String,
+    useLocationDefault: Boolean,
+    state: RoutingTilePickerState,
+    actions: RoutingTilePickerActions,
+    modifier: Modifier = Modifier,
+) {
+    val initialBounds =
+        remember(initialBbox) {
+            MapPickerBounds.parseOrNull(initialBbox) ?: defaultRoutingPickerBounds()
+        }
+    var pickerView by remember(useLocationDefault, initialBbox) { mutableStateOf<MapLibreRoutingTilePickerView?>(null) }
+
+    Box(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        key(useLocationDefault, initialBbox) {
+            AndroidView(
+                factory = { context ->
+                    MapLibreRoutingTilePickerView(
+                        context = context,
+                        initialBounds = initialBounds,
+                        useLocationDefault = useLocationDefault,
+                        onSelectionChanged = actions.onSelectionChanged,
+                        onReady = actions.onReady,
+                    ).also { view -> pickerView = view }
+                },
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+        if (!state.mapReady) {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+        if (state.mapReady) {
+            MapPickerZoomControls(
+                onZoomIn = { pickerView?.zoomIn() },
+                onZoomOut = { pickerView?.zoomOut() },
+                modifier =
+                    Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(5.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun RoutingTilePickerFooter(
+    state: RoutingTilePickerState,
+    actions: RoutingTilePickerActions,
+) {
+    Text(
+        "Selected routing packs (${state.selectedTiles.size})",
+        style = MaterialTheme.typography.labelSmall,
+    )
+    Text(
+        state.selectedTiles.joinToString(", ").ifBlank { "Tap tiles on the map." },
+        style = MaterialTheme.typography.bodySmall,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+    )
+    Spacer(modifier = Modifier.height(12.dp))
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+        OutlinedButton(onClick = actions.onDismiss) { Text("Cancel") }
+        Spacer(modifier = Modifier.width(8.dp))
+        Button(
+            onClick = { actions.onConfirm(state.selectedBbox) },
+            enabled = state.selectedTiles.isNotEmpty(),
+        ) {
+            Text("Use tiles")
+        }
+    }
+}
+
+private fun resolveInitialRoutingPickerBbox(initialBbox: String): String =
+    runCatching {
+        val parsed = BRouterTileMath.parseBbox(initialBbox)
+        val tileCount = BRouterTileMath.tileFileNamesForBbox(parsed).size
+        if (tileCount in 1..4) {
+            parsed.asQueryString()
+        } else {
+            DEFAULT_ROUTING_PICKER_BBOX
+        }
+    }.getOrElse { DEFAULT_ROUTING_PICKER_BBOX }
+
+private fun hasUsableInitialRoutingBbox(initialBbox: String): Boolean =
+    runCatching {
+        val parsed = BRouterTileMath.parseBbox(initialBbox)
+        BRouterTileMath.tileFileNamesForBbox(parsed).size in 1..4
+    }.getOrDefault(false)
+
+private fun defaultRoutingPickerBounds(): MapPickerBounds =
+    MapPickerBounds.parseOrNull(DEFAULT_ROUTING_PICKER_BBOX) ?: MapPickerBounds.defaultAround(45.5, 7.5)

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.Dialogs.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.Dialogs.kt
@@ -305,9 +305,12 @@ internal fun FilePickerQuickGuideDialog(
             listOf(
                 QuickGuidePage(
                     title = "Welcome to GlanceMap Companion App",
+                    intro =
+                        "GlanceMap is a map viewer. It does not provide map data; " +
+                            ".map files must be downloaded from external sources.",
                     lines =
                         listOf(
-                            "Send maps, routes, POI, and GPX files from your phone to the watch.",
+                            "This phone app is necessary to send maps, routes, POI, and GPX files to your watch.",
                             "Once files are on the watch, GlanceMap can work offline without the phone.",
                             "For battery saving, keeping phone and watch connected is still recommended.",
                         ),
@@ -317,7 +320,7 @@ internal fun FilePickerQuickGuideDialog(
                     lines =
                         listOf(
                             "Use 1. Download to get Mapsforge OSM .map, POI, GPX, or routing files.",
-                            "Tap 2. Select file(s) to add .map, .poi, .gpx, or .rd5 files from the phone.",
+                            "Tap 2. Select file(s) to add .map, .poi, .gpx, .rd5, or DEM .hgt files from the phone.",
                         ),
                 ),
                 QuickGuidePage(
@@ -335,7 +338,8 @@ internal fun FilePickerQuickGuideDialog(
                     lines =
                         listOf(
                             "Use POI for Refuges / OSM, Routing for BRouter packs.",
-                            "Choose the area from the watch map, a region, or a manual BBox.",
+                            "Use the map picker to select a POI area, or the tile picker for BRouter routing packs.",
+                            "You can also choose a region or enter a manual BBox.",
                             "BBox format: west,south,east,north. Example: 5.50,45.10,6.50,45.60.",
                             "Use Refresh last import to update the same area later without choosing it again.",
                         ),
@@ -407,6 +411,20 @@ internal fun FilePickerQuickGuideDialog(
                         modifier = Modifier.fillMaxWidth(),
                         style = MaterialTheme.typography.titleMedium,
                         textAlign = TextAlign.Start,
+                    )
+                }
+                page.intro?.let { intro ->
+                    Text(
+                        text = intro,
+                        modifier = Modifier.fillMaxWidth(),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign =
+                            if (isWelcomePage) {
+                                TextAlign.Center
+                            } else {
+                                TextAlign.Start
+                            },
                     )
                 }
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -534,6 +552,7 @@ private fun quickGuidePageIndicator(
 
 private data class QuickGuidePage(
     val title: String,
+    val intro: String? = null,
     val lines: List<String>,
 )
 

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.Support.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.Support.kt
@@ -45,11 +45,13 @@ internal data class PhoneStoredFilesSummary(
 internal enum class PoiAreaMethod {
     WATCH_MAP,
     REFUGES_PRESET,
+    MAP_PICKER,
     MANUAL_BBOX,
 }
 
 internal enum class RoutingAreaMethod {
     WATCH_MAP,
+    TILE_PICKER,
     MANUAL_BBOX,
 }
 

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.kt
@@ -592,7 +592,7 @@ fun FilePickerScreen(viewModel: FileTransferViewModel) {
                     Spacer(modifier = Modifier.height(adaptive.sectionGap))
 
                     SectionCard(
-                        title = "2. Select files (.gpx / .map / .poi / .rd5)",
+                        title = "2. Select files (.gpx / .map / .poi / .rd5 / .hgt)",
                         headerAction = {
                             TextButton(
                                 onClick = { viewModel.clearSelectedFiles() },

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/refuges/OsmOverpassPoiImporter.Support.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/refuges/OsmOverpassPoiImporter.Support.kt
@@ -9,7 +9,9 @@ private const val OSM_OVERPASS_TILE_MAX_AREA_DEGREES = 3.0
 private const val OSM_OVERPASS_MIN_SUBDIVIDE_LON_SPAN_DEGREES = 0.10
 private const val OSM_OVERPASS_MIN_SUBDIVIDE_LAT_SPAN_DEGREES = 0.10
 internal const val OSM_OVERPASS_TOO_LARGE_MESSAGE =
-    "OSM Overpass response is too large. Please use a smaller area."
+    "OSM Overpass response is too large. Please use a smaller area or select fewer POI categories."
+internal const val OSM_OVERPASS_PREFLIGHT_WARNING_POI_COUNT = 4_000L
+internal const val OSM_OVERPASS_PREFLIGHT_MAX_POI_COUNT = 10_000L
 private val HTML_TITLE_REGEX = Regex("(?is)<title[^>]*>(.*?)</title>")
 private val OVERPASS_RATE_LIMIT_REGEX = Regex("""Rate limit:\s*(\d+)""", RegexOption.IGNORE_CASE)
 private val OVERPASS_SLOTS_AVAILABLE_REGEX =
@@ -17,6 +19,69 @@ private val OVERPASS_SLOTS_AVAILABLE_REGEX =
 private val OVERPASS_SLOT_WAIT_SECONDS_REGEX =
     Regex("""slot available after.*?(\d+)\s+seconds?""", RegexOption.IGNORE_CASE)
 private val OVERPASS_IN_SECONDS_REGEX = Regex("""in\s+(\d+)\s+seconds?""", RegexOption.IGNORE_CASE)
+private val OVERPASS_COUNT_TYPE_REGEX = Regex(""""type"\s*:\s*"count"""", RegexOption.IGNORE_CASE)
+private val OVERPASS_COUNT_TAG_REGEX =
+    Regex(""""(nodes|ways|relations|total)"\s*:\s*"?(\d+)"?""", RegexOption.IGNORE_CASE)
+
+internal data class OsmOverpassPoiCountEstimate(
+    val nodes: Long,
+    val ways: Long,
+    val relations: Long,
+    val total: Long,
+)
+
+internal fun buildOverpassSelectionClauses(
+    bbox: BBox,
+    selectedCategories: List<OsmPoiImportCategory>,
+): String {
+    val b = "${bbox.minLat},${bbox.minLon},${bbox.maxLat},${bbox.maxLon}"
+    val tagValues = linkedMapOf<String, LinkedHashSet<String>>()
+    selectedCategories.forEach { category ->
+        category.tagValues.forEach { (tagKey, values) ->
+            tagValues.getOrPut(tagKey) { linkedSetOf() }.addAll(values)
+        }
+    }
+    return buildString {
+        tagValues.forEach { (tagKey, values) ->
+            if (values.isEmpty()) return@forEach
+            val escapedKey = escapeOverpassLiteral(tagKey)
+            values.forEach { value ->
+                val escapedValue = escapeOverpassLiteral(value)
+                appendLine("""  node["$escapedKey"="$escapedValue"]($b);""")
+                appendLine("""  way["$escapedKey"="$escapedValue"]($b);""")
+                appendLine("""  relation["$escapedKey"="$escapedValue"]($b);""")
+            }
+            appendLine()
+        }
+    }.trimEnd()
+}
+
+internal fun parseOverpassCountResponse(body: String): OsmOverpassPoiCountEstimate {
+    require(OVERPASS_COUNT_TYPE_REGEX.containsMatchIn(body)) {
+        "Invalid Overpass count response."
+    }
+    val counts =
+        OVERPASS_COUNT_TAG_REGEX
+            .findAll(body)
+            .associate { match ->
+                match.groupValues[1].lowercase() to (match.groupValues[2].toLongOrNull() ?: -1L)
+            }
+    val nodes = counts["nodes"] ?: -1L
+    val ways = counts["ways"] ?: -1L
+    val relations = counts["relations"] ?: -1L
+    val total = counts["total"].takeIf { it != null && it >= 0L } ?: (nodes + ways + relations)
+    return OsmOverpassPoiCountEstimate(
+        nodes = nodes.coerceAtLeast(0L),
+        ways = ways.coerceAtLeast(0L),
+        relations = relations.coerceAtLeast(0L),
+        total = total.coerceAtLeast(0L),
+    )
+}
+
+internal fun escapeOverpassLiteral(value: String): String =
+    value
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
 
 internal fun splitBboxForOverpass(
     bbox: BBox,

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/refuges/OsmOverpassPoiImporter.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/refuges/OsmOverpassPoiImporter.kt
@@ -36,14 +36,17 @@ class OsmOverpassPoiImporter(
         private const val API_ENDPOINT = "https://overpass-api.de/api/interpreter"
         private const val MAX_RESPONSE_BYTES = 8_000_000
         private const val MAX_ERROR_RESPONSE_BYTES = 120_000
+        private const val MAX_COUNT_RESPONSE_BYTES = 48_000
         private const val MAX_STATUS_RESPONSE_BYTES = 24_000
-        private const val MAX_BBOX_AREA_DEGREES = 120.0
-        private const val MAX_LON_SPAN_DEGREES = 20.0
-        private const val MAX_LAT_SPAN_DEGREES = 12.0
+        private const val MAX_BBOX_AREA_DEGREES = 12.0
+        private const val MAX_LON_SPAN_DEGREES = 5.0
+        private const val MAX_LAT_SPAN_DEGREES = 4.0
         private const val CONNECT_TIMEOUT_MS = 20_000
         private const val READ_TIMEOUT_MS = 90_000
+        private const val COUNT_READ_TIMEOUT_MS = 45_000
         private const val STATUS_TIMEOUT_MS = 6_000
         private const val OVERPASS_TIMEOUT_SECONDS = 40
+        private const val OVERPASS_COUNT_TIMEOUT_SECONDS = 25
         private const val OVERPASS_MAXSIZE_BYTES = 64L * 1024L * 1024L
         private const val MAX_REQUEST_ATTEMPTS = 3
         private const val RETRY_BACKOFF_BASE_MS = 1_500L
@@ -82,6 +85,22 @@ class OsmOverpassPoiImporter(
                 )
 
                 reportProgress?.invoke(0, "Preparing OpenStreetMap import…")
+                val estimate =
+                    preflightPoiCount(
+                        bbox = bbox,
+                        selectedCategories = selectedCategories,
+                        reportProgress = reportProgress,
+                    )
+                check(estimate.total != 0L) {
+                    "No OpenStreetMap points found in this area."
+                }
+                require(estimate.total <= OSM_OVERPASS_PREFLIGHT_MAX_POI_COUNT) {
+                    buildPoiCountTooLargeMessage(estimate.total)
+                }
+                reportProgress?.invoke(
+                    8,
+                    buildPoiCountPreflightMessage(estimate.total),
+                )
                 val summary =
                     try {
                         PoiSqliteCodec
@@ -174,7 +193,7 @@ class OsmOverpassPoiImporter(
             "OSM",
             "Plan bbox=${bbox.asRefugesQueryParam()} tileCount=${tiles.size} categories=${selectedCategories.joinToString(",") { it.id }}",
         )
-        val importSegment = ProgressSegment(start = 0.0, end = 92.0)
+        val importSegment = ProgressSegment(start = 8.0, end = 92.0)
         var importedCount = 0
 
         tiles.forEachIndexed { index, tile ->
@@ -211,6 +230,165 @@ class OsmOverpassPoiImporter(
 
         return importedCount
     }
+
+    private suspend fun preflightPoiCount(
+        bbox: BBox,
+        selectedCategories: List<OsmPoiImportCategory>,
+        reportProgress: ((percent: Int, status: String) -> Unit)?,
+    ): OsmOverpassPoiCountEstimate {
+        var lastFailure: Throwable? = null
+        repeat(MAX_REQUEST_ATTEMPTS) { attemptIndex ->
+            currentCoroutineContext().ensureActive()
+            throwIfCancellationRequested()
+            val attempt = attemptIndex + 1
+            try {
+                reportProgress?.invoke(
+                    if (attempt == 1) 2 else 4,
+                    if (attempt == 1) {
+                        "Estimating OpenStreetMap POI count…"
+                    } else {
+                        "Retrying OpenStreetMap POI estimate ($attempt/$MAX_REQUEST_ATTEMPTS)…"
+                    },
+                )
+                return fetchPoiCountOnce(
+                    bbox = bbox,
+                    selectedCategories = selectedCategories,
+                    requestLabel = "count",
+                )
+            } catch (error: Throwable) {
+                lastFailure = error
+                if (error is CancellationException || !shouldRetryRequest(error) || attempt >= MAX_REQUEST_ATTEMPTS) {
+                    throw error
+                }
+                val busyStatus =
+                    if (shouldInspectOverpassStatus(error)) {
+                        fetchOverpassStatusSummary("count")
+                    } else {
+                        null
+                    }
+                delay(resolveRetryDelayMs(attempt, busyStatus))
+            }
+        }
+        error(lastFailure?.localizedMessage ?: "OpenStreetMap POI estimate failed.")
+    }
+
+    private fun fetchPoiCountOnce(
+        bbox: BBox,
+        selectedCategories: List<OsmPoiImportCategory>,
+        requestLabel: String,
+    ): OsmOverpassPoiCountEstimate {
+        throwIfCancellationRequested()
+        val requestStartedAtMs = SystemClock.elapsedRealtime()
+        var completedSuccessfully = false
+        val query = buildOverpassCountQuery(bbox, selectedCategories)
+        val bodyBytes = "data=${encode(query)}".toByteArray(Charsets.UTF_8)
+        val connection = openOverpassPostConnection(readTimeoutMs = COUNT_READ_TIMEOUT_MS)
+        activeConnection = connection
+
+        try {
+            PhoneDownloadDiagnostics.log(
+                "OSM",
+                "count_start bbox=${bbox.asRefugesQueryParam()} bodyBytes=${bodyBytes.size}",
+            )
+            writeOverpassRequestBody(connection, bodyBytes)
+            val code = readOverpassResponseCode(connection, "Timed out waiting for OpenStreetMap POI estimate.")
+            throwIfCancellationRequested()
+            val responseBody = readOverpassResponseBody(connection, code, MAX_COUNT_RESPONSE_BYTES)
+            throwIfOverpassHttpError(code, responseBody)
+
+            val estimate = parseOverpassCountResponse(responseBody)
+            PhoneDownloadDiagnostics.log(
+                "OSM",
+                buildCountCompletedLog(requestLabel, bbox, estimate, requestStartedAtMs),
+            )
+            completedSuccessfully = true
+            return estimate
+        } finally {
+            if (!completedSuccessfully || cancelRequested) {
+                connection.disconnect()
+            }
+            if (activeConnection === connection) {
+                activeConnection = null
+            }
+        }
+    }
+
+    private fun openOverpassPostConnection(readTimeoutMs: Int): HttpURLConnection =
+        (URL(API_ENDPOINT).openConnection() as HttpURLConnection).apply {
+            requestMethod = "POST"
+            doOutput = true
+            connectTimeout = CONNECT_TIMEOUT_MS
+            readTimeout = readTimeoutMs
+            setRequestProperty(
+                "Content-Type",
+                "application/x-www-form-urlencoded; charset=UTF-8",
+            )
+            setRequestProperty("Accept", "application/json")
+            setRequestProperty("User-Agent", "GlanceMap-Companion")
+            setRequestProperty("Connection", "Keep-Alive")
+        }
+
+    private fun writeOverpassRequestBody(
+        connection: HttpURLConnection,
+        bodyBytes: ByteArray,
+    ) {
+        connection.outputStream.use { out ->
+            out.write(bodyBytes)
+            out.flush()
+        }
+    }
+
+    private fun readOverpassResponseCode(
+        connection: HttpURLConnection,
+        timeoutMessage: String,
+    ): Int =
+        try {
+            connection.responseCode
+        } catch (error: SocketTimeoutException) {
+            if (cancelRequested) throw CancellationException("Cancelled by user")
+            throw OverpassHeaderWaitTimeoutException(timeoutMessage, error)
+        } catch (error: IOException) {
+            if (cancelRequested) throw CancellationException("Cancelled by user")
+            throw error
+        }
+
+    private fun readOverpassResponseBody(
+        connection: HttpURLConnection,
+        code: Int,
+        maxSuccessBytes: Int,
+    ): String =
+        try {
+            if (code in 200..299) {
+                readResponseText(connection.inputStream, maxSuccessBytes)
+            } else {
+                readResponseText(connection.errorStream, MAX_ERROR_RESPONSE_BYTES)
+            }
+        } catch (error: IOException) {
+            if (cancelRequested) throw CancellationException("Cancelled by user")
+            throw error
+        }
+
+    private fun throwIfOverpassHttpError(
+        code: Int,
+        responseBody: String,
+    ) {
+        if (code !in 200..299) {
+            throw OverpassHttpException(
+                summarizeOsmOverpassFailure(code, responseBody),
+                code,
+            )
+        }
+    }
+
+    private fun buildCountCompletedLog(
+        requestLabel: String,
+        bbox: BBox,
+        estimate: OsmOverpassPoiCountEstimate,
+        requestStartedAtMs: Long,
+    ): String =
+        "count_complete label=$requestLabel bbox=${bbox.asRefugesQueryParam()} " +
+            "total=${estimate.total} nodes=${estimate.nodes} ways=${estimate.ways} " +
+            "relations=${estimate.relations} durationMs=${SystemClock.elapsedRealtime() - requestStartedAtMs}"
 
     private suspend fun importTileWithAdaptiveSplit(
         tile: BBox,
@@ -768,33 +946,27 @@ class OsmOverpassPoiImporter(
         bbox: BBox,
         selectedCategories: List<OsmPoiImportCategory>,
     ): String {
-        val b = bbox.asOverpassBbox()
-        val tagValues = linkedMapOf<String, LinkedHashSet<String>>()
-        selectedCategories.forEach { category ->
-            category.tagValues.forEach { (tagKey, values) ->
-                tagValues.getOrPut(tagKey) { linkedSetOf() }.addAll(values)
-            }
-        }
-        val clauses =
-            buildString {
-                tagValues.forEach { (tagKey, values) ->
-                    if (values.isEmpty()) return@forEach
-                    val escapedKey = escapeOverpassLiteral(tagKey)
-                    values.forEach { value ->
-                        val escapedValue = escapeOverpassLiteral(value)
-                        appendLine("""  node["$escapedKey"="$escapedValue"]($b);""")
-                        appendLine("""  way["$escapedKey"="$escapedValue"]($b);""")
-                        appendLine("""  relation["$escapedKey"="$escapedValue"]($b);""")
-                    }
-                    appendLine()
-                }
-            }.trimEnd()
+        val clauses = buildOverpassSelectionClauses(bbox, selectedCategories)
         return """
             [out:json][timeout:$OVERPASS_TIMEOUT_SECONDS][maxsize:$OVERPASS_MAXSIZE_BYTES];
             (
             $clauses
             );
             out center tags qt;
+            """.trimIndent()
+    }
+
+    private fun buildOverpassCountQuery(
+        bbox: BBox,
+        selectedCategories: List<OsmPoiImportCategory>,
+    ): String {
+        val clauses = buildOverpassSelectionClauses(bbox, selectedCategories)
+        return """
+            [out:json][timeout:$OVERPASS_COUNT_TIMEOUT_SECONDS][maxsize:$OVERPASS_MAXSIZE_BYTES];
+            (
+            $clauses
+            );
+            out count;
             """.trimIndent()
     }
 
@@ -913,7 +1085,9 @@ class OsmOverpassPoiImporter(
         return false
     }
 
-    private fun buildAdaptiveSplitFailureMessage(areaSuffix: String): String = "OSM Overpass area is still too large or timing out after smaller requests. Please try again later or use a smaller area.$areaSuffix"
+    private fun buildAdaptiveSplitFailureMessage(areaSuffix: String): String =
+        "OSM Overpass area is still too large or timing out after smaller requests. " +
+            "Please try again later, use a smaller area, or select fewer POI categories.$areaSuffix"
 
     private fun buildTileLabel(
         tileIndex: Int,
@@ -985,6 +1159,20 @@ class OsmOverpassPoiImporter(
             "OpenStreetMap data received… ${formatCount(importedCount)} POI"
         }
 
+    private fun buildPoiCountTooLargeMessage(total: Long): String =
+        "About ${formatCount(total)} POIs found. " +
+            "Too many, choose a smaller area or select fewer POI categories."
+
+    private fun buildPoiCountPreflightMessage(total: Long): String {
+        val sizeLabel =
+            if (total > OSM_OVERPASS_PREFLIGHT_WARNING_POI_COUNT) {
+                "Large import, trying anyway."
+            } else {
+                "Importing now."
+            }
+        return "About ${formatCount(total)} POIs found. $sizeLabel"
+    }
+
     private fun resolveDownloadFraction(
         bytesRead: Long,
         expectedBytes: Long,
@@ -1017,7 +1205,9 @@ class OsmOverpassPoiImporter(
         return String.format(Locale.US, "%.1f MB", mib)
     }
 
-    private fun formatCount(value: Int): String = String.format(Locale.US, "%,d", value)
+    private fun formatCount(value: Int): String = formatCount(value.toLong())
+
+    private fun formatCount(value: Long): String = String.format(Locale.US, "%,d", value)
 
     private fun throwIfCancellationRequested() {
         if (cancelRequested) {
@@ -1027,11 +1217,6 @@ class OsmOverpassPoiImporter(
 
     private fun encode(value: String): String = URLEncoder.encode(value, StandardCharsets.UTF_8.toString())
 
-    private fun escapeOverpassLiteral(value: String): String =
-        value
-            .replace("\\", "\\\\")
-            .replace("\"", "\\\"")
-
     private fun overpassStatusEndpoint(): String = API_ENDPOINT.substringBeforeLast('/') + "/status"
 
     private fun summarizeThrowable(error: Throwable): String =
@@ -1039,8 +1224,6 @@ class OsmOverpassPoiImporter(
             ?.trim()
             .orEmpty()
             .ifBlank { error::class.java.simpleName }
-
-    private fun BBox.asOverpassBbox(): String = "$minLat,$minLon,$maxLat,$maxLon"
 
     private fun BBox.asRefugesQueryParam(): String = "$minLon,$minLat,$maxLon,$maxLat"
 

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/WatchWifiStatusChecker.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/WatchWifiStatusChecker.kt
@@ -1,0 +1,78 @@
+package com.glancemap.glancemapcompanionapp.transfer
+
+import android.util.Log
+import com.glancemap.glancemapcompanionapp.diagnostics.PhoneTransferDiagnostics
+import com.glancemap.glancemapcompanionapp.transfer.datalayer.DataLayerPaths
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withTimeoutOrNull
+import org.json.JSONObject
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+internal data class WatchWifiStatus(
+    val wifiAvailable: Boolean,
+    val reason: String,
+)
+
+internal class WatchWifiStatusChecker(
+    private val sendMessage: suspend (nodeId: String, path: String, payload: ByteArray) -> Unit,
+) {
+    private val pendingChecks = ConcurrentHashMap<String, CompletableDeferred<WatchWifiStatus>>()
+
+    suspend fun check(nodeId: String): WatchWifiStatus? {
+        val requestId = UUID.randomUUID().toString()
+        val deferred = CompletableDeferred<WatchWifiStatus>()
+        pendingChecks[requestId] = deferred
+
+        val payload =
+            JSONObject()
+                .put("id", requestId)
+                .toString()
+                .toByteArray(Charsets.UTF_8)
+
+        return try {
+            runCatching {
+                PhoneTransferDiagnostics.log("WatchWifi", "Check requestId=$requestId node=$nodeId")
+                sendMessage(nodeId, DataLayerPaths.PATH_CHECK_WIFI_STATUS, payload)
+                val result = withTimeoutOrNull(CHECK_TIMEOUT_MS) { deferred.await() }
+                if (result == null) {
+                    PhoneTransferDiagnostics.warn("WatchWifi", "Check timeout requestId=$requestId node=$nodeId")
+                }
+                result
+            }.getOrElse { error ->
+                if (error is CancellationException) throw error
+                Log.w(TAG, "Watch Wi-Fi status check failed", error)
+                PhoneTransferDiagnostics.error("WatchWifi", "Check failed requestId=$requestId node=$nodeId", error)
+                null
+            }
+        } finally {
+            pendingChecks.remove(requestId)?.cancel()
+        }
+    }
+
+    fun handleWifiStatusResult(data: ByteArray) {
+        runCatching {
+            val json = JSONObject(String(data, Charsets.UTF_8))
+            val requestId = json.getString("id")
+            val status =
+                WatchWifiStatus(
+                    wifiAvailable = json.optBoolean("wifiAvailable", false),
+                    reason = json.optString("reason", ""),
+                )
+            pendingChecks.remove(requestId)?.complete(status)
+            PhoneTransferDiagnostics.log(
+                "WatchWifi",
+                "Check result requestId=$requestId wifiAvailable=${status.wifiAvailable} reason=${status.reason}",
+            )
+        }.onFailure {
+            Log.w(TAG, "Failed to parse watch Wi-Fi status result", it)
+            PhoneTransferDiagnostics.error("WatchWifi", "Failed to parse status result", it)
+        }
+    }
+
+    private companion object {
+        const val TAG = "WatchWifiStatusChecker"
+        const val CHECK_TIMEOUT_MS = 3_000L
+    }
+}

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/datalayer/DataLayerPaths.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/datalayer/DataLayerPaths.kt
@@ -10,6 +10,8 @@ internal object DataLayerPaths {
     const val PATH_PREPARE_CHANNEL = TransferDataLayerContract.PATH_PREPARE_CHANNEL
     const val PATH_PING = TransferDataLayerContract.PATH_PING
     const val PATH_PING_RESULT = TransferDataLayerContract.PATH_PING_RESULT
+    const val PATH_CHECK_WIFI_STATUS = TransferDataLayerContract.PATH_CHECK_WIFI_STATUS
+    const val PATH_CHECK_WIFI_STATUS_RESULT = TransferDataLayerContract.PATH_CHECK_WIFI_STATUS_RESULT
     const val PATH_DIAGNOSTICS_EMAIL_REQUEST = TransferDataLayerContract.PATH_DIAGNOSTICS_EMAIL_REQUEST
     const val PATH_TRANSFER_ACK = TransferDataLayerContract.PATH_TRANSFER_ACK
     const val PATH_TRANSFER_STATUS = TransferDataLayerContract.PATH_TRANSFER_STATUS

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/datalayer/PhoneDataLayerEvent.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/datalayer/PhoneDataLayerEvent.kt
@@ -13,6 +13,10 @@ internal sealed interface PhoneDataLayerEvent {
         val payload: ByteArray,
     ) : PhoneDataLayerEvent
 
+    data class WifiStatusResult(
+        val payload: ByteArray,
+    ) : PhoneDataLayerEvent
+
     data class ExistsResult(
         val payload: ByteArray,
     ) : PhoneDataLayerEvent

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/datalayer/PhoneDataLayerRepository.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/datalayer/PhoneDataLayerRepository.kt
@@ -48,6 +48,7 @@ internal class PhoneDataLayerRepository(
                     DataLayerPaths.PATH_TRANSFER_STATUS -> PhoneDataLayerEvent.TransferStatus(event.data)
                     DataLayerPaths.PATH_TRANSFER_ACK -> PhoneDataLayerEvent.TransferAck(event.data)
                     DataLayerPaths.PATH_PING_RESULT -> PhoneDataLayerEvent.PingResult(event.data)
+                    DataLayerPaths.PATH_CHECK_WIFI_STATUS_RESULT -> PhoneDataLayerEvent.WifiStatusResult(event.data)
                     DataLayerPaths.PATH_CHECK_EXISTS_RESULT -> PhoneDataLayerEvent.ExistsResult(event.data)
                     DataLayerPaths.PATH_CHECK_EXISTS_BATCH_RESULT -> PhoneDataLayerEvent.BatchExistsResult(event.data)
                     DataLayerPaths.PATH_DELETE_FILE_RESULT -> PhoneDataLayerEvent.DeleteFileResult(event.data)

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/service/FileTransferService.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/service/FileTransferService.kt
@@ -18,6 +18,7 @@ import com.glancemap.glancemapcompanionapp.transfer.FileExistenceChecker
 import com.glancemap.glancemapcompanionapp.transfer.TransferStrategyFactory
 import com.glancemap.glancemapcompanionapp.transfer.WatchFileDeleteRequester
 import com.glancemap.glancemapcompanionapp.transfer.WatchInstalledMapsRequester
+import com.glancemap.glancemapcompanionapp.transfer.WatchWifiStatusChecker
 import com.glancemap.glancemapcompanionapp.transfer.datalayer.PhoneDataLayerEvent
 import com.glancemap.glancemapcompanionapp.transfer.datalayer.PhoneDataLayerRepository
 import com.glancemap.glancemapcompanionapp.transfer.service.internal.AckRegistry
@@ -49,6 +50,7 @@ class FileTransferService : LifecycleService() {
     private lateinit var notificationHelper: NotificationHelper
     private lateinit var existenceChecker: FileExistenceChecker
     private lateinit var deleteRequester: WatchFileDeleteRequester
+    private lateinit var wifiStatusChecker: WatchWifiStatusChecker
     private lateinit var installedMapsRequester: WatchInstalledMapsRequester
 
     private val powerManager by lazy { getSystemService(POWER_SERVICE) as PowerManager }
@@ -78,18 +80,7 @@ class FileTransferService : LifecycleService() {
 
         notificationHelper = NotificationHelper(this).apply { createNotificationChannel() }
         dataLayerRepository = PhoneDataLayerRepository(this)
-        existenceChecker =
-            FileExistenceChecker { nodeId, path, payload ->
-                dataLayerRepository.sendMessage(nodeId, path, payload)
-            }
-        deleteRequester =
-            WatchFileDeleteRequester { nodeId, path, payload ->
-                dataLayerRepository.sendMessage(nodeId, path, payload)
-            }
-        installedMapsRequester =
-            WatchInstalledMapsRequester { nodeId, path, payload ->
-                dataLayerRepository.sendMessage(nodeId, path, payload)
-            }
+        configureTransferRequesters()
 
         ackRegistry = AckRegistry()
         historyStore = HistoryStore(this, _uiState)
@@ -104,6 +95,7 @@ class FileTransferService : LifecycleService() {
                 wifiManager = wifiManager,
                 existenceChecker = existenceChecker,
                 deleteRequester = deleteRequester,
+                wifiStatusChecker = wifiStatusChecker,
                 ackRegistry = ackRegistry,
                 uiUpdater = uiUpdater,
                 cancelTransferOnWatch = { nodeId, transferId ->
@@ -133,6 +125,25 @@ class FileTransferService : LifecycleService() {
 
         historyStore.load()
         observeDataLayer()
+    }
+
+    private fun configureTransferRequesters() {
+        existenceChecker =
+            FileExistenceChecker { nodeId, path, payload ->
+                dataLayerRepository.sendMessage(nodeId, path, payload)
+            }
+        deleteRequester =
+            WatchFileDeleteRequester { nodeId, path, payload ->
+                dataLayerRepository.sendMessage(nodeId, path, payload)
+            }
+        wifiStatusChecker =
+            WatchWifiStatusChecker { nodeId, path, payload ->
+                dataLayerRepository.sendMessage(nodeId, path, payload)
+            }
+        installedMapsRequester =
+            WatchInstalledMapsRequester { nodeId, path, payload ->
+                dataLayerRepository.sendMessage(nodeId, path, payload)
+            }
     }
 
     override fun onDestroy() {
@@ -535,6 +546,8 @@ class FileTransferService : LifecycleService() {
                                 ackRegistry.handleAck(event.payload)
                             }
                             is PhoneDataLayerEvent.PingResult -> existenceChecker.handlePingResult(event.payload)
+                            is PhoneDataLayerEvent.WifiStatusResult ->
+                                wifiStatusChecker.handleWifiStatusResult(event.payload)
                             is PhoneDataLayerEvent.ExistsResult -> existenceChecker.handleExistsResult(event.payload)
                             is PhoneDataLayerEvent.BatchExistsResult -> existenceChecker.handleBatchExistsResult(event.payload)
                             is PhoneDataLayerEvent.DeleteFileResult -> deleteRequester.handleDeleteResult(event.payload)

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/service/internal/BatchTransferRunner.Support.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/service/internal/BatchTransferRunner.Support.kt
@@ -42,6 +42,7 @@ internal fun shouldPreferChannelForRemainingBatch(result: TransferResult): Boole
     val msg = result.message.lowercase()
     return isLikelyDifferentSubnetHttpFailure(result.message) ||
         msg.contains("no wi-fi network available") ||
+        msg.contains(HttpTransferServer.RESULT_HTTP_NO_FIRST_REQUEST_PREFIX.lowercase()) ||
         isExplicitPhoneHttpUnreachableFailure(result.message)
 }
 
@@ -188,12 +189,18 @@ internal fun toUserFacingTransferError(result: TransferResult): String {
         normalized.contains(HttpTransferServer.RESULT_HTTP_RECONNECT_TIMEOUT_PREFIX.lowercase()) ->
             "The watch did not reconnect in time."
 
+        normalized.contains(HttpTransferServer.RESULT_HTTP_NO_FIRST_REQUEST_PREFIX.lowercase()) ->
+            "The watch did not connect to the phone HTTP server. Check watch Wi-Fi or phone hotspot."
+
         else ->
             result.message
     }
 }
 
-internal fun isSupportedTransferFileName(fileName: String): Boolean = fileName.endsWith(".gpx", ignoreCase = true) || isMapLikeTransferFile(fileName)
+internal fun isSupportedTransferFileName(fileName: String): Boolean =
+    fileName.endsWith(".gpx", ignoreCase = true) ||
+        isMapLikeTransferFile(fileName) ||
+        isDemTransferFile(fileName)
 
 internal fun isReplaceableTransferFileName(fileName: String): Boolean = fileName.endsWith(".rd5", ignoreCase = true)
 
@@ -201,3 +208,8 @@ internal fun isMapLikeTransferFile(fileName: String): Boolean =
     fileName.endsWith(".map", ignoreCase = true) ||
         fileName.endsWith(".poi", ignoreCase = true) ||
         fileName.endsWith(".rd5", ignoreCase = true)
+
+internal fun isDemTransferFile(fileName: String): Boolean {
+    val lower = fileName.lowercase()
+    return lower.endsWith(".hgt") || lower.endsWith(".hgt.zip")
+}

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/service/internal/BatchTransferRunner.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/service/internal/BatchTransferRunner.kt
@@ -15,6 +15,8 @@ import com.glancemap.glancemapcompanionapp.transfer.FileExistenceChecker
 import com.glancemap.glancemapcompanionapp.transfer.TransferStrategyFactory
 import com.glancemap.glancemapcompanionapp.transfer.TransferStrategyKind
 import com.glancemap.glancemapcompanionapp.transfer.WatchFileDeleteRequester
+import com.glancemap.glancemapcompanionapp.transfer.WatchWifiStatus
+import com.glancemap.glancemapcompanionapp.transfer.WatchWifiStatusChecker
 import com.glancemap.glancemapcompanionapp.transfer.strategy.ChannelClientStrategy
 import com.glancemap.glancemapcompanionapp.transfer.strategy.HttpTransferServer
 import com.glancemap.glancemapcompanionapp.transfer.strategy.TransferMetadata
@@ -31,6 +33,7 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 
+@Suppress("LongParameterList")
 internal class BatchTransferRunner(
     private val context: Context,
     private val uiState: MutableStateFlow<FileTransferUiState>,
@@ -39,6 +42,7 @@ internal class BatchTransferRunner(
     private val wifiManager: WifiManager,
     private val existenceChecker: FileExistenceChecker,
     private val deleteRequester: WatchFileDeleteRequester,
+    private val wifiStatusChecker: WatchWifiStatusChecker,
     private val ackRegistry: AckRegistry,
     private val uiUpdater: UiProgressUpdater,
     private val cancelTransferOnWatch: suspend (nodeId: String, transferId: String) -> Unit,
@@ -86,7 +90,7 @@ internal class BatchTransferRunner(
         val first = supportedItems.firstOrNull()
 
         if (first == null) {
-            clearSelectedFiles(statusMessage = "No compatible files selected (.gpx, .map, .poi, .rd5).")
+            clearSelectedFiles(statusMessage = "No compatible files selected (.gpx, .map, .poi, .rd5, .hgt).")
             return
         }
 
@@ -223,11 +227,56 @@ internal class BatchTransferRunner(
             uiUpdater.update(0f, "Skipped ${conflicts.size} file(s) already on watch. Transferring ${itemsToTransfer.size}…")
         }
 
-        val selectionContext =
+        var selectionContext =
             strategyFactory.buildSelectionContext(
                 context = context,
                 totalSizesBytes = itemsToTransfer.map { it.size },
             )
+        var watchWifiStatus: WatchWifiStatus? = null
+        val initialTransferPlans =
+            itemsToTransfer.map { item ->
+                PlannedTransfer(
+                    item = item,
+                    strategyKind = strategyFactory.decide(item.size, selectionContext),
+                )
+            }
+
+        if (
+            selectionContext.wifiAvailable &&
+            initialTransferPlans.any { TransferStrategyFactory.usesWifi(it.strategyKind) }
+        ) {
+            uiUpdater.update(0f, "Checking watch Wi-Fi…")
+            watchWifiStatus = wifiStatusChecker.check(targetNode.id)
+            when {
+                watchWifiStatus == null -> {
+                    PhoneTransferDiagnostics.warn(
+                        "Batch",
+                        "Watch Wi-Fi preflight unavailable; keeping HTTP eligible",
+                    )
+                }
+
+                !watchWifiStatus.wifiAvailable -> {
+                    PhoneTransferDiagnostics.warn(
+                        "Batch",
+                        "Watch Wi-Fi unavailable reason=${watchWifiStatus.reason}; disabling HTTP for this batch",
+                    )
+                    selectionContext =
+                        selectionContext.copy(
+                            wifiAvailable = false,
+                            preferSharedHttpForBatch = false,
+                        )
+                    uiUpdater.update(0f, "Watch Wi-Fi is off. Using Bluetooth when possible…")
+                }
+
+                else -> {
+                    PhoneTransferDiagnostics.log(
+                        "Batch",
+                        "Watch Wi-Fi preflight ok reason=${watchWifiStatus.reason}",
+                    )
+                }
+            }
+        }
+
         val transferPlans =
             itemsToTransfer.map { item ->
                 PlannedTransfer(
@@ -271,11 +320,12 @@ internal class BatchTransferRunner(
             if (anyRequiresWifi) wifiLock.acquire()
 
             if (anyRequiresWifi) {
+                if (!selectionContext.wifiAvailable) {
+                    throw IllegalStateException(wifiRequiredMessage(watchWifiStatus))
+                }
                 val ip = TransferUtils.getWifiIpAddress(context)
                 if (ip.isNullOrBlank()) {
-                    throw IllegalStateException(
-                        "Wi-Fi required for this transfer batch. Connect the watch to the same Wi-Fi or to this phone’s hotspot.",
-                    )
+                    throw IllegalStateException(wifiRequiredMessage(watchWifiStatus))
                 }
             }
 
@@ -991,6 +1041,7 @@ internal class BatchTransferRunner(
         if (msg.contains("checksum_mismatch")) return false
         if (msg.contains("unauthorized")) return false
         if (msg.contains(HttpTransferServer.RESULT_HTTP_PAUSED_PREFIX.lowercase())) return false
+        if (msg.contains(HttpTransferServer.RESULT_HTTP_NO_FIRST_REQUEST_PREFIX.lowercase())) return false
         if (msg.contains("cancelled")) return false
 
         return msg.contains(HttpTransferServer.RESULT_HTTP_STALLED_PREFIX.lowercase()) ||
@@ -1048,6 +1099,14 @@ internal class BatchTransferRunner(
         val authority = item.uri.authority.orEmpty()
         return authority == "${context.packageName}.fileprovider"
     }
+
+    private fun wifiRequiredMessage(watchWifiStatus: WatchWifiStatus?): String =
+        if (watchWifiStatus?.wifiAvailable == false) {
+            "Watch Wi-Fi is off. Files over 50 MB require Wi-Fi on the watch, " +
+                "or connect the watch to this phone’s hotspot."
+        } else {
+            "Wi-Fi required for this transfer batch. Connect the watch to the same Wi-Fi or to this phone’s hotspot."
+        }
 
     private companion object {
         const val TAG = "BatchTransferRunner"

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/strategy/HttpTransferServer.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/strategy/HttpTransferServer.kt
@@ -58,10 +58,12 @@ class HttpTransferServer :
         const val RESULT_HTTP_STALLED_PREFIX = "HTTP_STALLED_RETRY:"
         const val RESULT_HTTP_SLOW_PREFIX = "HTTP_SLOW_RETRY:"
         const val RESULT_HTTP_RECONNECT_TIMEOUT_PREFIX = "HTTP_RECONNECT_TIMEOUT:"
+        const val RESULT_HTTP_NO_FIRST_REQUEST_PREFIX = "HTTP_NO_REQUEST:"
 
         private const val DEFAULT_BUFFER_SIZE = 2 * 1024 * 1024
         private const val MAP_BUFFER_SIZE = 4 * 1024 * 1024
         private const val ACK_TIMEOUT_MS = 45 * 60 * 1000L
+        private const val FIRST_REQUEST_TIMEOUT_MS = 15_000L
 
         private const val SERVER_READY_TIMEOUT_MS = 5_000L
         private const val SERVER_READY_POLL_DELAY_MS = 100L
@@ -200,7 +202,7 @@ class HttpTransferServer :
                 val firstRequestStartMs = SystemClock.elapsedRealtime()
                 var ackBeforeFirstRequest: TransferResult? = null
                 val firstRequestHit =
-                    withTimeoutOrNull(15_000L) {
+                    withTimeoutOrNull(FIRST_REQUEST_TIMEOUT_MS) {
                         select<Boolean> {
                             firstRequest.onAwait {
                                 true
@@ -217,14 +219,23 @@ class HttpTransferServer :
                     }
                 val firstRequestMs = SystemClock.elapsedRealtime() - firstRequestStartMs
                 if (firstRequestHit == null) {
+                    val detail =
+                        "Watch did not connect to phone HTTP server within ${FIRST_REQUEST_TIMEOUT_MS / 1000}s. " +
+                            "Check watch Wi-Fi or phone hotspot."
                     Log.w(
                         TAG,
-                        "Watch did not hit server within 15s file=${metadata.displayFileName} " +
+                        "Watch did not hit server within ${FIRST_REQUEST_TIMEOUT_MS / 1000}s " +
+                            "file=${metadata.displayFileName} " +
                             "node=$targetNodeId ip=$ipAddress port=$port path=$downloadPath",
                     )
                     PhoneTransferDiagnostics.warn(
                         "Http",
-                        "Watch did not hit server within 15s file=${metadata.displayFileName} node=$targetNodeId",
+                        "Watch did not hit server within ${FIRST_REQUEST_TIMEOUT_MS / 1000}s " +
+                            "file=${metadata.displayFileName} node=$targetNodeId",
+                    )
+                    return@withContext TransferResult(
+                        success = false,
+                        message = "$RESULT_HTTP_NO_FIRST_REQUEST_PREFIX detail=$detail",
                     )
                 }
 

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/util/TransferUtils.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/transfer/util/TransferUtils.kt
@@ -364,6 +364,7 @@ object TransferUtils {
             for (iface in ifaces) {
                 if (!iface.isUp || iface.isLoopback) continue
                 val ifName = iface.name ?: continue
+                if (!isLocalPeerInterfaceName(ifName)) continue
 
                 val addrs = iface.inetAddresses ?: continue
                 for (addr in addrs) {
@@ -448,6 +449,15 @@ object TransferUtils {
     private fun isHotspotInterfaceName(ifName: String): Boolean {
         val normalized = ifName.lowercase(Locale.ROOT)
         return normalized.contains("ap") || normalized.contains("softap")
+    }
+
+    internal fun isLocalPeerInterfaceName(ifName: String): Boolean {
+        val normalized = ifName.lowercase(Locale.ROOT)
+        return isWifiInterfaceName(normalized) ||
+            isHotspotInterfaceName(normalized) ||
+            normalized.contains("rndis") ||
+            normalized.contains("usb") ||
+            normalized.contains("eth")
     }
 
     private fun isPrivateIpv4(ip: String): Boolean {

--- a/glancemapcompanionapp/src/main/res/drawable/ic_drag_pan.xml
+++ b/glancemapcompanionapp/src/main/res/drawable/ic_drag_pan.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="#0B7285"
+            android:pathData="M480,-80L310,-250L367,-307L440,-234L440,-440L235,-440L308,-368L250,-310L80,-480L249,-649L306,-592L234,-520L440,-520L440,-726L367,-653L310,-710L480,-880L650,-710L593,-653L520,-726L520,-520L725,-520L652,-592L710,-650L880,-480L710,-310L653,-367L726,-440L520,-440L520,-235L592,-308L650,-250L480,-80Z" />
+    </group>
+</vector>

--- a/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/FileTransferViewModelUriSupportTest.kt
+++ b/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/FileTransferViewModelUriSupportTest.kt
@@ -1,0 +1,16 @@
+package com.glancemap.glancemapcompanionapp
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FileTransferViewModelUriSupportTest {
+    @Test
+    fun `recognizes geojson file names`() {
+        assertTrue(isGeoJsonFileName("refuges.geojson"))
+        assertTrue(isGeoJsonFileName("refuges.geo.json"))
+        assertTrue(isGeoJsonFileName("REFUGES.GEOJSON"))
+        assertFalse(isGeoJsonFileName("refuges.json"))
+        assertFalse(isGeoJsonFileName("refuges.gpx"))
+    }
+}

--- a/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/refuges/OsmOverpassPoiImporterSupportTest.kt
+++ b/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/refuges/OsmOverpassPoiImporterSupportTest.kt
@@ -126,6 +126,64 @@ class OsmOverpassPoiImporterSupportTest {
     }
 
     @Test
+    fun `too large overpass message suggests area and category fixes`() {
+        assertTrue(OSM_OVERPASS_TOO_LARGE_MESSAGE.contains("smaller area"))
+        assertTrue(OSM_OVERPASS_TOO_LARGE_MESSAGE.contains("fewer POI categories"))
+    }
+
+    @Test
+    fun `osm count preflight warns before it blocks`() {
+        assertEquals(4_000L, OSM_OVERPASS_PREFLIGHT_WARNING_POI_COUNT)
+        assertEquals(10_000L, OSM_OVERPASS_PREFLIGHT_MAX_POI_COUNT)
+        assertTrue(OSM_OVERPASS_PREFLIGHT_WARNING_POI_COUNT < OSM_OVERPASS_PREFLIGHT_MAX_POI_COUNT)
+    }
+
+    @Test
+    fun `parses overpass count response`() {
+        val body =
+            """
+            {
+              "elements": [
+                {
+                  "type": "count",
+                  "tags": {
+                    "nodes": "320",
+                    "ways": "12",
+                    "relations": "1",
+                    "total": "333"
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+
+        val estimate = parseOverpassCountResponse(body)
+
+        assertEquals(320L, estimate.nodes)
+        assertEquals(12L, estimate.ways)
+        assertEquals(1L, estimate.relations)
+        assertEquals(333L, estimate.total)
+    }
+
+    @Test
+    fun `builds overpass clauses from selected osm categories`() {
+        val bbox =
+            BBox(
+                minLon = 6.0,
+                minLat = 45.0,
+                maxLon = 6.8,
+                maxLat = 45.7,
+            )
+        val categories = resolveOsmPoiImportCategories(linkedSetOf("huts", "water"))
+
+        val clauses = buildOverpassSelectionClauses(bbox, categories)
+
+        assertTrue(clauses.contains("""node["tourism"="alpine_hut"](45.0,6.0,45.7,6.8);"""))
+        assertTrue(clauses.contains("""way["amenity"="shelter"](45.0,6.0,45.7,6.8);"""))
+        assertTrue(clauses.contains("""relation["natural"="spring"](45.0,6.0,45.7,6.8);"""))
+    }
+
+    @Test
     fun `default osm categories keep mountain essentials selected`() {
         val defaultIds = defaultOsmPoiCategoryIds()
 

--- a/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/transfer/service/internal/BatchTransferRunnerSupportTest.kt
+++ b/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/transfer/service/internal/BatchTransferRunnerSupportTest.kt
@@ -116,9 +116,43 @@ class BatchTransferRunnerSupportTest {
     }
 
     @Test
+    fun `poisons remaining batch when watch never connects to http server`() {
+        val result =
+            TransferResult(
+                success = false,
+                message = "${HttpTransferServer.RESULT_HTTP_NO_FIRST_REQUEST_PREFIX} detail=Watch did not connect",
+            )
+
+        assertTrue(shouldPreferChannelForRemainingBatch(result))
+        assertTrue(
+            shouldFallbackToChannel(
+                strategy = HttpTransferServer(),
+                fileSize = TransferStrategyFactory.CHANNEL_FALLBACK_MAX_BYTES,
+                result = result,
+            ),
+        )
+        assertFalse(
+            shouldFallbackToChannel(
+                strategy = HttpTransferServer(),
+                fileSize = TransferStrategyFactory.CHANNEL_FALLBACK_MAX_BYTES + 1L,
+                result = result,
+            ),
+        )
+    }
+
+    @Test
     fun `routing packs are replaceable transfer targets`() {
         assertTrue(isReplaceableTransferFileName("E5_N45.rd5"))
         assertFalse(isReplaceableTransferFileName("Alps.map"))
         assertFalse(isReplaceableTransferFileName("track.gpx"))
+    }
+
+    @Test
+    fun `supports watch dem tile file names on companion`() {
+        assertTrue(isSupportedTransferFileName("N45E006.hgt"))
+        assertTrue(isSupportedTransferFileName("N45E006.hgt.zip"))
+        assertTrue(isDemTransferFile("s01w002.HGT.ZIP"))
+        assertFalse(isMapLikeTransferFile("N45E006.hgt.zip"))
+        assertFalse(isSupportedTransferFileName("N45E006.zip"))
     }
 }

--- a/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/transfer/util/TransferUtilsLocalIpCandidateTest.kt
+++ b/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/transfer/util/TransferUtilsLocalIpCandidateTest.kt
@@ -1,6 +1,7 @@
 package com.glancemap.glancemapcompanionapp.transfer.util
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -45,5 +46,14 @@ class TransferUtilsLocalIpCandidateTest {
         val hotspotScore = TransferUtils.scoreLocalIpCandidate("ap0", "192.168.43.1")
 
         assertTrue(wifiScore > hotspotScore)
+    }
+
+    @Test
+    fun `local http interface filter rejects cellular style interfaces`() {
+        assertTrue(TransferUtils.isLocalPeerInterfaceName("wlan0"))
+        assertTrue(TransferUtils.isLocalPeerInterfaceName("softap0"))
+        assertTrue(TransferUtils.isLocalPeerInterfaceName("rndis0"))
+        assertFalse(TransferUtils.isLocalPeerInterfaceName("rmnet_data0"))
+        assertFalse(TransferUtils.isLocalPeerInterfaceName("ccmni0"))
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ activityCompose = "1.13.0"
 coreSplashscreen = "1.2.0"
 playServicesLocation = "21.3.0"
 mapsforge = "0.28.0"
+maplibre = "13.1.0"
 wearCompose = "1.6.1"
 navigationCompose = "2.9.8"
 lifecycleViewmodelCompose = "2.10.0"
@@ -70,6 +71,7 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 mapsforge-map = { module = "com.github.mapsforge.mapsforge:mapsforge-map", version.ref = "mapsforge" }
 mapsforge-map-android = { module = "com.github.mapsforge.mapsforge:mapsforge-map-android", version.ref = "mapsforge" }
 mapsforge-themes = { module = "com.github.mapsforge.mapsforge:mapsforge-themes", version.ref = "mapsforge" }
+maplibre-android = { module = "org.maplibre.gl:android-sdk", version.ref = "maplibre" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist" }
 

--- a/licenses/COMPLIANCE_STATUS.md
+++ b/licenses/COMPLIANCE_STATUS.md
@@ -1,6 +1,6 @@
 # Compliance Status
 
-Last reviewed: 2026-04-29
+Last reviewed: 2026-05-06
 
 Status legend:
 - `DONE`: implemented and verified.

--- a/licenses/CREDITS_AND_THANKS.md
+++ b/licenses/CREDITS_AND_THANKS.md
@@ -1,6 +1,6 @@
 # Credits and Thanks
 
-Last reviewed: 2026-04-29
+Last reviewed: 2026-05-06
 
 This page is the user-friendly credit summary for the main projects and communities used by GlanceMap.
 
@@ -53,11 +53,15 @@ This page is the user-friendly credit summary for the main projects and communit
    - Core offline map rendering stack in the watch app.
    - Project: https://github.com/mapsforge/mapsforge
 
-12. BRouter (Arndt Brenschede and contributors)
+12. MapLibre Native
+   - Native online map picker used by the companion app for area and routing-tile selection.
+   - Project: https://github.com/maplibre/maplibre-native
+
+13. BRouter (Arndt Brenschede and contributors)
    - Offline routing engine used by the watch app, with routing packs downloaded by the companion app.
    - Project: https://github.com/abrensch/brouter
 
-13. Mapbox Maki icons
+14. Mapbox Maki icons
    - Build-time POI icon source.
    - Project: https://github.com/mapbox/maki
 

--- a/licenses/PRIVACY_POLICY.md
+++ b/licenses/PRIVACY_POLICY.md
@@ -48,7 +48,7 @@ Data may leave your device in the following situations:
 
 ### 1. User-requested downloads from third-party data providers
 
-When you request online POI, routing, elevation, or similar data, the app sends the information needed to fulfill that request to the selected provider, such as a user-selected geographic area (bounding box), requested tile names, or requested files.
+When you request online POI, routing, elevation, map-picker previews, or similar data, the app sends the information needed to fulfill that request to the selected provider, such as a user-selected geographic area (bounding box), requested routing tile names, map display tile coordinates, or requested files.
 
 As with normal internet requests, those providers may also receive standard request metadata such as your IP address, request time, and user-agent or similar connection information.
 
@@ -56,6 +56,7 @@ Providers used by the current app configuration include:
 
 - `refuges.info`
 - `overpass-api.de`
+- `tile.openstreetmap.org`
 - `brouter.de`
 - `download.mapsforge.org`
 

--- a/licenses/RUNTIME_DEPENDENCIES_RESOLVED.txt
+++ b/licenses/RUNTIME_DEPENDENCIES_RESOLVED.txt
@@ -224,4 +224,8 @@ org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.3
 org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3
 org.jetbrains:annotations:23.0.0
 org.jspecify:jspecify:1.0.0
+org.maplibre.gl:android-sdk-geojson:6.0.1
+org.maplibre.gl:android-sdk-turf:6.0.1
+org.maplibre.gl:android-sdk:13.1.0
+org.maplibre.gl:maplibre-android-gestures:0.0.4
 org.slf4j:slf4j-api:2.0.17

--- a/licenses/SERVICE_TERMS_AND_API_USAGE.md
+++ b/licenses/SERVICE_TERMS_AND_API_USAGE.md
@@ -1,6 +1,6 @@
 # Service Terms and API Usage
 
-Last reviewed: 2026-04-29
+Last reviewed: 2026-05-06
 
 This document captures non-library legal/usage constraints for external services and providers referenced by the app/build pipeline.
 
@@ -87,15 +87,20 @@ Term notes:
 
 Used for:
 - OSM attribution in app.
+- Companion map picker background raster tiles:
+  - `https://tile.openstreetmap.org/{z}/{x}/{y}.png`
 - OSM POI enrichment via Overpass API endpoint:
   - `https://overpass-api.de/api/interpreter`
 
 References:
 - OSM copyright and attribution: https://www.openstreetmap.org/copyright
+- OSM tile usage policy: https://operations.osmfoundation.org/policies/tiles/
 - ODbL: https://opendatacommons.org/licenses/odbl/1-0/
 - Overpass API documentation: https://wiki.openstreetmap.org/wiki/Overpass_API
 
 Usage policy note:
+- OSM tile usage must remain normal interactive viewing only. Do not add tile prefetching, bulk download, or offline tile caching features against `tile.openstreetmap.org`.
+- OSM tiles require visible attribution, the official HTTPS tile URL, a clear app User-Agent, and HTTP caching behavior that respects server cache headers.
 - Overpass public-instance guidance indicates conservative safe usage around:
   - less than 10,000 queries/day
   - less than 1 GB downloaded/day

--- a/licenses/THIRD_PARTY_NOTICES.md
+++ b/licenses/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Third-Party Notices (Open Source)
 
-Last reviewed: 2026-03-20
+Last reviewed: 2026-05-06
 
 This document covers open-source software and assets used by the watch app (`app`) and companion app (`glancemapcompanionapp`).
 
@@ -19,6 +19,7 @@ This document covers open-source software and assets used by the watch app (`app
 | Horologist | `com.google.android.horologist:*` | Apache License 2.0 | https://github.com/google/horologist |
 | AndroidSVG | `com.caverock:androidsvg` | Apache License 2.0 | https://github.com/BigBadaboom/androidsvg |
 | Mapsforge | `com.github.mapsforge.mapsforge:*` (`mapsforge-map`, `mapsforge-map-android`, `mapsforge-themes`, etc.) | LGPL-3.0-or-later (with Mapsforge stated static-linking/derivative waiver in project README) | https://github.com/mapsforge/mapsforge |
+| MapLibre Native Android | `org.maplibre.gl:*` (`android-sdk`, `android-sdk-geojson`, `android-sdk-turf`, `maplibre-android-gestures`) | BSD 2-Clause License | https://github.com/maplibre/maplibre-native |
 | BRouter | Vendored modules `:brouter-core`, `:brouter-codec`, `:brouter-expressions`, `:brouter-mapaccess`, `:brouter-util` from `third_party/brouter/*` | MIT License | https://github.com/abrensch/brouter |
 | kXML2 | `net.sf.kxml:kxml2` | BSD-style / very permissive (per project and POM metadata) | https://kobjects.org/kxml/ |
 | Maki icons (build-time downloaded POI icons) | SVG icon set from Mapbox Maki | CC0 1.0 Universal | https://github.com/mapbox/maki |
@@ -42,4 +43,5 @@ This file helps internal review of transitive dependencies beyond the main famil
 
 - Keep Apache-2.0 attributions and license references available in distributed app documentation.
 - For Mapsforge (LGPL family), keep notices and review obligations for your distribution model.
+- For MapLibre Native (BSD 2-Clause), keep the copyright/license notice available with binary distribution documentation.
 - Re-check upstream license changes when upgrading dependency versions.

--- a/transfercontract/src/main/kotlin/com/glancemap/shared/transfer/TransferDataLayerContract.kt
+++ b/transfercontract/src/main/kotlin/com/glancemap/shared/transfer/TransferDataLayerContract.kt
@@ -12,6 +12,8 @@ object TransferDataLayerContract {
     const val PATH_PREPARE_CHANNEL = "/glancemap/prepare_channel"
     const val PATH_PING = "/glancemap/ping"
     const val PATH_PING_RESULT = "/glancemap/ping_result"
+    const val PATH_CHECK_WIFI_STATUS = "/glancemap/check_wifi_status"
+    const val PATH_CHECK_WIFI_STATUS_RESULT = "/glancemap/check_wifi_status_result"
     const val PATH_DIAGNOSTICS_EMAIL_REQUEST = "/glancemap/diagnostics_email_request"
 
     const val PATH_CHECK_EXISTS = "/glancemap/check_exists"


### PR DESCRIPTION
## Summary
- Improve companion file transfer behavior and watch Wi-Fi/HTTP fallback handling.
- Add MapLibre-based POI area and BRouter routing tile pickers with location centering, resize/move controls, zoom buttons, and clearer picker guidance.
- Add OSM Overpass preflight count handling, tighter area guards, clearer failure messages, and related tests.
- Update quick guide copy and MapLibre/OpenStreetMap licensing/privacy documentation.

## Validation
- `./gradlew :glancemapcompanionapp:compileDebugKotlin --no-daemon --console=plain`
- `./gradlew :glancemapcompanionapp:testDebugUnitTest --tests com.glancemap.glancemapcompanionapp.refuges.OsmOverpassPoiImporterSupportTest --no-daemon --console=plain`
- `./gradlew :glancemapcompanionapp:detekt --no-daemon --console=plain`
- `git diff --check`