### PR TITLE
Fix Wi-Fi availability detekt issue

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/core/service/transfer/datalayer/DataLayerMessageRequestHandler.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/core/service/transfer/datalayer/DataLayerMessageRequestHandler.kt
@@ -1,6 +1,7 @@
 package com.glancemap.glancemapwearos.core.service.transfer.datalayer
 
 import android.net.ConnectivityManager
+import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.Uri
 import android.util.Log
@@ -16,6 +17,15 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import org.json.JSONObject
 import java.util.concurrent.ConcurrentHashMap
+
+private fun ConnectivityManager.hasWifiTransport(network: Network?): Boolean =
+    network
+        ?.let { getNetworkCapabilities(it) }
+        ?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+
+private val ConnectivityManager.hasAvailableWifiNetwork: Boolean
+    @Suppress("DEPRECATION")
+    get() = allNetworks.any { network -> hasWifiTransport(network) }
 
 internal class DataLayerMessageRequestHandler(
     private val service: DataLayerListenerService,
@@ -296,30 +306,17 @@ internal class DataLayerMessageRequestHandler(
     private fun readWifiAvailability(): Pair<Boolean, String> {
         val connectivityManager =
             service.getSystemService(ConnectivityManager::class.java)
-                ?: return false to "connectivity_manager_missing"
-        val active = connectivityManager.activeNetwork
-        val activeCaps = active?.let { connectivityManager.getNetworkCapabilities(it) }
-        if (activeCaps?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true) {
-            return true to "active_wifi"
-        }
+        val active = connectivityManager?.activeNetwork
 
-        @Suppress("DEPRECATION")
-        val availableWifi =
-            connectivityManager.allNetworks.any { network ->
-                connectivityManager
-                    .getNetworkCapabilities(network)
-                    ?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+        val result =
+            when {
+                connectivityManager == null -> false to "connectivity_manager_missing"
+                connectivityManager.hasWifiTransport(active) -> true to "active_wifi"
+                connectivityManager.hasAvailableWifiNetwork -> true to "available_wifi"
+                active == null -> false to "no_active_network"
+                else -> false to "no_wifi_network"
             }
-        return if (availableWifi) {
-            true to "available_wifi"
-        } else {
-            false to
-                if (active == null) {
-                    "no_active_network"
-                } else {
-                    "no_wifi_network"
-                }
-        }
+        return result
     }
 
     private fun handleBatchCheckExists(messageEvent: MessageEvent) {

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/BboxMapPickerDialog.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/BboxMapPickerDialog.kt
@@ -2,12 +2,12 @@
 
 package com.glancemap.glancemapcompanionapp
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -358,8 +358,10 @@ private fun hasUsableInitialPickerBbox(
         .parseOrNull(initialBbox)
         ?.takeUnless { it.isTooLargeForPoiImport(selectedSource) } != null
 
-private fun defaultPickerBounds(): MapPickerBounds =
-    MapPickerBounds.parseOrNull(DEFAULT_PICKER_BBOX) ?: MapPickerBounds.defaultAround(45.6, 6.45)
+private fun defaultPickerBounds(): MapPickerBounds {
+    val fallback = MapPickerBounds.defaultAround(45.6, 6.45)
+    return MapPickerBounds.parseOrNull(DEFAULT_PICKER_BBOX) ?: fallback
+}
 
 private fun MapPickerBounds.isTooLargeForPoiImport(selectedSource: PoiImportSource): Boolean =
     if (selectedSource == PoiImportSource.OSM) {

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/FileTransferViewModel.UriSupport.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/FileTransferViewModel.UriSupport.kt
@@ -133,7 +133,11 @@ internal fun isGeoJsonUri(
     val name = resolveUriDisplayName(context, uri)
     if (isGeoJsonFileName(name)) return true
 
-    val mimeType = context.contentResolver.getType(uri).orEmpty().lowercase()
+    val mimeType =
+        context.contentResolver
+            .getType(uri)
+            .orEmpty()
+            .lowercase()
     return mimeType == "application/geo+json" ||
         mimeType == "application/vnd.geo+json" ||
         (mimeType == "application/json" && name.lowercase().endsWith(".json"))

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/MapLibrePickerViews.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/MapLibrePickerViews.kt
@@ -24,8 +24,8 @@ import org.maplibre.android.MapLibre
 import org.maplibre.android.camera.CameraUpdateFactory
 import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.geometry.LatLngBounds
-import org.maplibre.android.maps.MapLibreMapOptions
 import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapLibreMapOptions
 import org.maplibre.android.maps.MapView
 import org.maplibre.android.maps.Style
 import org.maplibre.android.module.http.HttpRequestUtil
@@ -610,7 +610,7 @@ private class BboxSelectionOverlay(
                 current.scaledTo(latLng)
             } else {
                 current.resizedTo(handle, latLng)
-        }
+            }
         onBoundsChanged(nextBounds)
     }
 
@@ -990,8 +990,10 @@ private fun routingTilesForBounds(
     return result
 }
 
-private fun tileOrigin(coordinate: Double): Int =
-    floor(coordinate / ROUTING_TILE_DEGREES.toDouble()).toInt() * ROUTING_TILE_DEGREES
+private fun tileOrigin(coordinate: Double): Int {
+    val tileIndex = floor(coordinate / ROUTING_TILE_DEGREES.toDouble()).toInt()
+    return tileIndex * ROUTING_TILE_DEGREES
+}
 
 private fun formatTileCoord(
     value: Int,
@@ -1019,11 +1021,9 @@ private fun ensureMapLibreConfigured(context: Context) {
                             .header(
                                 "User-Agent",
                                 "GlanceMapCompanion/1 ($packageName)",
-                            )
-                            .build(),
+                            ).build(),
                     )
-                }
-                .build(),
+                }.build(),
         )
         MapLibreConfiguration.initialized = true
     }

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RefugesImportDialog.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RefugesImportDialog.kt
@@ -108,6 +108,7 @@ internal fun RefugesImportDialog(
     }
     var selectedSource by remember { mutableStateOf(PoiImportSource.OSM) }
     var enrichWithOsm by remember { mutableStateOf(false) }
+
     fun selectSource(source: PoiImportSource) {
         if (selectedSource == source) return
 

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RoutingDownloadDialog.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RoutingDownloadDialog.kt
@@ -78,7 +78,8 @@ internal fun RoutingDownloadDialog(
             when (areaMethod) {
                 RoutingAreaMethod.WATCH_MAP -> selectedRoutingMapCandidate?.bbox.orEmpty()
                 RoutingAreaMethod.TILE_PICKER,
-                RoutingAreaMethod.MANUAL_BBOX -> bboxInput.trim()
+                RoutingAreaMethod.MANUAL_BBOX,
+                -> bboxInput.trim()
             }
         }
     val routingTiles =

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RoutingTilePickerDialog.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RoutingTilePickerDialog.kt
@@ -2,12 +2,12 @@
 
 package com.glancemap.glancemapcompanionapp
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -246,5 +246,7 @@ private fun hasUsableInitialRoutingBbox(initialBbox: String): Boolean =
         BRouterTileMath.tileFileNamesForBbox(parsed).size in 1..4
     }.getOrDefault(false)
 
-private fun defaultRoutingPickerBounds(): MapPickerBounds =
-    MapPickerBounds.parseOrNull(DEFAULT_ROUTING_PICKER_BBOX) ?: MapPickerBounds.defaultAround(45.5, 7.5)
+private fun defaultRoutingPickerBounds(): MapPickerBounds {
+    val fallback = MapPickerBounds.defaultAround(45.5, 7.5)
+    return MapPickerBounds.parseOrNull(DEFAULT_ROUTING_PICKER_BBOX) ?: fallback
+}


### PR DESCRIPTION
## Summary
- Refactor watch Wi-Fi availability detection to avoid detekt `ReturnCount`, `NestedBlockDepth`, and class function-count issues.
- Keep the same Wi-Fi status reasons while moving the reusable transport checks into private top-level helpers.
- Apply companion ktlint formatting fixes that were surfaced after the previous PR merged.

## Validation
- `./gradlew ktlintCheck detekt :app:compileDebugKotlin :glancemapcompanionapp:compileDebugKotlin --no-daemon --console=plain`
- `git diff --check`
- GitHub Actions Android CI run `25457072295` passed