### PR TITLE
fix samsung compass

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/domain/sensors/FusedOrientationProviderAdapter.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/domain/sensors/FusedOrientationProviderAdapter.kt
@@ -193,6 +193,10 @@ internal class FusedOrientationProviderAdapter(
 
     @Volatile private var lastFusedSampleLogAtElapsedMs = 0L
 
+    @Volatile private var consecutiveUnusableFusedSamples = 0
+
+    @Volatile private var firstUnusableFusedSampleAtElapsedMs = 0L
+
     @Volatile private var fusedSampleFreshnessGeneration = 0L
 
     @Volatile private var recalibrationBoostUntilElapsedMs = 0L
@@ -284,6 +288,7 @@ internal class FusedOrientationProviderAdapter(
         awaitingFirstOrientationSample = false
         clearRestartHeadingConfirmationState()
         lastFusedSampleLogAtElapsedMs = 0L
+        resetUnusableFusedSampleState()
         publishNorthReferenceStatus()
     }
 
@@ -387,6 +392,7 @@ internal class FusedOrientationProviderAdapter(
         pendingRestartHeadingAtElapsedMs = 0L
         pendingRestartHeadingSampleCount = 0
         lastFusedSampleLogAtElapsedMs = 0L
+        resetUnusableFusedSampleState()
 
         val samplingPeriodMicros = currentSamplingPeriodMicros()
         val usingBoost = isRecalibrationBoostActive()
@@ -455,6 +461,35 @@ internal class FusedOrientationProviderAdapter(
             conservativeHeadingErrorDeg = conservativeHeadingErrorDeg,
             mappedAccuracy = mappedAccuracy,
         )
+
+        if (!isUsableGoogleFusedHeadingError(headingErrorDeg)) {
+            publishUnusableFusedSampleState(
+                headingErrorDeg = headingErrorDeg,
+                conservativeHeadingErrorDeg = conservativeHeadingErrorDeg,
+            )
+            val unusableUpdate =
+                computeFusedUnusableHeadingUpdate(
+                    nowElapsedMs = now,
+                    consecutiveUnusableSamples = consecutiveUnusableFusedSamples,
+                    firstUnusableSampleAtElapsedMs = firstUnusableFusedSampleAtElapsedMs,
+                    minSamples = FUSED_UNUSABLE_HEADING_FALLBACK_MIN_SAMPLES,
+                    minDurationMs = FUSED_UNUSABLE_HEADING_FALLBACK_MIN_DURATION_MS,
+                )
+            consecutiveUnusableFusedSamples = unusableUpdate.state.consecutiveSamples
+            firstUnusableFusedSampleAtElapsedMs = unusableUpdate.state.firstSampleAtElapsedMs
+            if (unusableUpdate.shouldFallback) {
+                logDiagnostics(
+                    "google_fused unusable_heading fallback " +
+                        "samples=${unusableUpdate.state.consecutiveSamples} " +
+                        "durationMs=${unusableUpdate.durationMs} " +
+                        "errorDeg=${headingErrorDeg.formatOrNA(1)} " +
+                        "conservativeErrorDeg=${conservativeHeadingErrorDeg.formatOrNA(1)}",
+                )
+                startFallbackProvider(reason = "unusable_heading")
+            }
+            return
+        }
+        resetUnusableFusedSampleState()
 
         if (awaitingRestartHeadingConfirmation) {
             val timeoutMs = restartHeadingConfirmationTimeoutMs()
@@ -750,6 +785,11 @@ internal class FusedOrientationProviderAdapter(
         pendingRestartHeadingSampleCount = 0
     }
 
+    private fun resetUnusableFusedSampleState() {
+        consecutiveUnusableFusedSamples = 0
+        firstUnusableFusedSampleAtElapsedMs = 0L
+    }
+
     private fun restartHeadingConfirmationTimeoutMs(): Long =
         if (lowPowerMode && !isRecalibrationBoostActive()) {
             FUSED_RESTART_CONFIRM_TIMEOUT_LOW_POWER_MS
@@ -852,6 +892,17 @@ internal class FusedOrientationProviderAdapter(
         updateHeadingSourceState(HeadingSource.FUSED_ORIENTATION)
     }
 
+    private fun publishUnusableFusedSampleState(
+        headingErrorDeg: Float,
+        conservativeHeadingErrorDeg: Float,
+    ) {
+        _accuracy.value = SensorManager.SENSOR_STATUS_UNRELIABLE
+        _headingErrorDeg.value = headingErrorDeg.takeIf { it.isFinite() && it >= 0f }
+        _conservativeHeadingErrorDeg.value =
+            conservativeHeadingErrorDeg.takeIf { it.isFinite() && it >= 0f }
+        _headingSampleStale.value = _headingSampleElapsedRealtimeMs.value != null
+    }
+
     private fun logFusedSample(
         nowElapsedMs: Long,
         displayHeading: Float,
@@ -882,11 +933,15 @@ internal fun shouldUseFusedBootstrapHeading(
     bootstrapRenderState: CompassRenderState,
     nowElapsedMs: Long,
 ): Boolean {
+    val hasUsableFusedAccuracy =
+        fusedRenderState.accuracy != SensorManager.SENSOR_STATUS_UNRELIABLE
     val hasFreshFusedHeading =
         fusedRenderState.headingSource == HeadingSource.FUSED_ORIENTATION &&
             fusedRenderState.headingSampleElapsedRealtimeMs != null &&
-            !fusedRenderState.headingSampleStale
+            !fusedRenderState.headingSampleStale &&
+            hasUsableFusedAccuracy
     val hasRecentCachedFusedHeading =
+        hasUsableFusedAccuracy &&
         hasRecentGoogleFusedCachedHeading(
             renderState = fusedRenderState,
             nowElapsedMs = nowElapsedMs,
@@ -915,6 +970,46 @@ internal fun bootstrapFusedRenderState(
         magneticInterference = bootstrapRenderState.magneticInterference,
     )
 
+internal data class FusedUnusableHeadingState(
+    val consecutiveSamples: Int,
+    val firstSampleAtElapsedMs: Long,
+)
+
+internal data class FusedUnusableHeadingUpdate(
+    val state: FusedUnusableHeadingState,
+    val durationMs: Long,
+    val shouldFallback: Boolean,
+)
+
+internal fun isUsableGoogleFusedHeadingError(headingErrorDeg: Float): Boolean =
+    headingAccuracyFromUncertainty(headingErrorDeg) != SensorManager.SENSOR_STATUS_UNRELIABLE
+
+internal fun computeFusedUnusableHeadingUpdate(
+    nowElapsedMs: Long,
+    consecutiveUnusableSamples: Int,
+    firstUnusableSampleAtElapsedMs: Long,
+    minSamples: Int,
+    minDurationMs: Long,
+): FusedUnusableHeadingUpdate {
+    val nextFirstSampleAtElapsedMs =
+        if (consecutiveUnusableSamples <= 0 || firstUnusableSampleAtElapsedMs <= 0L) {
+            nowElapsedMs
+        } else {
+            firstUnusableSampleAtElapsedMs
+        }
+    val nextConsecutiveSamples = consecutiveUnusableSamples + 1
+    val durationMs = (nowElapsedMs - nextFirstSampleAtElapsedMs).coerceAtLeast(0L)
+    return FusedUnusableHeadingUpdate(
+        state =
+            FusedUnusableHeadingState(
+                consecutiveSamples = nextConsecutiveSamples,
+                firstSampleAtElapsedMs = nextFirstSampleAtElapsedMs,
+            ),
+        durationMs = durationMs,
+        shouldFallback = nextConsecutiveSamples >= minSamples && durationMs >= minDurationMs,
+    )
+}
+
 private const val FUSED_ORIENTATION_THREAD_NAME = "FusedOrientationThread"
 private const val FUSED_ORIENTATION_SETTLE_WINDOW_MS = 250L
 private const val FUSED_ORIENTATION_HIGH_POWER_SAMPLING_MICROS = 20_000L // 50 Hz
@@ -923,6 +1018,8 @@ private const val FUSED_INVALID_HEADING_ERROR_DEG = 180f
 private const val FUSED_ORIENTATION_SAMPLE_STALE_MS = 1_500L
 private const val FUSED_RECALIBRATION_HIGH_POWER_WINDOW_MS = 6_000L
 private const val FUSED_WARM_RESTART_CACHED_HEADING_MAX_AGE_MS = 5_000L
+private const val FUSED_UNUSABLE_HEADING_FALLBACK_MIN_SAMPLES = 5
+private const val FUSED_UNUSABLE_HEADING_FALLBACK_MIN_DURATION_MS = 1_200L
 private const val FUSED_RESTART_CONFIRM_TIMEOUT_HIGH_POWER_MS = 160L
 private const val FUSED_RESTART_CONFIRM_TIMEOUT_LOW_POWER_MS = 350L
 private const val FUSED_RESTART_STABLE_DELTA_DEG = 15f
@@ -989,8 +1086,13 @@ internal fun resolveFusedRestartHeadingDecision(
         headingErrorDeg.isFinite() &&
             headingErrorDeg in 0f..FUSED_RESTART_TRUSTED_LIVE_ERROR_DEG
     val hasTrustedHeadingError = hasTrustedConservativeError || hasTrustedLiveError
+    val hasUsableHeadingError = isUsableGoogleFusedHeadingError(headingErrorDeg)
     val hasEnoughStableSamples = sampleCount >= FUSED_RESTART_MIN_CONFIRM_SAMPLES
-    if (stableWithPending && (hasTrustedHeadingError || hasEnoughStableSamples || pendingAgeMs >= timeoutMs)) {
+    if (
+        stableWithPending &&
+        hasUsableHeadingError &&
+        (hasTrustedHeadingError || hasEnoughStableSamples || pendingAgeMs >= timeoutMs)
+    ) {
         return FusedRestartHeadingDecision(
             action = FusedRestartHeadingAction.CONFIRM,
             nextPendingHeadingDeg = null,

--- a/app/src/test/java/com/glancemap/glancemapwearos/domain/sensors/FusedOrientationProviderAdapterSupportTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/domain/sensors/FusedOrientationProviderAdapterSupportTest.kt
@@ -134,6 +134,26 @@ class FusedOrientationProviderAdapterSupportTest {
     }
 
     @Test
+    fun unusableRestartSamplesStayPendingEvenAfterConfirmationBudget() {
+        val decision =
+            resolveFusedRestartHeadingDecision(
+                pendingHeadingDeg = 4.2f,
+                displayHeadingDeg = 5.0f,
+                pendingAtElapsedMs = 100L,
+                nowElapsedMs = 320L,
+                pendingSampleCount = 3,
+                timeoutMs = 160L,
+                headingErrorDeg = 180f,
+                conservativeHeadingErrorDeg = 180f,
+            )
+
+        assertEquals(FusedRestartHeadingAction.AWAIT_PENDING, decision.action)
+        assertEquals(4.2f, decision.nextPendingHeadingDeg)
+        assertEquals(4, decision.sampleCount)
+        assertNull(decision.confirmReason)
+    }
+
+    @Test
     fun relockLargeJumpNeedsConfirmationWhenFusedConfidenceIsWeak() {
         val action =
             resolveFusedLargeJumpAction(
@@ -252,11 +272,36 @@ class FusedOrientationProviderAdapterSupportTest {
     }
 
     @Test
+    fun bootstrapSensorHeadingContinuesWhenFreshFusedHeadingIsUnreliable() {
+        val fusedState =
+            initialCompassRenderState(providerType = CompassProviderType.GOOGLE_FUSED).copy(
+                headingSource = HeadingSource.FUSED_ORIENTATION,
+                accuracy = android.hardware.SensorManager.SENSOR_STATUS_UNRELIABLE,
+                headingSampleElapsedRealtimeMs = 1_000L,
+                headingSampleStale = false,
+            )
+        val bootstrapState =
+            initialCompassRenderState(providerType = CompassProviderType.SENSOR_MANAGER).copy(
+                headingDeg = 212f,
+                accuracy = android.hardware.SensorManager.SENSOR_STATUS_ACCURACY_MEDIUM,
+                headingSource = HeadingSource.ROTATION_VECTOR,
+            )
+
+        assertTrue(
+            shouldUseFusedBootstrapHeading(
+                fusedRenderState = fusedState,
+                bootstrapRenderState = bootstrapState,
+                nowElapsedMs = 1_200L,
+            ),
+        )
+    }
+
+    @Test
     fun recentCachedFusedHeadingSuppressesBootstrapBridgeDuringWarmRestart() {
         val fusedState =
             initialCompassRenderState(providerType = CompassProviderType.GOOGLE_FUSED).copy(
                 headingDeg = 184f,
-                accuracy = android.hardware.SensorManager.SENSOR_STATUS_UNRELIABLE,
+                accuracy = android.hardware.SensorManager.SENSOR_STATUS_ACCURACY_MEDIUM,
                 headingSampleElapsedRealtimeMs = 10_000L,
                 headingSampleStale = true,
                 headingSource = HeadingSource.NONE,
@@ -275,5 +320,39 @@ class FusedOrientationProviderAdapterSupportTest {
                 nowElapsedMs = 14_000L,
             ),
         )
+    }
+
+    @Test
+    fun unusableFusedHeadingTriggersFallbackAfterSamplesAndDuration() {
+        val first =
+            computeFusedUnusableHeadingUpdate(
+                nowElapsedMs = 1_000L,
+                consecutiveUnusableSamples = 0,
+                firstUnusableSampleAtElapsedMs = 0L,
+                minSamples = 3,
+                minDurationMs = 1_000L,
+            )
+        val second =
+            computeFusedUnusableHeadingUpdate(
+                nowElapsedMs = 1_500L,
+                consecutiveUnusableSamples = first.state.consecutiveSamples,
+                firstUnusableSampleAtElapsedMs = first.state.firstSampleAtElapsedMs,
+                minSamples = 3,
+                minDurationMs = 1_000L,
+            )
+        val third =
+            computeFusedUnusableHeadingUpdate(
+                nowElapsedMs = 2_100L,
+                consecutiveUnusableSamples = second.state.consecutiveSamples,
+                firstUnusableSampleAtElapsedMs = second.state.firstSampleAtElapsedMs,
+                minSamples = 3,
+                minDurationMs = 1_000L,
+            )
+
+        assertFalse(first.shouldFallback)
+        assertFalse(second.shouldFallback)
+        assertTrue(third.shouldFallback)
+        assertEquals(3, third.state.consecutiveSamples)
+        assertEquals(1_100L, third.durationMs)
     }
 }

--- a/docs/compass/THRESHOLDS.md
+++ b/docs/compass/THRESHOLDS.md
@@ -5,6 +5,7 @@ This file documents intent for important compass constants.
 Source constants file:
 
 - `app/src/main/java/com/glancemap/glancemapwearos/domain/sensors/CompassManager.kt`
+- `app/src/main/java/com/glancemap/glancemapwearos/domain/sensors/FusedOrientationProviderAdapter.kt`
 
 ## How To Use This File
 
@@ -26,6 +27,8 @@ Source constants file:
 | `HEADING_NOISE_POOR_DEG` | `8.8 deg` | Low-quality noise bound | Flags unstable heading sooner | Neutral |
 | `ADAPTIVE_RATE_HIGH_TURN_RATE_DEG_PER_SEC` | `30 deg/s` | Trigger to stay/return to high sensor rate | Better behavior while turning | Higher sensor cost while active |
 | `ADAPTIVE_RATE_STABLE_TO_LOW_MS` | `4000 ms` | Time in stable state before dropping to low rate | Can slightly delay low-power transition | Reduces sustained sensor drain once stable |
+| `FUSED_UNUSABLE_HEADING_FALLBACK_MIN_SAMPLES` | `5 samples` | Require repeated unusable Google fused uncertainty before fallback | Avoids publishing streams that report `180 deg` heading uncertainty | May keep SensorManager fallback active when Google fused is unusable |
+| `FUSED_UNUSABLE_HEADING_FALLBACK_MIN_DURATION_MS` | `1200 ms` | Require unusable Google fused state to persist before fallback | Filters startup blips while catching sustained bad fused streams on SM-L505F | Neutral unless fallback stays active |
 | `MAG_FIELD_MIN_VALID_UT` | `15 uT` | Lower bound for plausible magnetic field | Detects abnormal environment | Neutral |
 | `MAG_FIELD_MAX_VALID_UT` | `85 uT` | Upper bound for plausible magnetic field | Detects interference/saturation | Neutral |
 | `MAG_FIELD_SPIKE_THRESHOLD_UT` | `18 uT` | Spike detector for sudden interference | Captures abrupt disturbances | Neutral |


### PR DESCRIPTION
## Summary
- Treat Google fused heading as unusable when it reports `SENSOR_STATUS_UNRELIABLE`-level uncertainty on the Samsung watch
- Keep the SensorManager rotation-vector bootstrap active until fused data is actually trustworthy
- Fall back to SensorManager if Google fused stays unusable for multiple samples
- Add unit coverage for the restart, bootstrap, and fallback behavior
- Document the new fused-heading fallback thresholds

## Testing
- `:app:compileDebugKotlin`
- `:app:testDebugUnitTest --tests com.glancemap.glancemapwearos.domain.sensors.FusedOrientationProviderAdapterSupportTest`
- `:app:testDebugUnitTest --tests "*domain.sensors*"`