### PR TITLE
[codex] Bump version name to 1.1.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ android.r8.strictFullModeForKeepRules=false
 # Play versioning.
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
-glanceMapVersionName=1.1.0
+glanceMapVersionName=1.1.1
 glanceMapWearVersionCode=1015
 glanceMapPhoneVersionCode=2013
 


### PR DESCRIPTION
## Summary
- Bump the shared GlanceMap version name from `1.1.0` to `1.1.1`.
- Keep Wear and phone version codes unchanged at `1015` and `2013`.

## Validation
- Config-only change; verified `gradle.properties` diff.