### PR TITLE
Fix arrow GPX

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/GpxDirectionArrowLayer.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/GpxDirectionArrowLayer.kt
@@ -32,7 +32,6 @@ internal class GpxDirectionArrowLayer(
         val zoom = zoomLevel.toInt()
         val tileSize = displayModel.tileSize
         val mapSize = getCachedMapSize(zoomLevel, tileSize)
-        val mapDeg = mapViewRotation.degrees
         trackLods.values.forEach { lod ->
             val arrows =
                 buildVisibleGpxDirectionArrows(
@@ -47,7 +46,6 @@ internal class GpxDirectionArrowLayer(
                     canvas = canvas,
                     topLeft = topLeft,
                     mapSize = mapSize,
-                    mapRotationDeg = mapDeg,
                 )
             }
         }
@@ -58,7 +56,6 @@ internal class GpxDirectionArrowLayer(
         canvas: Canvas,
         topLeft: Point,
         mapSize: Long,
-        mapRotationDeg: Float,
     ) {
         val pixelX = MercatorProjection.longitudeToPixelX(arrow.latLong.longitude, mapSize) - topLeft.x
         val pixelY = MercatorProjection.latitudeToPixelY(arrow.latLong.latitude, mapSize) - topLeft.y
@@ -66,7 +63,7 @@ internal class GpxDirectionArrowLayer(
         val drawY = floor(pixelY - bitmap.height / 2f).toInt()
         val pivotX = drawX + bitmap.width / 2f
         val pivotY = drawY + bitmap.height / 2f
-        val effective = normalize360(arrow.headingDeg - mapRotationDeg)
+        val effective = normalize360(arrow.headingDeg)
 
         canvas.save()
         if (effective != 0f) {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/overlays/GpxOverlayGeometry.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/overlays/GpxOverlayGeometry.kt
@@ -7,6 +7,7 @@ import com.glancemap.glancemapwearos.presentation.features.gpx.TrackPoint
 import org.mapsforge.core.model.LatLong
 import org.mapsforge.core.util.MercatorProjection
 import kotlin.math.atan2
+import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -181,12 +182,7 @@ internal fun buildVisibleGpxDirectionArrows(
     val candidates = ArrayList<GpxDirectionArrow>()
     val arrowPixels = ArrayList<XY>(maxArrows)
     visibleIntervals.forEach { interval ->
-        var distance =
-            if (interval.length <= GPX_VISIBLE_DIRECTION_ARROW_SPACING_PX) {
-                interval.start + interval.length * 0.5
-            } else {
-                interval.start + GPX_VISIBLE_DIRECTION_ARROW_SPACING_PX * 0.5
-            }
+        var distance = firstAnchoredArrowDistanceInInterval(interval)
 
         while (distance < interval.end) {
             val arrowPoint =
@@ -220,6 +216,14 @@ internal fun buildVisibleGpxDirectionArrows(
     }
 
     return downsampleEvenly(candidates, maxArrows)
+}
+
+private fun firstAnchoredArrowDistanceInInterval(interval: DistanceInterval): Double {
+    val spacing = GPX_VISIBLE_DIRECTION_ARROW_SPACING_PX
+    val firstAnchor = spacing * 0.5
+    if (interval.end <= firstAnchor) return firstAnchor
+    val steps = ceil((interval.start - firstAnchor) / spacing).coerceAtLeast(0.0)
+    return firstAnchor + steps * spacing
 }
 
 private fun pointAtDistance(

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/GpxDirectionArrowGeometryTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/GpxDirectionArrowGeometryTest.kt
@@ -6,6 +6,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mapsforge.core.model.BoundingBox
 import org.mapsforge.core.model.LatLong
+import kotlin.math.roundToInt
 
 class GpxDirectionArrowGeometryTest {
     @Test
@@ -190,6 +191,49 @@ class GpxDirectionArrowGeometryTest {
         assertTrue(arrows.first().latLong.longitude in 6.49..6.51)
     }
 
+    @Test
+    fun keepsVisibleArrowPositionsAnchoredWhenViewportPans() {
+        val points =
+            (0..2400).map { index ->
+                trackPoint(
+                    lat = 45.0,
+                    lon = 6.0 + index * 0.000025,
+                )
+            }
+
+        val firstViewport =
+            buildVisibleGpxDirectionArrows(
+                points = points,
+                zoom = 16,
+                tileSize = 256,
+                boundingBox =
+                    BoundingBox(
+                        44.999,
+                        6.0,
+                        45.001,
+                        6.03,
+                    ),
+            )
+        val slightlyPannedViewport =
+            buildVisibleGpxDirectionArrows(
+                points = points,
+                zoom = 16,
+                tileSize = 256,
+                boundingBox =
+                    BoundingBox(
+                        44.999,
+                        6.001,
+                        45.001,
+                        6.031,
+                    ),
+            )
+
+        val firstKeys = firstViewport.map { it.latLong.longitude.roundKey() }.toSet()
+        val pannedKeys = slightlyPannedViewport.map { it.latLong.longitude.roundKey() }.toSet()
+
+        assertTrue(firstKeys.intersect(pannedKeys).isNotEmpty())
+    }
+
     private fun trackPoint(
         lat: Double,
         lon: Double,
@@ -197,4 +241,6 @@ class GpxDirectionArrowGeometryTest {
         latLong = LatLong(lat, lon),
         elevation = null,
     )
+
+    private fun Double.roundKey(): Int = (this * 1_000_000).roundToInt()
 }


### PR DESCRIPTION
## Summary
- Keep GPX direction arrows aligned to the track heading instead of subtracting map rotation during rendering.
- Adjust arrow spacing so visible arrows stay anchored consistently as the viewport pans.
- Add a geometry test covering stable arrow positions across a slight pan.

## Testing
- Added unit coverage for anchored arrow placement during viewport movement.
- Not run (not requested).