### PR TITLE
change ui to fit screen

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/GpxSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/GpxSettingsScreen.kt
@@ -77,18 +77,7 @@ fun GpxSettingsScreen(
     onOpenGeneralSettings: () -> Unit,
 ) {
     val screenSize = rememberWearScreenSize()
-    val listTokens =
-        rememberSettingsListTokens(
-            compactTop = 12.dp,
-            standardTop = 14.dp,
-            expandedTop = 16.dp,
-            compactBottom = 12.dp,
-            standardBottom = 14.dp,
-            expandedBottom = 16.dp,
-            compactItemSpacing = 12.dp,
-            standardItemSpacing = 14.dp,
-            expandedItemSpacing = 16.dp,
-        )
+    val listTokens = rememberSettingsListTokens()
     val adaptive = rememberWearAdaptiveSpec()
     val trackColor by viewModel.gpxTrackColor.collectAsState()
     val trackColorMode by viewModel.gpxTrackColorMode.collectAsState()

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/LicensesScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/LicensesScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -394,6 +395,7 @@ private fun LicenseDocumentDialog(
                     text = documentText,
                     style = MaterialTheme.typography.bodySmall,
                 )
+                Spacer(modifier = Modifier.height(adaptive.dialogVerticalPadding + 28.dp))
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,9 +34,9 @@ android.r8.strictFullModeForKeepRules=false
 # Play versioning.
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
-glanceMapVersionName=1.1.1
-glanceMapWearVersionCode=1015
-glanceMapPhoneVersionCode=2013
+glanceMapVersionName=1.1.2
+glanceMapWearVersionCode=1016
+glanceMapPhoneVersionCode=2014
 
 # Elevate theme build-time sync (download -> generated assets -> packaged in APK)
 elevateThemeVersion=5.6


### PR DESCRIPTION
## Summary
- Restored GPX settings to the shared Wear OS list padding/spacing so the first control is no longer clipped on round displays.
- Added extra bottom scroll space in the Credits & Legal document dialog so the last lines can scroll above the screen edge.
- Bumped shared app versioning for the watch and companion releases.

## Testing
- `./gradlew :app:compileDebugKotlin :glancemapcompanionapp:compileDebugKotlin --no-daemon --console=plain` passed.
- Verified the affected Wear OS settings and dialog layouts in code against the existing POI/Maps patterns.