### PR TITLE
[codex] Add round-safe dialog layout helpers

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadDialogs.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadDialogs.kt
@@ -11,10 +11,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Update
 import androidx.compose.runtime.Composable
@@ -41,7 +44,9 @@ import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
+import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpacer
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
+import com.glancemap.glancemapwearos.presentation.ui.wearDialogWidth
 
 @Composable
 internal fun AreaSearchDialog(
@@ -69,7 +74,7 @@ internal fun AreaSearchDialog(
         Column(
             modifier =
                 Modifier
-                    .fillMaxWidth(0.86f)
+                    .wearDialogWidth(roundFraction = 0.86f, squareFraction = 0.86f)
                     .background(
                         Color.Black,
                         RoundedCornerShape(adaptive.dialogCornerRadius),
@@ -146,6 +151,7 @@ internal fun OamAttributionDialog(
     onDismiss: () -> Unit,
 ) {
     if (!visible) return
+    val adaptive = rememberWearAdaptiveSpec()
 
     AlertDialog(
         visible = visible,
@@ -153,6 +159,11 @@ internal fun OamAttributionDialog(
         title = { Text("Download") },
         text = {
             Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = adaptive.helpDialogMaxHeight)
+                        .verticalScroll(rememberScrollState()),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
@@ -183,6 +194,7 @@ internal fun OamAttributionDialog(
                     )
                     Text("Use update button to refresh bundles.")
                 }
+                WearDialogScrollBottomSpacer()
             }
         },
         confirmButton = {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxHelpBottomSheet.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxHelpBottomSheet.kt
@@ -21,6 +21,7 @@ import androidx.wear.compose.material3.AlertDialog
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.R
+import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpacer
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 
 @Composable
@@ -73,6 +74,7 @@ fun GpxHelpBottomSheet(
                         ),
                 )
                 Text("Use edit or delete mode to rename or remove tracks.")
+                WearDialogScrollBottomSpacer()
             }
         },
     )

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxLongPressTipBottomSheet.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxLongPressTipBottomSheet.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
+import com.glancemap.glancemapwearos.presentation.ui.wearDialogWidth
 
 private const val GPX_TIP_DRAG_DISMISS_PX = 55f
 
@@ -36,7 +37,7 @@ fun GpxLongPressTipBottomSheet(
         Column(
             modifier =
                 Modifier
-                    .fillMaxWidth()
+                    .wearDialogWidth()
                     .background(
                         Color.Black.copy(alpha = 0.82f),
                         RoundedCornerShape(adaptive.dialogCornerRadius),

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
@@ -72,6 +72,7 @@ import com.glancemap.glancemapwearos.presentation.features.routetools.RouteToolB
 import com.glancemap.glancemapwearos.presentation.navigation.WatchRoutes
 import com.glancemap.glancemapwearos.presentation.ui.DeleteConfirmationDialog
 import com.glancemap.glancemapwearos.presentation.ui.RenameValueDialog
+import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpacer
 import com.glancemap.glancemapwearos.presentation.ui.WearScreenSize
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearScreenSize
@@ -464,6 +465,7 @@ fun MapsScreen(
                             }
                         }
                     }
+                    WearDialogScrollBottomSpacer()
                 }
             },
             confirmButton = {
@@ -537,6 +539,7 @@ fun MapsScreen(
                             DemMapCoverageRow(mapFile = mapFile)
                         }
                     }
+                    WearDialogScrollBottomSpacer()
                 }
             },
             confirmButton = {
@@ -619,6 +622,7 @@ fun MapsScreen(
                         Text("Routing enables offline route calculation.")
                     }
                     Text("Grey means missing, amber partial, green ready.")
+                    WearDialogScrollBottomSpacer()
                 }
             },
         )

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiScreen.kt
@@ -61,6 +61,7 @@ import com.glancemap.glancemapwearos.presentation.features.maps.MapViewModel
 import com.glancemap.glancemapwearos.presentation.navigation.WatchRoutes
 import com.glancemap.glancemapwearos.presentation.ui.DeleteConfirmationDialog
 import com.glancemap.glancemapwearos.presentation.ui.RenameValueDialog
+import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpacer
 import com.glancemap.glancemapwearos.presentation.ui.WearScreenSize
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearScreenSize
@@ -575,6 +576,7 @@ fun PoiScreen(
                                     },
                             ),
                     )
+                    WearDialogScrollBottomSpacer()
                 }
             },
         )

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RoutePoiSearchDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RoutePoiSearchDialog.kt
@@ -34,7 +34,9 @@ import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.presentation.features.poi.PoiSearchResultUiState
 import com.glancemap.glancemapwearos.presentation.features.poi.PoiSearchUiState
+import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpacer
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
+import com.glancemap.glancemapwearos.presentation.ui.wearDialogWidth
 
 @Composable
 internal fun RoutePoiSearchDialog(
@@ -71,7 +73,7 @@ internal fun RoutePoiSearchDialog(
         Column(
             modifier =
                 Modifier
-                    .fillMaxWidth()
+                    .wearDialogWidth()
                     .background(
                         Color.Black.copy(alpha = 0.92f),
                         RoundedCornerShape(adaptive.dialogCornerRadius),
@@ -180,6 +182,7 @@ internal fun RoutePoiSearchDialog(
                             }
                         }
                     }
+                    WearDialogScrollBottomSpacer()
                 }
             }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolResultDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolResultDialog.kt
@@ -39,6 +39,7 @@ import com.glancemap.glancemapwearos.presentation.formatting.DurationFormatter
 import com.glancemap.glancemapwearos.presentation.formatting.UnitFormatter
 import com.glancemap.glancemapwearos.presentation.ui.RenameValueDialog
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
+import com.glancemap.glancemapwearos.presentation.ui.wearDialogWidth
 
 @Composable
 internal fun RouteToolResultDialog(
@@ -97,7 +98,7 @@ internal fun RouteToolResultDialog(
             Column(
                 modifier =
                     Modifier
-                        .fillMaxWidth()
+                        .wearDialogWidth(roundFraction = 0.9f, squareFraction = 0.94f)
                         .padding(
                             horizontal = adaptive.dialogHorizontalPadding,
                             vertical = adaptive.dialogVerticalPadding,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/LicensesScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/LicensesScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -40,7 +39,9 @@ import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
+import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpacer
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
+import com.glancemap.glancemapwearos.presentation.ui.wearDialogWidth
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.material.Chip
@@ -336,7 +337,7 @@ private fun LicenseDocumentDialog(
         Column(
             modifier =
                 Modifier
-                    .fillMaxWidth()
+                    .wearDialogWidth()
                     .background(
                         Color.Black.copy(alpha = 0.82f),
                         RoundedCornerShape(adaptive.dialogCornerRadius),
@@ -395,7 +396,7 @@ private fun LicenseDocumentDialog(
                     text = documentText,
                     style = MaterialTheme.typography.bodySmall,
                 )
-                Spacer(modifier = Modifier.height(adaptive.dialogVerticalPadding + 28.dp))
+                WearDialogScrollBottomSpacer()
             }
         }
     }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/OptionPickerDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/OptionPickerDialog.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -29,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
+import com.glancemap.glancemapwearos.presentation.ui.wearDialogWidth
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.material.ToggleChip
 import com.google.android.horologist.compose.material.ToggleChipToggleControl
@@ -59,7 +61,7 @@ internal fun <T> OptionPickerDialog(
         Column(
             modifier =
                 Modifier
-                    .fillMaxWidth()
+                    .wearDialogWidth()
                     .background(
                         Color.Black.copy(alpha = 0.82f),
                         RoundedCornerShape(adaptive.dialogCornerRadius),
@@ -112,6 +114,7 @@ internal fun <T> OptionPickerDialog(
                         }.focusRequester(focusRequester)
                         .focusable(),
                 state = listState,
+                contentPadding = PaddingValues(bottom = adaptive.dialogVerticalPadding + 24.dp),
                 verticalArrangement = Arrangement.spacedBy(6.dp),
                 userScrollEnabled = true,
             ) {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/RenameValueDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/RenameValueDialog.kt
@@ -63,8 +63,10 @@ fun RenameValueDialog(
         Column(
             modifier =
                 Modifier
-                    .fillMaxWidth(dialogWidthFraction)
-                    .background(
+                    .wearDialogWidth(
+                        roundFraction = dialogWidthFraction,
+                        squareFraction = dialogWidthFraction,
+                    ).background(
                         Color.Black,
                         RoundedCornerShape(adaptive.dialogCornerRadius),
                     ).padding(

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearDialogLayout.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearDialogLayout.kt
@@ -1,0 +1,31 @@
+package com.glancemap.glancemapwearos.presentation.ui
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun Modifier.wearDialogWidth(
+    roundFraction: Float = 0.88f,
+    squareFraction: Float = 0.92f,
+): Modifier {
+    val adaptive = rememberWearAdaptiveSpec()
+    return this.fillMaxWidth(
+        if (adaptive.isRound) {
+            roundFraction
+        } else {
+            squareFraction
+        },
+    )
+}
+
+@Composable
+@Suppress("FunctionNaming")
+fun WearDialogScrollBottomSpacer(extra: Dp = 28.dp) {
+    val adaptive = rememberWearAdaptiveSpec()
+    Spacer(modifier = Modifier.height(adaptive.dialogVerticalPadding + extra))
+}


### PR DESCRIPTION
## Summary

- Add shared Wear dialog layout helpers for round-safe custom dialog width and reusable scroll bottom spacing.
- Apply the helpers to option pickers, rename/search dialogs, Credits & Legal, route-tool dialogs, and map/POI/GPX/download help content.
- Give long scrollable dialog bodies extra bottom room so final text and controls can scroll above round display edges.

## Why

Play Store flagged clipped text/controls on Wear OS. The previous fixes addressed known GPX settings and Credits & Legal cases; this broadens the same safe-area treatment to the remaining custom dialog surfaces most likely to assume rectangular bounds.

## Validation

- `./gradlew :app:compileDebugKotlin --no-daemon --console=plain`
- `./gradlew :app:ktlintCheck --no-daemon --console=plain`
- `./gradlew :app:detekt --no-daemon --console=plain`