### PR TITLE
Polish wear max-font chrome and GPX sharing

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/MainActivity.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/MainActivity.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -156,7 +155,7 @@ class MainActivity : ComponentActivity() {
                 AppScaffold(
                     timeText = {
                         if (showTimeInNavigate && isNavigateScreen && !isAmbient) {
-                            cappedFontScale(maxFontScale = 0.85f) {
+                            cappedFontScale(maxFontScale = 1f) {
                                 val context = LocalContext.current
                                 TimeText(
                                     modifier = Modifier.padding(top = 2.dp),
@@ -170,7 +169,6 @@ class MainActivity : ComponentActivity() {
                                         style =
                                             CurvedTextStyle(
                                                 color = Color.White,
-                                                fontSize = 13.sp,
                                             ),
                                     )
                                 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/home/MainScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/home/MainScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -71,6 +72,7 @@ fun MainScreen(
 ) {
     val offlineModeFlow = settingsViewModel?.offlineMode ?: flowOf(false)
     val offlineMode by offlineModeFlow.collectAsState(initial = false)
+    val fontScale = LocalDensity.current.fontScale
     var gpsStatusMessage by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(gpsStatusMessage) {
@@ -110,6 +112,13 @@ fun MainScreen(
             WearScreenSize.LARGE -> 28.dp
             WearScreenSize.MEDIUM -> 26.dp
             WearScreenSize.SMALL -> 24.dp
+        }
+    val settingsButtonTouchTargetSize = 48.dp
+    val settingsIconYOffset =
+        when (screenSize) {
+            WearScreenSize.LARGE -> 5.dp
+            WearScreenSize.MEDIUM -> 4.dp
+            WearScreenSize.SMALL -> 3.dp
         }
     val navigateIconButtonSize =
         when (screenSize) {
@@ -182,9 +191,15 @@ fun MainScreen(
         val centerRowYOffset = 0.dp
         val centerScrollState = rememberScrollState()
         val centerScrollBottomInset =
-            settingsButtonSize +
-                settingsButtonBottomPadding +
-                if (compactScreen) 8.dp else 10.dp
+            if (fontScale > 1f) {
+                settingsButtonTouchTargetSize +
+                    settingsButtonBottomPadding +
+                    if (compactScreen) 6.dp else 8.dp
+            } else {
+                settingsButtonSize / 2 +
+                    settingsButtonBottomPadding +
+                    if (compactScreen) 3.dp else 5.dp
+            }
         val centerScrollTopInset =
             settingsButtonSize / 2 +
                 if (compactScreen) 4.dp else 6.dp
@@ -286,16 +301,20 @@ fun MainScreen(
                     Modifier
                         .align(Alignment.BottomCenter)
                         .padding(bottom = settingsButtonBottomPadding)
-                        .size(settingsButtonSize),
+                        .size(settingsButtonTouchTargetSize),
                 colors =
                     IconButtonDefaults.iconButtonColors(
-                        containerColor = Color.Black.copy(alpha = 0.72f),
+                        containerColor = Color.Transparent,
                         contentColor = Color.White,
                     ),
             ) {
                 Icon(
                     imageVector = Icons.Default.Settings,
                     contentDescription = "Settings",
+                    modifier =
+                        Modifier
+                            .offset(y = settingsIconYOffset)
+                            .size(settingsButtonSize),
                 )
             }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/ui/NavigateOverlaysLayer.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/ui/NavigateOverlaysLayer.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -321,6 +322,8 @@ internal fun BoxScope.NavigateOverlaysLayer(
     }
 
     scaleIndicator?.let { indicator ->
+        val scaleFontScale = LocalDensity.current.fontScale
+        val scaleTopPadding = zoomLabelTopPadding + if (scaleFontScale > 1f) 4.dp else 0.dp
         AnimatedVisibility(
             visible = showScaleBar,
             enter = fadeIn(tween(180)),
@@ -328,9 +331,9 @@ internal fun BoxScope.NavigateOverlaysLayer(
             modifier =
                 Modifier
                     .align(Alignment.TopCenter)
-                    .padding(top = zoomLabelTopPadding),
+                    .padding(top = scaleTopPadding),
         ) {
-            cappedFontScale {
+            cappedFontScale(maxFontScale = 1f) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Text(
                         text = indicator.label,

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/FileTransferViewModel.UriSupport.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/FileTransferViewModel.UriSupport.kt
@@ -167,11 +167,39 @@ internal fun isGpxUri(
     uri: Uri,
 ): Boolean {
     val name = resolveUriDisplayName(context, uri)
-    if (name.lowercase().endsWith(".gpx")) return true
-    return context.contentResolver
-        .getType(uri)
-        .orEmpty()
-        .lowercase() == "application/gpx+xml"
+    val mimeType =
+        context.contentResolver
+            .getType(uri)
+            .orEmpty()
+            .lowercase()
+    return name.lowercase().endsWith(".gpx") ||
+        mimeType == "application/gpx+xml" ||
+        mimeType == "application/x-gpx+xml" ||
+        isLikelyGpxContent(context, uri)
+}
+
+private fun isLikelyGpxContent(
+    context: Context,
+    uri: Uri,
+): Boolean =
+    runCatching {
+        val input = context.contentResolver.openInputStream(uri) ?: return@runCatching false
+        input.use { stream ->
+            val buffer = ByteArray(GPX_SNIFF_MAX_BYTES)
+            val read = stream.read(buffer)
+            if (read <= 0) return@use false
+            isLikelyGpxTextPrefix(String(buffer, 0, read, Charsets.UTF_8))
+        }
+    }.getOrDefault(false)
+
+internal fun isLikelyGpxTextPrefix(text: String): Boolean {
+    val normalized =
+        text
+            .removePrefix("\uFEFF")
+            .trimStart()
+            .replace(Regex("""\A<\?xml[^>]*>\s*""", RegexOption.IGNORE_CASE), "")
+            .trimStart()
+    return Regex("""\A<\s*gpx(?:\s|>)""", RegexOption.IGNORE_CASE).containsMatchIn(normalized)
 }
 
 internal fun suggestPoiFileNameForGpxWaypoints(
@@ -372,6 +400,8 @@ private val GENERIC_SHARED_GPX_BASENAMES =
         "track",
         "unknown",
     )
+
+private const val GPX_SNIFF_MAX_BYTES = 8192
 
 internal fun queryUriSize(
     context: Context,

--- a/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/FileTransferViewModelUriSupportTest.kt
+++ b/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/FileTransferViewModelUriSupportTest.kt
@@ -53,4 +53,30 @@ class FileTransferViewModelUriSupportTest {
             ),
         )
     }
+
+    @Test
+    fun `recognizes gpx document prefix with xml declaration`() {
+        assertTrue(
+            isLikelyGpxTextPrefix(
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <gpx version="1.1" creator="WhatsApp">
+                    <trk><name>Tour du lac</name></trk>
+                </gpx>
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `does not recognize non gpx xml prefix`() {
+        assertFalse(
+            isLikelyGpxTextPrefix(
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <kml><Document /></kml>
+                """.trimIndent(),
+            ),
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- restore normal-size navigate time while capping large user font growth
- keep main menu and scale chip usable at max font/display settings
- recognize generic WhatsApp GPX shares by sniffing GPX XML content before transfer validation

## Testing
- ./gradlew ktlintCheck detekt :app:compileDebugKotlin :glancemapcompanionapp:compileDebugKotlin :app:testDebugUnitTest :glancemapcompanionapp:testDebugUnitTest :app:lintDebug :glancemapcompanionapp:lintDebug --no-daemon --console=plain