### PR TITLE
[codex] Bump versions and polish wear UI edge cases

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadScreen.kt
@@ -232,6 +232,17 @@ fun DownloadScreen(
             WearScreenSize.MEDIUM -> 18.dp
             WearScreenSize.SMALL -> 16.dp
         }
+    val areaPickerListBottomPadding =
+        listBottomPadding +
+            if (adaptive.isRound && adaptive.fontScale > 1f) {
+                when (screenSize) {
+                    WearScreenSize.LARGE -> 42.dp
+                    WearScreenSize.MEDIUM -> 36.dp
+                    WearScreenSize.SMALL -> 30.dp
+                }
+            } else {
+                0.dp
+            }
     LaunchedEffect(uiState.lastLibraryChangedAtMillis) {
         if (uiState.lastLibraryChangedAtMillis > 0L) {
             onLibraryChanged()
@@ -360,7 +371,7 @@ fun DownloadScreen(
                         start = listHorizontalPadding,
                         end = listHorizontalPadding,
                         top = listTopPadding,
-                        bottom = listBottomPadding,
+                        bottom = if (showAreaPicker) areaPickerListBottomPadding else listBottomPadding,
                     ),
                 verticalArrangement = Arrangement.spacedBy(rowSpacing),
                 anchorType = SettingsListAnchorType,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadScreen.kt
@@ -12,6 +12,7 @@
 package com.glancemap.glancemapwearos.presentation.features.download
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -51,6 +52,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
+import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material3.Button
@@ -70,7 +72,6 @@ import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearScreenSize
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.layout.ScreenScaffold
-import com.google.android.horologist.compose.material.Chip
 import kotlinx.coroutines.launch
 import androidx.wear.compose.material3.Icon as Material3Icon
 
@@ -869,6 +870,7 @@ private fun InstalledBundleRow(
     DownloadChip(
         label = bundle.areaLabel,
         secondaryLabel = installedBundleSubtitle(bundle),
+        secondaryMarquee = true,
         icon =
             when {
                 refreshMode && refreshSelected -> Icons.Filled.Check
@@ -998,11 +1000,25 @@ internal fun DownloadChip(
     icon: ImageVector,
     onClick: () -> Unit,
     selected: Boolean = false,
+    secondaryMarquee: Boolean = false,
 ) {
     Chip(
         modifier = Modifier.fillMaxWidth(),
-        label = label,
-        secondaryLabel = secondaryLabel,
+        label = {
+            Text(
+                text = label,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
+        secondaryLabel = {
+            Text(
+                text = secondaryLabel,
+                modifier = if (secondaryMarquee) Modifier.basicMarquee() else Modifier,
+                maxLines = 1,
+                overflow = if (secondaryMarquee) TextOverflow.Visible else TextOverflow.Ellipsis,
+            )
+        },
         icon = {
             Icon(
                 imageVector = icon,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
@@ -87,7 +87,7 @@ import java.util.Locale
 private val MAP_DATA_BADGE_SIZE = 26.dp
 private val MAP_DATA_ICON_SIZE = 15.dp
 private val MAP_ROUTING_BADGE_SLOT_WIDTH = 22.dp
-private val MAP_DEM_BADGE_SLOT_WIDTH = 16.dp
+private val MAP_DEM_BADGE_SLOT_WIDTH = 18.dp
 
 @Composable
 fun MapsScreen(

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiScreen.kt
@@ -412,7 +412,7 @@ fun PoiScreen(
     }
 
     LaunchedEffect(Unit) {
-        poiViewModel.loadPoiFiles()
+        poiViewModel.loadPoiFiles(collapseAll = true)
     }
     LaunchedEffect(poiFiles.size) {
         if (poiFiles.isEmpty()) {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiScreen.kt
@@ -392,6 +392,7 @@ fun PoiScreen(
                 }
             }
         }
+    val hasDownloadedPoiFiles = remember(poiFiles) { poiFiles.any { it.path != USER_POI_SOURCE_PATH } }
 
     val columnState =
         rememberResponsiveColumnState(
@@ -677,10 +678,10 @@ fun PoiScreen(
                     modifier = Modifier.fillMaxSize(),
                     columnState = columnState,
                 ) {
-                    if (poiFiles.isEmpty()) {
+                    if (rows.isEmpty()) {
                         item {
                             Text(
-                                text = "Download POIs on the watch or send .poi files from the companion phone app.",
+                                text = "Loading POI...",
                                 modifier = Modifier.padding(emptyStatePadding),
                                 textAlign = TextAlign.Center,
                             )
@@ -796,6 +797,16 @@ fun PoiScreen(
                                     isError = row.isError,
                                 )
                             }
+                        }
+                    }
+
+                    if (rows.isNotEmpty() && !hasDownloadedPoiFiles) {
+                        item(key = "no-downloaded-poi-files") {
+                            Text(
+                                text = "Download POIs on the watch or send .poi files from the companion phone app.",
+                                modifier = Modifier.padding(emptyStatePadding),
+                                textAlign = TextAlign.Center,
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiViewModel.kt
@@ -744,43 +744,7 @@ class PoiViewModel(
         publishSyntheticUserFile(earlySyntheticUserFile)
         val files = poiRepository.listPoiFiles()
 
-        val (importedFiles, coverageAreas) =
-            withContext(Dispatchers.IO) {
-                val coverage = mutableListOf<PoiCoverageAreaUiState>()
-                files.map { file ->
-                    val categories = poiRepository.readCategories(file.absolutePath)
-                    poiRepository.readCoverageBounds(file.absolutePath)?.let { bounds ->
-                        coverage +=
-                            PoiCoverageAreaUiState(
-                                filePath = file.absolutePath,
-                                fileName = file.nameWithoutExtension,
-                                bounds = bounds,
-                            )
-                    }
-                    val categoryIds = categories.map { it.id }.toSet()
-                    val enabledIds = poiRepository.getEnabledCategories(file.absolutePath, categoryIds)
-                    val isEnabled = poiRepository.isFileEnabled(file.absolutePath)
-                    val (enabledPoiCount, totalPoiCount) =
-                        computePoiCounts(
-                            path = file.absolutePath,
-                            allCategoryIds = categoryIds,
-                            enabledCategoryIds = enabledIds,
-                        )
-
-                    PoiFileUiState(
-                        name = file.nameWithoutExtension,
-                        path = file.absolutePath,
-                        isEnabled = isEnabled,
-                        isExpanded = previousExpanded[file.absolutePath] ?: false,
-                        categories =
-                            categories.map { category ->
-                                category.toUiState(enabled = category.id in enabledIds)
-                            },
-                        enabledPoiCount = enabledPoiCount,
-                        totalPoiCount = totalPoiCount,
-                    )
-                } to coverage
-            }
+        val (importedFiles, coverageAreas) = loadImportedPoiFiles(files, previousExpanded)
 
         val syntheticUserFile =
             buildUserPoiFileUiState(
@@ -793,6 +757,43 @@ class PoiViewModel(
         _categoryCounts.value = emptyMap()
         updateUserPoiPreviewCache(syntheticUserFile)
     }
+
+    private suspend fun loadImportedPoiFiles(
+        files: List<File>,
+        previousExpanded: Map<String, Boolean>,
+    ): Pair<List<PoiFileUiState>, List<PoiCoverageAreaUiState>> =
+        withContext(Dispatchers.IO) {
+            val coverage = mutableListOf<PoiCoverageAreaUiState>()
+            files.map { file ->
+                val categories = poiRepository.readCategories(file.absolutePath)
+                poiRepository.readCoverageBounds(file.absolutePath)?.let { bounds ->
+                    coverage +=
+                        PoiCoverageAreaUiState(
+                            filePath = file.absolutePath,
+                            fileName = file.nameWithoutExtension,
+                            bounds = bounds,
+                        )
+                }
+                val categoryIds = categories.map { it.id }.toSet()
+                val enabledIds = poiRepository.getEnabledCategories(file.absolutePath, categoryIds)
+                val (enabledPoiCount, totalPoiCount) =
+                    computePoiCounts(
+                        path = file.absolutePath,
+                        allCategoryIds = categoryIds,
+                        enabledCategoryIds = enabledIds,
+                    )
+
+                PoiFileUiState(
+                    name = file.nameWithoutExtension,
+                    path = file.absolutePath,
+                    isEnabled = poiRepository.isFileEnabled(file.absolutePath),
+                    isExpanded = previousExpanded[file.absolutePath] ?: false,
+                    categories = categories.map { it.toUiState(enabled = it.id in enabledIds) },
+                    enabledPoiCount = enabledPoiCount,
+                    totalPoiCount = totalPoiCount,
+                )
+            } to coverage
+        }
 
     private fun publishSyntheticUserFile(file: PoiFileUiState) {
         _poiFiles.update { files ->

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiViewModel.kt
@@ -202,9 +202,9 @@ class PoiViewModel(
             }.launchIn(viewModelScope)
     }
 
-    fun loadPoiFiles() {
+    fun loadPoiFiles(collapseAll: Boolean = false) {
         viewModelScope.launch {
-            reloadFromDisk()
+            reloadFromDisk(collapseAll = collapseAll)
         }
     }
 
@@ -729,12 +729,17 @@ class PoiViewModel(
             markers
         }
 
-    private suspend fun reloadFromDisk() {
-        val previousExpanded = _poiFiles.value.associate { it.path to it.isExpanded }
+    private suspend fun reloadFromDisk(collapseAll: Boolean = false) {
+        val previousExpanded =
+            if (collapseAll) {
+                emptyMap()
+            } else {
+                _poiFiles.value.associate { it.path to it.isExpanded }
+            }
         userPoiSourceState = userPoiRepository.readSourceState()
         val earlySyntheticUserFile =
             buildUserPoiFileUiState(
-                isExpanded = previousExpanded[USER_POI_SOURCE_PATH] ?: userPoiSourceState.points.isNotEmpty(),
+                isExpanded = previousExpanded[USER_POI_SOURCE_PATH] ?: false,
             )
         publishSyntheticUserFile(earlySyntheticUserFile)
         val files = poiRepository.listPoiFiles()
@@ -779,7 +784,7 @@ class PoiViewModel(
 
         val syntheticUserFile =
             buildUserPoiFileUiState(
-                isExpanded = previousExpanded[USER_POI_SOURCE_PATH] ?: userPoiSourceState.points.isNotEmpty(),
+                isExpanded = previousExpanded[USER_POI_SOURCE_PATH] ?: false,
             )
 
         _poiFiles.value = listOf(syntheticUserFile) + importedFiles

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiViewModel.kt
@@ -731,8 +731,13 @@ class PoiViewModel(
 
     private suspend fun reloadFromDisk() {
         val previousExpanded = _poiFiles.value.associate { it.path to it.isExpanded }
-        val files = poiRepository.listPoiFiles()
         userPoiSourceState = userPoiRepository.readSourceState()
+        val earlySyntheticUserFile =
+            buildUserPoiFileUiState(
+                isExpanded = previousExpanded[USER_POI_SOURCE_PATH] ?: userPoiSourceState.points.isNotEmpty(),
+            )
+        publishSyntheticUserFile(earlySyntheticUserFile)
+        val files = poiRepository.listPoiFiles()
 
         val (importedFiles, coverageAreas) =
             withContext(Dispatchers.IO) {
@@ -782,6 +787,13 @@ class PoiViewModel(
         _categoryPreviews.value = emptyMap()
         _categoryCounts.value = emptyMap()
         updateUserPoiPreviewCache(syntheticUserFile)
+    }
+
+    private fun publishSyntheticUserFile(file: PoiFileUiState) {
+        _poiFiles.update { files ->
+            listOf(file) + files.filterNot { isUserPoiPath(it.path) }
+        }
+        updateUserPoiPreviewCache(file)
     }
 
     private suspend fun refreshPoiCounts(path: String) {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/SettingsChips.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/SettingsChips.kt
@@ -52,6 +52,7 @@ internal fun SettingsToggleChip(
     ToggleChip(
         modifier =
             Modifier
+                .fillMaxWidth()
                 .heightIn(min = minHeight)
                 .then(modifier),
         enabled = enabled,
@@ -78,6 +79,7 @@ internal fun SettingsPickerChip(
         Chip(
             modifier =
                 Modifier
+                    .fillMaxWidth()
                     .heightIn(min = minHeight)
                     .then(modifier),
             label = label,
@@ -102,6 +104,7 @@ internal fun SettingsPickerChip(
         Chip(
             modifier =
                 Modifier
+                    .fillMaxWidth()
                     .heightIn(min = minHeight)
                     .then(modifier),
             label = label,
@@ -132,6 +135,7 @@ internal fun SettingsSectionChip(
     Chip(
         modifier =
             Modifier
+                .fillMaxWidth()
                 .heightIn(min = minHeight)
                 .then(modifier),
         label = label,
@@ -169,6 +173,7 @@ internal fun DownloadSettingsSectionChip(
     Chip(
         modifier =
             Modifier
+                .fillMaxWidth()
                 .heightIn(min = minHeight)
                 .then(modifier),
         label = {

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,8 +35,8 @@ android.r8.strictFullModeForKeepRules=false
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
 glanceMapVersionName=1.1.2
-glanceMapWearVersionCode=1018
-glanceMapPhoneVersionCode=2016
+glanceMapWearVersionCode=1019
+glanceMapPhoneVersionCode=2017
 
 # Elevate theme build-time sync (download -> generated assets -> packaged in APK)
 elevateThemeVersion=5.6


### PR DESCRIPTION
## Summary

- Bump both app version codes for the next Play Store submission.
- Improve Wear UI behavior for max font / small round screens in download area picking, settings chips, POI loading, and Maps DEM spacing.
- Keep `mycreation` visible while large POI files load, and collapse POI folders on screen entry for a predictable list state.
- Marquee installed bundle details so long bundle component text remains readable.

## Validation

- `./gradlew :app:compileDebugKotlin --no-daemon --console=plain`

Note: one compile run reported a Kotlin daemon recovery warning, then completed successfully using the fallback compiler path.