### PR TITLE
Fix remaining large-font Wear dialog crops

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadDialogs.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadDialogs.kt
@@ -45,7 +45,7 @@ import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
-import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpacer
+import com.glancemap.glancemapwearos.presentation.ui.WearInfoDialog
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 
 @Composable
@@ -169,58 +169,54 @@ internal fun OamAttributionDialog(
 ) {
     if (!visible) return
 
-    AlertDialog(
+    WearInfoDialog(
         visible = visible,
-        onDismissRequest = onDismiss,
-        title = { Text("Download") },
-        content = {
-            item {
-                Text(
-                    text = "Connect the watch to Wi-Fi and keep it on the charger.",
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth(),
+        title = "Download",
+        onDismiss = onDismiss,
+    ) {
+        item {
+            Text(
+                text = "Connect the watch to Wi-Fi and keep it on the charger.",
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        item {
+            Text(
+                text = "Thank you to OpenAndroMaps for providing the offline maps and POIs.",
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        item {
+            Text(
+                text = "Routing enables offline route calculation.",
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        item {
+            Text(
+                text = "Elevation adds altitude, slope, and terrain shading.",
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        item {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Update,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
                 )
+                Text("Use update button to refresh bundles.")
             }
-            item {
-                Text(
-                    text = "Thank you to OpenAndroMaps for providing the offline maps and POIs.",
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-            item {
-                Text(
-                    text = "Routing enables offline route calculation.",
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-            item {
-                Text(
-                    text = "Elevation adds altitude, slope, and terrain shading.",
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-            item {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Update,
-                        contentDescription = null,
-                        modifier = Modifier.size(16.dp),
-                    )
-                    Text("Use update button to refresh bundles.")
-                }
-            }
-            item {
-                WearDialogScrollBottomSpacer()
-            }
-        },
-    )
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadDialogs.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadDialogs.kt
@@ -10,11 +10,15 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Update
 import androidx.compose.runtime.Composable
@@ -43,7 +47,6 @@ import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpacer
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
-import com.glancemap.glancemapwearos.presentation.ui.wearDialogWidth
 
 @Composable
 internal fun AreaSearchDialog(
@@ -58,6 +61,16 @@ internal fun AreaSearchDialog(
     var draftQuery by remember(visible, initialQuery) { mutableStateOf(initialQuery) }
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
+    val scrollState = rememberScrollState()
+    val topPadding =
+        adaptive.dialogVerticalPadding +
+            adaptive.headerTopSafeInset +
+            if (adaptive.isRound) 18.dp else 0.dp
+    val bottomPadding =
+        adaptive.dialogVerticalPadding +
+            if (adaptive.isRound) 42.dp else 12.dp
+    val controlWidthFraction = if (adaptive.isRound) 0.86f else 1f
+    val buttonMinHeight = 44.dp
 
     LaunchedEffect(visible) {
         focusRequester.requestFocus()
@@ -71,16 +84,17 @@ internal fun AreaSearchDialog(
         Column(
             modifier =
                 Modifier
-                    .wearDialogWidth(roundFraction = 0.86f, squareFraction = 0.86f)
-                    .background(
-                        Color.Black,
-                        RoundedCornerShape(adaptive.dialogCornerRadius),
-                    ).padding(
+                    .fillMaxSize()
+                    .background(Color.Black)
+                    .verticalScroll(scrollState)
+                    .padding(
                         horizontal = adaptive.dialogHorizontalPadding,
-                        vertical = adaptive.dialogVerticalPadding,
+                    ).padding(
+                        top = topPadding,
+                        bottom = bottomPadding,
                     ),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top),
         ) {
             Text(
                 text = "Search area",
@@ -100,7 +114,7 @@ internal fun AreaSearchDialog(
                 cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
                 modifier =
                     Modifier
-                        .fillMaxWidth()
+                        .fillMaxWidth(controlWidthFraction)
                         .focusRequester(focusRequester)
                         .background(
                             Color(0xFF1F1F1F),
@@ -122,14 +136,20 @@ internal fun AreaSearchDialog(
 
             Button(
                 onClick = { onApply(draftQuery) },
-                modifier = Modifier.fillMaxWidth(),
+                modifier =
+                    Modifier
+                        .fillMaxWidth(controlWidthFraction)
+                        .heightIn(min = buttonMinHeight),
             ) {
                 Text("Apply")
             }
 
             Button(
                 onClick = onDismiss,
-                modifier = Modifier.fillMaxWidth(),
+                modifier =
+                    Modifier
+                        .fillMaxWidth(controlWidthFraction)
+                        .heightIn(min = buttonMinHeight),
                 colors =
                     ButtonDefaults.buttonColors(
                         containerColor = Color.White.copy(alpha = 0.12f),

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadDialogs.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadDialogs.kt
@@ -33,12 +33,12 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material3.AlertDialog
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
+import com.glancemap.glancemapwearos.presentation.ui.WearActionDialog
 import com.glancemap.glancemapwearos.presentation.ui.WearFormDialog
 import com.glancemap.glancemapwearos.presentation.ui.WearInfoDialog
 
@@ -186,33 +186,14 @@ internal fun DownloadNetworkWarningDialog(
 ) {
     if (message == null) return
 
-    AlertDialog(
+    WearActionDialog(
         visible = true,
+        title = "Wi-Fi recommended",
+        message = message,
+        confirmText = "Continue",
+        onConfirm = onContinue,
         onDismissRequest = onDismiss,
-        title = { Text("Wi-Fi recommended") },
-        text = {
-            Text(
-                text = message,
-                textAlign = TextAlign.Center,
-            )
-        },
-        confirmButton = {
-            Button(onClick = onContinue) {
-                Text("Continue")
-            }
-        },
-        dismissButton = {
-            Button(
-                onClick = onDismiss,
-                colors =
-                    ButtonDefaults.buttonColors(
-                        containerColor = Color.White.copy(alpha = 0.12f),
-                        contentColor = Color.White,
-                    ),
-            ) {
-                Text("Cancel")
-            }
-        },
+        dismissText = "Cancel",
     )
 }
 
@@ -226,46 +207,20 @@ internal fun RefreshBundleDialog(
 
     val updateAvailable = check.status == OamBundleUpdateStatus.UPDATE_AVAILABLE
     val upToDate = check.status == OamBundleUpdateStatus.UP_TO_DATE
-    AlertDialog(
+    WearActionDialog(
         visible = true,
+        title =
+            when {
+                updateAvailable -> "Update available"
+                upToDate -> "Already up to date"
+                check.checkedFileCount == 0 -> "Update info missing"
+                else -> "Check incomplete"
+            },
+        message = refreshBundleDialogText(check),
+        confirmText = if (upToDate) "OK" else "Refresh",
+        onConfirm = if (upToDate) onDismiss else onConfirm,
         onDismissRequest = onDismiss,
-        title = {
-            Text(
-                text =
-                    when {
-                        updateAvailable -> "Update available"
-                        upToDate -> "Already up to date"
-                        check.checkedFileCount == 0 -> "Update info missing"
-                        else -> "Check incomplete"
-                    },
-                textAlign = TextAlign.Center,
-            )
-        },
-        text = {
-            Text(
-                text = refreshBundleDialogText(check),
-                textAlign = TextAlign.Center,
-            )
-        },
-        confirmButton = {
-            Button(onClick = if (upToDate) onDismiss else onConfirm) {
-                Text(if (upToDate) "OK" else "Refresh")
-            }
-        },
-        dismissButton = {
-            if (!upToDate) {
-                Button(
-                    onClick = onDismiss,
-                    colors =
-                        ButtonDefaults.buttonColors(
-                            containerColor = Color.White.copy(alpha = 0.12f),
-                            contentColor = Color.White,
-                        ),
-                ) {
-                    Text("Cancel")
-                }
-            }
-        },
+        dismissText = if (upToDate) null else "Cancel",
     )
 }
 
@@ -279,45 +234,19 @@ internal fun RefreshBundleSummaryDialog(
 
     val refreshCount = summary.bundlesToRefresh.size
     val hasUpdates = refreshCount > 0
-    AlertDialog(
+    WearActionDialog(
         visible = true,
+        title =
+            when {
+                hasUpdates -> "Refresh bundles?"
+                summary.unknownCount > 0 -> "Check incomplete"
+                else -> "All up to date"
+            },
+        message = refreshSummaryDialogText(summary),
+        confirmText = if (hasUpdates) "Refresh $refreshCount" else "OK",
+        onConfirm = if (hasUpdates) onConfirm else onDismiss,
         onDismissRequest = onDismiss,
-        title = {
-            Text(
-                text =
-                    when {
-                        hasUpdates -> "Refresh bundles?"
-                        summary.unknownCount > 0 -> "Check incomplete"
-                        else -> "All up to date"
-                    },
-                textAlign = TextAlign.Center,
-            )
-        },
-        text = {
-            Text(
-                text = refreshSummaryDialogText(summary),
-                textAlign = TextAlign.Center,
-            )
-        },
-        confirmButton = {
-            Button(onClick = if (hasUpdates) onConfirm else onDismiss) {
-                Text(if (hasUpdates) "Refresh $refreshCount" else "OK")
-            }
-        },
-        dismissButton = {
-            if (hasUpdates) {
-                Button(
-                    onClick = onDismiss,
-                    colors =
-                        ButtonDefaults.buttonColors(
-                            containerColor = Color.White.copy(alpha = 0.12f),
-                            contentColor = Color.White,
-                        ),
-                ) {
-                    Text("Cancel")
-                }
-            }
-        },
+        dismissText = if (hasUpdates) "Cancel" else null,
     )
 }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadDialogs.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadDialogs.kt
@@ -8,17 +8,13 @@ package com.glancemap.glancemapwearos.presentation.features.download
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Update
 import androidx.compose.runtime.Composable
@@ -37,16 +33,14 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.wear.compose.material3.AlertDialog
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
+import com.glancemap.glancemapwearos.presentation.ui.WearFormDialog
 import com.glancemap.glancemapwearos.presentation.ui.WearInfoDialog
-import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 
 @Composable
 internal fun AreaSearchDialog(
@@ -57,107 +51,72 @@ internal fun AreaSearchDialog(
 ) {
     if (!visible) return
 
-    val adaptive = rememberWearAdaptiveSpec()
     var draftQuery by remember(visible, initialQuery) { mutableStateOf(initialQuery) }
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
-    val scrollState = rememberScrollState()
-    val topPadding =
-        adaptive.dialogVerticalPadding +
-            adaptive.headerTopSafeInset +
-            if (adaptive.isRound) 18.dp else 0.dp
-    val bottomPadding =
-        adaptive.dialogVerticalPadding +
-            if (adaptive.isRound) 42.dp else 12.dp
-    val controlWidthFraction = if (adaptive.isRound) 0.86f else 1f
-    val buttonMinHeight = 44.dp
 
     LaunchedEffect(visible) {
         focusRequester.requestFocus()
         keyboardController?.show()
     }
 
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false),
-    ) {
-        Column(
+    WearFormDialog(
+        visible = visible,
+        title = "Search area",
+        onDismiss = onDismiss,
+    ) { formTokens ->
+        BasicTextField(
+            value = draftQuery,
+            onValueChange = { draftQuery = it.take(32) },
+            singleLine = true,
+            textStyle =
+                TextStyle(
+                    color = Color.White,
+                    textAlign = TextAlign.Center,
+                ),
+            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
             modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(Color.Black)
-                    .verticalScroll(scrollState)
-                    .padding(
-                        horizontal = adaptive.dialogHorizontalPadding,
-                    ).padding(
-                        top = topPadding,
-                        bottom = bottomPadding,
-                    ),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top),
-        ) {
-            Text(
-                text = "Search area",
-                style = MaterialTheme.typography.titleSmall,
-                textAlign = TextAlign.Center,
-            )
-
-            BasicTextField(
-                value = draftQuery,
-                onValueChange = { draftQuery = it.take(32) },
-                singleLine = true,
-                textStyle =
-                    TextStyle(
-                        color = Color.White,
+                formTokens.controlModifier
+                    .focusRequester(focusRequester)
+                    .background(
+                        Color(0xFF1F1F1F),
+                        RoundedCornerShape(12.dp),
+                    ).padding(horizontal = 12.dp, vertical = formTokens.textFieldVerticalPadding),
+            decorationBox = { innerTextField ->
+                if (draftQuery.isBlank()) {
+                    Text(
+                        text = "France, Alps...",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = Color.White.copy(alpha = 0.45f),
                         textAlign = TextAlign.Center,
-                    ),
-                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-                modifier =
-                    Modifier
-                        .fillMaxWidth(controlWidthFraction)
-                        .focusRequester(focusRequester)
-                        .background(
-                            Color(0xFF1F1F1F),
-                            RoundedCornerShape(12.dp),
-                        ).padding(horizontal = 12.dp, vertical = 10.dp),
-                decorationBox = { innerTextField ->
-                    if (draftQuery.isBlank()) {
-                        Text(
-                            text = "France, Alps...",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = Color.White.copy(alpha = 0.45f),
-                            textAlign = TextAlign.Center,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                    }
-                    innerTextField()
-                },
-            )
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+                innerTextField()
+            },
+        )
 
-            Button(
-                onClick = { onApply(draftQuery) },
-                modifier =
-                    Modifier
-                        .fillMaxWidth(controlWidthFraction)
-                        .heightIn(min = buttonMinHeight),
-            ) {
-                Text("Apply")
-            }
+        Button(
+            onClick = { onApply(draftQuery) },
+            modifier =
+                formTokens.controlModifier
+                    .heightIn(min = formTokens.buttonMinHeight),
+        ) {
+            Text("Apply")
+        }
 
-            Button(
-                onClick = onDismiss,
-                modifier =
-                    Modifier
-                        .fillMaxWidth(controlWidthFraction)
-                        .heightIn(min = buttonMinHeight),
-                colors =
-                    ButtonDefaults.buttonColors(
-                        containerColor = Color.White.copy(alpha = 0.12f),
-                        contentColor = Color.White,
-                    ),
-            ) {
-                Text("Cancel")
-            }
+        Button(
+            onClick = onDismiss,
+            modifier =
+                formTokens.controlModifier
+                    .heightIn(min = formTokens.buttonMinHeight),
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = Color.White.copy(alpha = 0.12f),
+                    contentColor = Color.White,
+                ),
+        ) {
+            Text("Cancel")
         }
     }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadScreen.kt
@@ -68,6 +68,7 @@ import com.glancemap.glancemapwearos.presentation.ui.CompactIconHitTargetButton
 import com.glancemap.glancemapwearos.presentation.ui.DeleteConfirmationDialog
 import com.glancemap.glancemapwearos.presentation.ui.KeepScreenOnEffect
 import com.glancemap.glancemapwearos.presentation.ui.WearScreenSize
+import com.glancemap.glancemapwearos.presentation.ui.cappedFontScale
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearScreenSize
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
@@ -338,6 +339,7 @@ fun DownloadScreen(
                 refreshMode = refreshMode,
                 deleteMode = deleteMode,
                 selectedRefreshBundleCount = uiState.selectedRefreshBundleIds.size,
+                useLargeFontHeader = adaptive.isRound && adaptive.fontScale >= 1.25f,
                 topPadding = headerTopSafePadding,
                 bottomPadding = headerBottomPadding,
                 actionButtonSize = headerActionButtonSize,
@@ -657,6 +659,7 @@ private fun DownloadHeader(
     refreshMode: Boolean,
     deleteMode: Boolean,
     selectedRefreshBundleCount: Int,
+    useLargeFontHeader: Boolean,
     topPadding: Dp,
     bottomPadding: Dp,
     actionButtonSize: Dp,
@@ -678,13 +681,25 @@ private fun DownloadHeader(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(verticalSpacing),
         ) {
-            Text(
-                text = "Download",
-                style = MaterialTheme.typography.titleMedium,
-                textAlign = TextAlign.Center,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+            if (useLargeFontHeader) {
+                cappedFontScale(maxFontScale = 1.08f) {
+                    Text(
+                        text = "Download",
+                        style = MaterialTheme.typography.titleSmall,
+                        textAlign = TextAlign.Center,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            } else {
+                Text(
+                    text = "Download",
+                    style = MaterialTheme.typography.titleMedium,
+                    textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
             Row(
                 horizontalArrangement = Arrangement.spacedBy(actionSpacing),
                 verticalAlignment = Alignment.CenterVertically,
@@ -709,17 +724,30 @@ private fun DownloadHeader(
                 )
             }
             if (refreshMode) {
-                Text(
-                    text =
-                        when {
-                            isCheckingUpdates -> "Checking selected"
-                            selectedRefreshBundleCount == 0 -> "Select bundles to update"
-                            else -> "$selectedRefreshBundleCount selected"
-                        },
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.primary,
-                    textAlign = TextAlign.Center,
-                )
+                val refreshInstruction =
+                    when {
+                        isCheckingUpdates -> "Checking selected"
+                        selectedRefreshBundleCount == 0 && useLargeFontHeader -> "Select bundles"
+                        selectedRefreshBundleCount == 0 -> "Select bundles to update"
+                        else -> "$selectedRefreshBundleCount selected"
+                    }
+                if (useLargeFontHeader) {
+                    cappedFontScale(maxFontScale = 1.08f) {
+                        Text(
+                            text = refreshInstruction,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                } else {
+                    Text(
+                        text = refreshInstruction,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        textAlign = TextAlign.Center,
+                    )
+                }
             } else if (deleteMode) {
                 Text(
                     text = "Delete mode",

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadScreen.kt
@@ -199,9 +199,9 @@ fun DownloadScreen(
     val headerTopSafePadding = headerTopPadding + adaptive.headerTopSafeInset
     val actionButtonHeight =
         when (screenSize) {
-            WearScreenSize.LARGE -> 44.dp
-            WearScreenSize.MEDIUM -> 42.dp
-            WearScreenSize.SMALL -> 38.dp
+            WearScreenSize.LARGE -> 48.dp
+            WearScreenSize.MEDIUM -> 46.dp
+            WearScreenSize.SMALL -> 44.dp
         }
     val actionButtonIconSize =
         when (screenSize) {
@@ -339,7 +339,7 @@ fun DownloadScreen(
                 refreshMode = refreshMode,
                 deleteMode = deleteMode,
                 selectedRefreshBundleCount = uiState.selectedRefreshBundleIds.size,
-                useLargeFontHeader = adaptive.isRound && adaptive.fontScale >= 1.25f,
+                useLargeFontHeader = adaptive.isRound && adaptive.fontScale > 1f,
                 topPadding = headerTopSafePadding,
                 bottomPadding = headerBottomPadding,
                 actionButtonSize = headerActionButtonSize,
@@ -356,6 +356,7 @@ fun DownloadScreen(
                     }
                     if (nextRefreshMode) {
                         deleteMode = false
+                        onAreaPickerOpenChange(false)
                         coroutineScope.launch {
                             listState.animateScrollToItem(DOWNLOAD_FIRST_REFRESH_BUNDLE_ITEM_INDEX)
                         }
@@ -398,73 +399,77 @@ fun DownloadScreen(
                         onToggleArea = viewModel::toggleArea,
                     )
                 } else {
-                    item {
-                        DownloadChip(
-                            label = selectedAreaLabel,
-                            secondaryLabel = selectedAreaSecondaryLabel,
-                            icon = Icons.Filled.UnfoldMore,
-                            onClick = {
-                                if (!uiState.isDownloading) {
-                                    onAreaPickerOpenChange(true)
-                                }
-                            },
-                        )
-                    }
-
-                    item {
-                        DownloadSummary(
-                            areas = selectedAreas,
-                            selection = uiState.selection,
-                            estimatedSize = estimatedSize,
-                        )
-                    }
-
-                    if (uiState.isDownloading) {
+                    if (!refreshMode) {
                         item {
-                            DownloadProgress(uiState)
-                        }
-                        item {
-                            DownloadActionButton(
-                                label = "Pause",
-                                icon = Icons.Filled.Pause,
-                                enabled = true,
-                                height = actionButtonHeight,
-                                iconSize = actionButtonIconSize,
-                                onClick = viewModel::pauseDownload,
+                            DownloadChip(
+                                label = selectedAreaLabel,
+                                secondaryLabel = selectedAreaSecondaryLabel,
+                                icon = Icons.Filled.UnfoldMore,
+                                onClick = {
+                                    if (!uiState.isDownloading) {
+                                        onAreaPickerOpenChange(true)
+                                    }
+                                },
                             )
                         }
+
                         item {
-                            DownloadActionButton(
-                                label = "Cancel",
-                                icon = Icons.Filled.Close,
-                                enabled = true,
-                                containerColor = MaterialTheme.colorScheme.errorContainer,
-                                contentColor = MaterialTheme.colorScheme.onErrorContainer,
-                                height = actionButtonHeight,
-                                iconSize = actionButtonIconSize,
-                                onClick = viewModel::cancelDownload,
+                            DownloadSummary(
+                                areas = selectedAreas,
+                                selection = uiState.selection,
+                                estimatedSize = estimatedSize,
                             )
                         }
-                    } else {
-                        item {
-                            DownloadActionButton(
-                                label = if (uiState.isPausedDownload) "Resume" else "Download",
-                                icon = Icons.Filled.Download,
-                                enabled = uiState.selection.canDownload && selectedAreas.isNotEmpty(),
-                                height = actionButtonHeight,
-                                iconSize = actionButtonIconSize,
-                                onClick = viewModel::downloadSelectedBundle,
-                            )
+
+                        if (uiState.isDownloading) {
+                            item {
+                                DownloadProgress(uiState)
+                            }
+                            item {
+                                DownloadActionButton(
+                                    label = "Pause",
+                                    icon = Icons.Filled.Pause,
+                                    enabled = true,
+                                    height = actionButtonHeight,
+                                    iconSize = actionButtonIconSize,
+                                    onClick = viewModel::pauseDownload,
+                                )
+                            }
+                            item {
+                                DownloadActionButton(
+                                    label = "Cancel",
+                                    icon = Icons.Filled.Close,
+                                    enabled = true,
+                                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                                    height = actionButtonHeight,
+                                    iconSize = actionButtonIconSize,
+                                    onClick = viewModel::cancelDownload,
+                                )
+                            }
+                        } else {
+                            item {
+                                DownloadActionButton(
+                                    label = if (uiState.isPausedDownload) "Resume" else "Download",
+                                    icon = Icons.Filled.Download,
+                                    enabled = uiState.selection.canDownload && selectedAreas.isNotEmpty(),
+                                    height = actionButtonHeight,
+                                    iconSize = actionButtonIconSize,
+                                    onClick = viewModel::downloadSelectedBundle,
+                                )
+                            }
                         }
                     }
 
-                    item {
-                        Text(
-                            text = "Installed bundles",
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.72f),
-                            maxLines = 1,
-                        )
+                    if (!refreshMode) {
+                        item {
+                            Text(
+                                text = "Installed bundles",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.72f),
+                                maxLines = 1,
+                            )
+                        }
                     }
 
                     if (uiState.installedBundles.isEmpty()) {
@@ -478,7 +483,13 @@ fun DownloadScreen(
                             )
                         }
                     } else {
-                        if (refreshMode) {
+                        if (
+                            refreshMode &&
+                            (
+                                uiState.selectedRefreshBundleIds.isNotEmpty() ||
+                                    uiState.isCheckingUpdates
+                            )
+                        ) {
                             item {
                                 DownloadActionButton(
                                     label =
@@ -682,7 +693,7 @@ private fun DownloadHeader(
             verticalArrangement = Arrangement.spacedBy(verticalSpacing),
         ) {
             if (useLargeFontHeader) {
-                cappedFontScale(maxFontScale = 1.08f) {
+                cappedFontScale(maxFontScale = 1f) {
                     Text(
                         text = "Download",
                         style = MaterialTheme.typography.titleSmall,
@@ -726,18 +737,22 @@ private fun DownloadHeader(
             if (refreshMode) {
                 val refreshInstruction =
                     when {
+                        isCheckingUpdates && useLargeFontHeader -> "Checking"
                         isCheckingUpdates -> "Checking selected"
-                        selectedRefreshBundleCount == 0 && useLargeFontHeader -> "Select bundles"
+                        selectedRefreshBundleCount == 0 && useLargeFontHeader -> "Select"
                         selectedRefreshBundleCount == 0 -> "Select bundles to update"
                         else -> "$selectedRefreshBundleCount selected"
                     }
                 if (useLargeFontHeader) {
-                    cappedFontScale(maxFontScale = 1.08f) {
+                    cappedFontScale(maxFontScale = 1f) {
                         Text(
                             text = refreshInstruction,
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.primary,
                             textAlign = TextAlign.Center,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.padding(top = 6.dp),
                         )
                     }
                 } else {
@@ -746,6 +761,7 @@ private fun DownloadHeader(
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.primary,
                         textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(top = 6.dp),
                     )
                 }
             } else if (deleteMode) {
@@ -1087,4 +1103,4 @@ private val SelectedChipIcon = Color(0xFF7FE4C8)
 private const val DOWNLOAD_INFO_PREFS = "download_screen_info_prefs"
 private const val DOWNLOAD_INFO_SHOWN_KEY = "oam_info_shown"
 private const val DOWNLOAD_MAIN_ACTION_ITEM_INDEX = 2
-private const val DOWNLOAD_FIRST_REFRESH_BUNDLE_ITEM_INDEX = 5
+private const val DOWNLOAD_FIRST_REFRESH_BUNDLE_ITEM_INDEX = 0

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadSettingsScreen.kt
@@ -2,9 +2,6 @@
 
 package com.glancemap.glancemapwearos.presentation.features.download
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -20,20 +17,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.SplitSwitchButton
 import androidx.wear.compose.material3.SwitchButtonDefaults
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.core.maps.DemSource
 import com.glancemap.glancemapwearos.presentation.features.settings.OptionPickerDialog
-import com.glancemap.glancemapwearos.presentation.features.settings.SettingsListAnchorType
-import com.glancemap.glancemapwearos.presentation.features.settings.SettingsListAutoCentering
 import com.glancemap.glancemapwearos.presentation.features.settings.SettingsToggleChip
+import com.glancemap.glancemapwearos.presentation.features.settings.WearSettingsListScreen
 import com.glancemap.glancemapwearos.presentation.features.settings.rememberSettingsListTokens
-import com.glancemap.glancemapwearos.presentation.features.settings.rememberSettingsScalingLazyListState
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.compose.layout.ScreenScaffold
 
 @OptIn(ExperimentalHorologistApi::class)
 @Composable
@@ -45,7 +38,6 @@ fun DownloadSettingsScreen(viewModel: DownloadViewModel) {
             standardTop = 44.dp,
             expandedTop = 48.dp,
         )
-    val listState = rememberSettingsScalingLazyListState(topPadding = listTokens.topPadding)
     var showDemSourcePicker by remember { mutableStateOf(false) }
 
     OptionPickerDialog(
@@ -57,62 +49,46 @@ fun DownloadSettingsScreen(viewModel: DownloadViewModel) {
         onSelect = viewModel::setDemSource,
     )
 
-    ScreenScaffold(scrollState = listState) {
-        ScalingLazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            state = listState,
-            contentPadding =
-                PaddingValues(
-                    start = listTokens.horizontalPadding,
-                    end = listTokens.horizontalPadding,
-                    top = listTokens.topPadding,
-                    bottom = listTokens.bottomPadding,
-                ),
-            verticalArrangement = Arrangement.spacedBy(listTokens.itemSpacing),
-            anchorType = SettingsListAnchorType,
-            autoCentering = SettingsListAutoCentering,
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            item {
-                SettingsToggleChip(
-                    checked = uiState.selection.includeMap,
-                    onCheckedChanged = viewModel::setIncludeMap,
-                    label = "Maps",
-                    secondaryLabel = "OpenAndroMaps",
-                )
-            }
-            item {
-                SettingsToggleChip(
-                    checked = uiState.selection.includePoi,
-                    onCheckedChanged = viewModel::setIncludePoi,
-                    label = "POI",
-                    secondaryLabel = "Mapsforge POI",
-                )
-            }
-            item {
-                SettingsToggleChip(
-                    checked = uiState.selection.includeRouting,
-                    onCheckedChanged = viewModel::setIncludeRouting,
-                    label = "Routing",
-                    secondaryLabel = "BRouter RD5",
-                )
-            }
-            item {
-                ElevationDownloadSetting(
-                    checked = uiState.selection.includeDem,
-                    source = uiState.selection.demSource,
-                    onCheckedChanged = viewModel::setIncludeDem,
-                    onPickSource = { showDemSourcePicker = true },
-                )
-            }
-            item {
-                SettingsToggleChip(
-                    checked = uiState.selection.includeRefugesInfo,
-                    onCheckedChanged = viewModel::setIncludeRefugesInfo,
-                    label = "Refuges.info",
-                    secondaryLabel = "All refuge POIs",
-                )
-            }
+    WearSettingsListScreen(listTokens = listTokens, horizontalAlignment = Alignment.CenterHorizontally) {
+        item {
+            SettingsToggleChip(
+                checked = uiState.selection.includeMap,
+                onCheckedChanged = viewModel::setIncludeMap,
+                label = "Maps",
+                secondaryLabel = "OpenAndroMaps",
+            )
+        }
+        item {
+            SettingsToggleChip(
+                checked = uiState.selection.includePoi,
+                onCheckedChanged = viewModel::setIncludePoi,
+                label = "POI",
+                secondaryLabel = "Mapsforge POI",
+            )
+        }
+        item {
+            SettingsToggleChip(
+                checked = uiState.selection.includeRouting,
+                onCheckedChanged = viewModel::setIncludeRouting,
+                label = "Routing",
+                secondaryLabel = "BRouter RD5",
+            )
+        }
+        item {
+            ElevationDownloadSetting(
+                checked = uiState.selection.includeDem,
+                source = uiState.selection.demSource,
+                onCheckedChanged = viewModel::setIncludeDem,
+                onPickSource = { showDemSourcePicker = true },
+            )
+        }
+        item {
+            SettingsToggleChip(
+                checked = uiState.selection.includeRefugesInfo,
+                onCheckedChanged = viewModel::setIncludeRefugesInfo,
+                label = "Refuges.info",
+                secondaryLabel = "All refuge POIs",
+            )
         }
     }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxHelpBottomSheet.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxHelpBottomSheet.kt
@@ -1,6 +1,5 @@
 package com.glancemap.glancemapwearos.presentation.features.gpx
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.InlineTextContent
@@ -13,13 +12,10 @@ import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.wear.compose.material3.AlertDialog
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.R
-import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpacer
-import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollableColumn
-import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
+import com.glancemap.glancemapwearos.presentation.ui.WearInfoDialog
 
 @Composable
 fun GpxHelpBottomSheet(
@@ -27,52 +23,58 @@ fun GpxHelpBottomSheet(
     onDismiss: () -> Unit,
 ) {
     if (!visible) return
-    val adaptive = rememberWearAdaptiveSpec()
 
-    AlertDialog(
+    WearInfoDialog(
         visible = visible,
-        onDismissRequest = onDismiss,
-        title = { Text("GPX Actions") },
-        text = {
-            WearDialogScrollableColumn(
-                maxHeight = adaptive.helpDialogMaxHeight,
-                modifier =
-                    Modifier
-                        .fillMaxWidth(),
-                scrollable = false,
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Text("Toggle tracks to show or hide them on the map.")
-                Text("Long press a track to view elevation.")
-                Text(
-                    text =
-                        buildAnnotatedString {
-                            append("Use the ")
-                            appendInlineContent("sendToPhone", "[send]")
-                            append(" button to select one or more GPX, then send them to your phone.")
-                        },
-                    inlineContent =
-                        mapOf(
-                            "sendToPhone" to
-                                InlineTextContent(
-                                    placeholder =
-                                        Placeholder(
-                                            width = 16.sp,
-                                            height = 16.sp,
-                                            placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
-                                        ),
-                                ) {
-                                    Icon(
-                                        painter = painterResource(R.drawable.ic_mobile_arrow_right),
-                                        contentDescription = null,
-                                        modifier = Modifier.size(16.dp),
-                                    )
-                                },
-                        ),
-                )
-                Text("Use edit or delete mode to rename or remove tracks.")
-                WearDialogScrollBottomSpacer()
-            }
-        },
-    )
+        title = "GPX Actions",
+        onDismiss = onDismiss,
+    ) {
+        item {
+            Text(
+                "Toggle tracks to show or hide them on the map.",
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        item {
+            Text(
+                "Long press a track to view elevation.",
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        item {
+            Text(
+                text =
+                    buildAnnotatedString {
+                        append("Use the ")
+                        appendInlineContent("sendToPhone", "[send]")
+                        append(" button to select one or more GPX, then send them to your phone.")
+                    },
+                modifier = Modifier.fillMaxWidth(),
+                inlineContent =
+                    mapOf(
+                        "sendToPhone" to
+                            InlineTextContent(
+                                placeholder =
+                                    Placeholder(
+                                        width = 16.sp,
+                                        height = 16.sp,
+                                        placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
+                                    ),
+                            ) {
+                                Icon(
+                                    painter = painterResource(R.drawable.ic_mobile_arrow_right),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(16.dp),
+                                )
+                            },
+                    ),
+            )
+        }
+        item {
+            Text(
+                "Use edit or delete mode to rename or remove tracks.",
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/home/MainScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/home/MainScreen.kt
@@ -60,6 +60,7 @@ import com.glancemap.glancemapwearos.presentation.features.settings.SettingsView
 import com.glancemap.glancemapwearos.presentation.navigation.WatchRoutes
 import com.glancemap.glancemapwearos.presentation.ui.WearScreenEdgeScrollIndicator
 import com.glancemap.glancemapwearos.presentation.ui.WearScreenSize
+import com.glancemap.glancemapwearos.presentation.ui.cappedFontScale
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearScreenSize
 import kotlinx.coroutines.delay
@@ -338,15 +339,18 @@ private fun GpsStatusOverlay(
             modifier
                 .background(
                     color = Color.Black.copy(alpha = 0.88f),
-                    shape = RoundedCornerShape(14.dp),
-                ).padding(horizontal = 14.dp, vertical = 8.dp),
+                    shape = RoundedCornerShape(12.dp),
+                ).padding(horizontal = 10.dp, vertical = 6.dp),
     ) {
-        Text(
-            text = message,
-            color = Color.White,
-            maxLines = 2,
-            textAlign = TextAlign.Center,
-        )
+        cappedFontScale(maxFontScale = 1.1f) {
+            Text(
+                text = message,
+                color = Color.White,
+                maxLines = 1,
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.titleSmall,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/DemSetupBottomSheet.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/DemSetupBottomSheet.kt
@@ -1,43 +1,24 @@
+@file:Suppress("MatchingDeclarationName")
+
 package com.glancemap.glancemapwearos.presentation.features.maps
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.focusable
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Landscape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.input.rotary.onPreRotaryScrollEvent
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
-import com.glancemap.glancemapwearos.presentation.ui.WearCustomDialogScrollableColumn
-import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
-import kotlin.math.abs
-
-private const val DEM_SETUP_DRAG_DISMISS_PX = 55f
+import com.glancemap.glancemapwearos.presentation.ui.WearInfoDialog
 
 enum class DemSetupReason {
     GENERIC,
@@ -54,9 +35,6 @@ fun DemSetupBottomSheet(
     onDismiss: () -> Unit,
 ) {
     if (!visible) return
-    val adaptive = rememberWearAdaptiveSpec()
-    val scrollState = rememberScrollState()
-    val focusRequester = remember { FocusRequester() }
     val title =
         when (reason) {
             DemSetupReason.GENERIC -> "DEM Setup"
@@ -83,101 +61,43 @@ fun DemSetupBottomSheet(
                     "Open Maps and tap the DEM icon to download it.\n" +
                     "When it is ready, come back and enable Slope overlay again."
         }
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
-    }
 
-    Dialog(onDismissRequest = onDismiss) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .background(
-                        Color.Black.copy(alpha = 0.82f),
-                        RoundedCornerShape(adaptive.dialogCornerRadius),
-                    ).padding(
-                        horizontal = adaptive.dialogHorizontalPadding,
-                        vertical = adaptive.dialogVerticalPadding,
-                    ),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(6.dp),
-        ) {
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .pointerInput(Unit) {
-                            var totalDrag = 0f
-                            detectVerticalDragGestures(
-                                onDragEnd = { totalDrag = 0f },
-                                onDragCancel = { totalDrag = 0f },
-                            ) { _, dragAmount ->
-                                totalDrag += dragAmount
-                                if (totalDrag > DEM_SETUP_DRAG_DISMISS_PX) {
-                                    onDismiss()
-                                    totalDrag = 0f
-                                }
-                            }
-                        },
-                contentAlignment = Alignment.Center,
-            ) {
-                Box(
-                    modifier =
-                        Modifier
-                            .width(26.dp)
-                            .height(3.dp)
-                            .background(Color.White.copy(alpha = 0.42f), RoundedCornerShape(50)),
-                )
-            }
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-                textAlign = TextAlign.Center,
-            )
-            WearCustomDialogScrollableColumn(
-                maxHeight = adaptive.dialogBodyMaxHeight,
-                modifier =
-                    Modifier
-                        .fillMaxWidth(),
-                contentModifier =
-                    Modifier
-                        .onPreRotaryScrollEvent { event ->
-                            val consumed = scrollState.dispatchRawDelta(event.verticalScrollPixels)
-                            abs(consumed) > 0.5f
-                        }.focusRequester(focusRequester)
-                        .focusable(),
-                scrollState = scrollState,
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(6.dp),
-            ) {
-                if (reason == DemSetupReason.GENERIC) {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(5.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Landscape,
-                            contentDescription = "Elevation icon",
-                            tint = Color(0xFFFFB300),
-                            modifier = Modifier.size(16.dp),
-                        )
-                        Text(
-                            text = "DEM",
-                            style = MaterialTheme.typography.titleSmall,
-                        )
-                        Icon(
-                            imageVector = Icons.Default.Info,
-                            contentDescription = "DEM means elevation data",
-                            tint = Color.White.copy(alpha = 0.82f),
-                            modifier = Modifier.size(14.dp),
-                        )
-                    }
+    WearInfoDialog(
+        visible = visible,
+        title = title,
+        onDismiss = onDismiss,
+    ) {
+        if (reason == DemSetupReason.GENERIC) {
+            item {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(5.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Landscape,
+                        contentDescription = "Elevation icon",
+                        tint = Color(0xFFFFB300),
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Text(
+                        text = "DEM",
+                        style = MaterialTheme.typography.titleSmall,
+                    )
+                    Icon(
+                        imageVector = Icons.Default.Info,
+                        contentDescription = "DEM means elevation data",
+                        tint = Color.White.copy(alpha = 0.82f),
+                        modifier = Modifier.size(14.dp),
+                    )
                 }
-                Text(
-                    text = message,
-                    textAlign = TextAlign.Center,
-                )
             }
+        }
+        item {
+            Text(
+                text = message,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
     }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
@@ -72,6 +72,7 @@ import com.glancemap.glancemapwearos.presentation.navigation.WatchRoutes
 import com.glancemap.glancemapwearos.presentation.ui.CompactIconHitTargetButton
 import com.glancemap.glancemapwearos.presentation.ui.DeleteConfirmationDialog
 import com.glancemap.glancemapwearos.presentation.ui.RenameValueDialog
+import com.glancemap.glancemapwearos.presentation.ui.WearActionDialog
 import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpacer
 import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollableColumn
 import com.glancemap.glancemapwearos.presentation.ui.WearInfoDialog
@@ -355,22 +356,16 @@ fun MapsScreen(
             },
         )
 
-        AlertDialog(
+        WearActionDialog(
             visible = showDemNetworkErrorDialog,
+            title = "DEM download failed",
+            message =
+                demNetworkErrorMessage.ifBlank {
+                    "No internet on watch. Connect Wi-Fi or phone internet, then retry DEM download."
+                },
+            confirmText = "OK",
+            onConfirm = { showDemNetworkErrorDialog = false },
             onDismissRequest = { showDemNetworkErrorDialog = false },
-            title = { Text("DEM download failed") },
-            text = {
-                Text(
-                    demNetworkErrorMessage.ifBlank {
-                        "No internet on watch. Connect Wi-Fi or phone internet, then retry DEM download."
-                    },
-                )
-            },
-            confirmButton = {
-                Button(onClick = { showDemNetworkErrorDialog = false }) {
-                    Text("OK")
-                }
-            },
         )
 
         DeleteConfirmationDialog(

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
@@ -74,6 +74,7 @@ import com.glancemap.glancemapwearos.presentation.ui.DeleteConfirmationDialog
 import com.glancemap.glancemapwearos.presentation.ui.RenameValueDialog
 import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpacer
 import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollableColumn
+import com.glancemap.glancemapwearos.presentation.ui.WearInfoDialog
 import com.glancemap.glancemapwearos.presentation.ui.WearScreenSize
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearScreenSize
@@ -566,64 +567,74 @@ fun MapsScreen(
             },
         )
 
-        AlertDialog(
+        WearInfoDialog(
             visible = showHelpDialog,
-            onDismissRequest = { dismissHelpDialog() },
-            title = { Text("Map Actions") },
-            text = {
-                WearDialogScrollableColumn(
-                    maxHeight = adaptive.helpDialogMaxHeight,
-                    modifier =
-                        Modifier
-                            .fillMaxWidth(),
-                    scrollable = false,
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
+            title = "Map Actions",
+            onDismiss = { dismissHelpDialog() },
+        ) {
+            item {
+                Text(
+                    "Toggle a map to use it on Navigate.",
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            item {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
                 ) {
-                    Text("Toggle a map to use it on Navigate.")
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Download,
-                            contentDescription = null,
-                            modifier = Modifier.size(16.dp),
-                        )
-                        Text(
-                            "Use the download bundle or the phone app to send .map and " +
-                                "routing to the watch.",
-                        )
-                    }
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Landscape,
-                            contentDescription = null,
-                            modifier = Modifier.size(16.dp),
-                        )
-                        Text(
-                            "Click on Elevation icon to download elevation that adds " +
-                                "altitude, slope, and terrain shading.",
-                        )
-                    }
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.CallSplit,
-                            contentDescription = null,
-                            modifier = Modifier.size(16.dp),
-                        )
-                        Text("Routing enables offline route calculation.")
-                    }
-                    Text("Grey means missing, amber partial, green ready.")
-                    WearDialogScrollBottomSpacer()
+                    Icon(
+                        imageVector = Icons.Default.Download,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Text(
+                        "Use the download bundle or the phone app to send .map and " +
+                            "routing to the watch.",
+                    )
                 }
-            },
-        )
+            }
+            item {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Landscape,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Text(
+                        "Click on Elevation icon to download elevation that adds " +
+                            "altitude, slope, and terrain shading.",
+                    )
+                }
+            }
+            item {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.CallSplit,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Text("Routing enables offline route calculation.")
+                }
+            }
+            item {
+                Text(
+                    "Grey means missing, amber partial, green ready.",
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
         Column(
             modifier = Modifier.fillMaxSize(),
         ) {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateContent.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateContent.kt
@@ -13,9 +13,12 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -425,6 +428,13 @@ internal fun NavigateContent(
             adaptive.fontScale >= 1.25f -> 50.dp
             else -> 0.dp
         }
+    val permissionScrollBottomPadding =
+        permissionContentPadding +
+            when {
+                adaptive.fontScale >= 1.45f -> 36.dp
+                adaptive.fontScale >= 1.25f -> 28.dp
+                else -> 20.dp
+            }
     val latestNavMode = rememberUpdatedState(navMode)
     val latestOnUserPanStarted = rememberUpdatedState(onUserPanStarted)
     val latestOnInspectTrack = rememberUpdatedState(onInspectTrack)
@@ -1221,24 +1231,39 @@ internal fun NavigateContent(
             scaleIndicator = null
             val permissionScrollState = rememberScrollState()
             Box(modifier = Modifier.fillMaxSize()) {
-                Column(
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .padding(permissionContentPadding)
-                            .verticalScroll(permissionScrollState),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center,
-                ) {
-                    Text(
-                        "Location permission required for this screen.",
-                        textAlign = TextAlign.Center,
-                    )
-                    Button(
-                        onClick = onPermissionLaunch,
-                        modifier = Modifier.heightIn(min = permissionButtonMinHeight),
+                BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                    Column(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .heightIn(min = maxHeight)
+                                .verticalScroll(permissionScrollState)
+                                .padding(
+                                    start = permissionContentPadding,
+                                    top = permissionContentPadding,
+                                    end = permissionContentPadding,
+                                    bottom = permissionScrollBottomPadding,
+                                ),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterVertically),
                     ) {
-                        Text("Grant Permission")
+                        Text(
+                            "Location permission required for this screen.",
+                            textAlign = TextAlign.Center,
+                        )
+                        Button(
+                            onClick = onPermissionLaunch,
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .heightIn(min = permissionButtonMinHeight),
+                        ) {
+                            Text(
+                                "Grant Permission",
+                                textAlign = TextAlign.Center,
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(1.dp))
                     }
                 }
                 WearVerticalScrollIndicator(

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateContent.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateContent.kt
@@ -435,6 +435,18 @@ internal fun NavigateContent(
                 adaptive.fontScale >= 1.25f -> 28.dp
                 else -> 20.dp
             }
+    val permissionScrollTopPadding =
+        permissionContentPadding +
+            adaptive.headerTopSafeInset +
+            if (adaptive.isRound) {
+                when {
+                    adaptive.fontScale >= 1.45f -> 34.dp
+                    adaptive.fontScale >= 1.25f -> 26.dp
+                    else -> 18.dp
+                }
+            } else {
+                0.dp
+            }
     val latestNavMode = rememberUpdatedState(navMode)
     val latestOnUserPanStarted = rememberUpdatedState(onUserPanStarted)
     val latestOnInspectTrack = rememberUpdatedState(onInspectTrack)
@@ -1240,7 +1252,7 @@ internal fun NavigateContent(
                                 .verticalScroll(permissionScrollState)
                                 .padding(
                                     start = permissionContentPadding,
-                                    top = permissionContentPadding,
+                                    top = permissionScrollTopPadding,
                                     end = permissionContentPadding,
                                     bottom = permissionScrollBottomPadding,
                                 ),

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.Dialogs.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.Dialogs.kt
@@ -14,9 +14,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.wear.compose.material3.AlertDialog
-import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.data.repository.UserPoiRecord
@@ -30,6 +27,9 @@ import com.glancemap.glancemapwearos.presentation.features.routetools.RouteToolS
 import com.glancemap.glancemapwearos.presentation.features.routetools.RouteToolSession
 import com.glancemap.glancemapwearos.presentation.features.routetools.RouteToolsActionPanel
 import com.glancemap.glancemapwearos.presentation.ui.RenameValueDialog
+import com.glancemap.glancemapwearos.presentation.ui.WearActionButtonRole
+import com.glancemap.glancemapwearos.presentation.ui.WearActionDialog
+import com.glancemap.glancemapwearos.presentation.ui.WearActionDialogButton
 import org.mapsforge.core.model.LatLong
 
 @Composable
@@ -41,52 +41,68 @@ internal fun NavigateKeepAppOpenDialog(
     onContinue: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    if (!visible) return
-
-    AlertDialog(
-        visible = true,
+    WearActionDialog(
+        visible = visible,
+        title = "Stay open",
         onDismissRequest = onDismiss,
-        title = {
-            Text(
-                text = "Stay open",
-                fontSize = 16.sp,
-                lineHeight = 18.sp,
-            )
-        },
-        text = {
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                KeepAppOpenInfoRow(
-                    imageVector = Icons.Filled.Visibility,
-                    text = "keeps GlanceMap active.",
-                )
-                KeepAppOpenInfoRow(
-                    imageVector = Icons.Filled.VisibilityOff,
-                    text = "lets the watch sleep and removes it from Recents.",
-                )
-            }
-        },
-        confirmButton = {
-            Button(onClick = onContinue) {
-                Text(
+        buttons =
+            listOf(
+                WearActionDialogButton(
                     text = "Continue",
-                    fontSize = 12.sp,
-                    lineHeight = 14.sp,
-                )
-            }
-        },
-        dismissButton = {
-            Button(onClick = onDismiss) {
-                Text(
+                    onClick = onContinue,
+                ),
+                WearActionDialogButton(
                     text = "Later",
-                    fontSize = 12.sp,
-                    lineHeight = 14.sp,
-                )
-            }
-        },
-    )
+                    onClick = onDismiss,
+                    role = WearActionButtonRole.Secondary,
+                ),
+            ),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            KeepAppOpenInfoRow(
+                imageVector = Icons.Filled.Visibility,
+                text = "keeps GlanceMap active.",
+            )
+            KeepAppOpenInfoRow(
+                imageVector = Icons.Filled.VisibilityOff,
+                text = "lets the watch sleep and removes it from Recents.",
+            )
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+internal fun NavigateNotificationPermissionDialog(
+    visible: Boolean,
+    onContinue: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    WearActionDialog(
+        visible = visible,
+        title = "Notifications",
+        onDismissRequest = onDismiss,
+        buttons =
+            listOf(
+                WearActionDialogButton(
+                    text = "Continue",
+                    onClick = onContinue,
+                ),
+                WearActionDialogButton(
+                    text = "Later",
+                    onClick = onDismiss,
+                    role = WearActionButtonRole.Secondary,
+                ),
+            ),
+    ) {
+        KeepAppOpenInfoRow(
+            imageVector = Icons.Filled.Visibility,
+            text = "Stay uses notifications while GlanceMap remains active.",
+        )
+    }
 }
 
 @Composable
@@ -107,8 +123,6 @@ private fun KeepAppOpenInfoRow(
         )
         Text(
             text = text,
-            fontSize = 12.sp,
-            lineHeight = 14.sp,
         )
     }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.kt
@@ -153,6 +153,7 @@ fun NavigateScreen(
     val keepAppOpenTipShown by settingsViewModel.keepAppOpenTipShown.collectAsState(initial = false)
     var pendingKeepAppOpen by rememberSaveable { mutableStateOf(false) }
     var showKeepAppOpenInfoDialog by rememberSaveable { mutableStateOf(false) }
+    var showNotificationPermissionDialog by rememberSaveable { mutableStateOf(false) }
     var hasAppliedInitialKeepAppOpenSync by rememberSaveable { mutableStateOf(false) }
 
     // ---- PERMISSIONS ----
@@ -173,7 +174,7 @@ fun NavigateScreen(
                     notificationPermissionState.isPermissionRequired &&
                     !notificationPermissionState.hasNotificationPermission
                 ) {
-                    notificationPermissionState.launchPermissionRequest()
+                    showNotificationPermissionDialog = true
                 } else {
                     settingsViewModel.setKeepAppOpen(true)
                     pendingKeepAppOpen = false
@@ -182,6 +183,10 @@ fun NavigateScreen(
                 pendingKeepAppOpen = false
             }
         }
+    val notificationPermissionPromptState =
+        notificationPermissionState.copy(
+            launchPermissionRequest = { showNotificationPermissionDialog = true },
+        )
 
     // ---- SETTINGS ----
     val zoomDefaultScaleMeters by settingsViewModel.mapZoomDefaultScaleMeters.collectAsState()
@@ -621,7 +626,7 @@ fun NavigateScreen(
             context = context,
             settingsViewModel = settingsViewModel,
             locationPermissionState = locationPermissionState,
-            notificationPermissionState = notificationPermissionState,
+            notificationPermissionState = notificationPermissionPromptState,
             keepAppOpen = keepAppOpen,
             keepAppOpenTipShown = keepAppOpenTipShown,
             offlineMode = offlineMode,
@@ -977,6 +982,18 @@ fun NavigateScreen(
         },
         onDismiss = {
             showKeepAppOpenInfoDialog = false
+            pendingKeepAppOpen = false
+        },
+    )
+
+    NavigateNotificationPermissionDialog(
+        visible = showNotificationPermissionDialog,
+        onContinue = {
+            showNotificationPermissionDialog = false
+            notificationPermissionState.launchPermissionRequest()
+        },
+        onDismiss = {
+            showNotificationPermissionDialog = false
             pendingKeepAppOpen = false
         },
     )

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiScreen.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import androidx.wear.compose.foundation.lazy.items
-import androidx.wear.compose.material3.AlertDialog
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
@@ -57,8 +56,7 @@ import com.glancemap.glancemapwearos.presentation.navigation.WatchRoutes
 import com.glancemap.glancemapwearos.presentation.ui.CompactIconHitTargetButton
 import com.glancemap.glancemapwearos.presentation.ui.DeleteConfirmationDialog
 import com.glancemap.glancemapwearos.presentation.ui.RenameValueDialog
-import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpacer
-import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollableColumn
+import com.glancemap.glancemapwearos.presentation.ui.WearInfoDialog
 import com.glancemap.glancemapwearos.presentation.ui.WearScreenSize
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearScreenSize
@@ -555,56 +553,64 @@ fun PoiScreen(
             },
         )
 
-        AlertDialog(
+        WearInfoDialog(
             visible = showHelpDialog,
-            onDismissRequest = { dismissHelpDialog() },
-            title = { Text("POI Actions") },
-            text = {
-                WearDialogScrollableColumn(
-                    maxHeight = adaptive.helpDialogMaxHeight,
-                    modifier =
-                        Modifier
-                            .fillMaxWidth(),
-                    scrollable = false,
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Text(
-                        "Toggle POI files or categories to show them on the map.",
-                    )
-                    Text("Expand a category to preview its POIs.")
-                    Text("Tap a POI on the map to see details.")
-                    Text(
-                        text =
-                            buildAnnotatedString {
-                                append("Create POI by using the tool button (")
-                                appendInlineContent("toolButton", "[tool]")
-                                append(").")
-                            },
-                        textAlign = TextAlign.Center,
-                        inlineContent =
-                            mapOf(
-                                "toolButton" to
-                                    InlineTextContent(
-                                        placeholder =
-                                            Placeholder(
-                                                width = 16.sp,
-                                                height = 16.sp,
-                                                placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
-                                            ),
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Default.ViewComfyAlt,
-                                            contentDescription = null,
-                                            modifier = Modifier.size(16.dp),
-                                            tint = Color.White,
-                                        )
-                                    },
-                            ),
-                    )
-                    WearDialogScrollBottomSpacer()
-                }
-            },
-        )
+            title = "POI Actions",
+            onDismiss = { dismissHelpDialog() },
+        ) {
+            item {
+                Text(
+                    "Toggle POI files or categories to show them on the map.",
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            item {
+                Text(
+                    "Expand a category to preview its POIs.",
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            item {
+                Text(
+                    "Tap a POI on the map to see details.",
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            item {
+                Text(
+                    text =
+                        buildAnnotatedString {
+                            append("Create POI by using the tool button (")
+                            appendInlineContent("toolButton", "[tool]")
+                            append(").")
+                        },
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                    inlineContent =
+                        mapOf(
+                            "toolButton" to
+                                InlineTextContent(
+                                    placeholder =
+                                        Placeholder(
+                                            width = 16.sp,
+                                            height = 16.sp,
+                                            placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
+                                        ),
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.ViewComfyAlt,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(16.dp),
+                                        tint = Color.White,
+                                    )
+                                },
+                        ),
+                )
+            }
+        }
 
         Column(
             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiViewModel.kt
@@ -361,14 +361,14 @@ class PoiViewModel(
             val file = _poiFiles.value.firstOrNull { it.path == path } ?: return@launch
             if (file.categories.none { it.id == categoryId }) return@launch
 
-            val key = PoiCategoryPreviewKey(filePath = path, categoryId = categoryId)
-            val current = _categoryPreviews.value[key]
-            if (!forceRefresh && current != null && (current.isLoading || current.isLoaded)) {
+            if (isUserPoiPath(path) && categoryId == USER_POI_CATEGORY_ID) {
+                updateUserPoiPreviewCache(file.copy(isExpanded = true))
                 return@launch
             }
 
-            if (isUserPoiPath(path) && categoryId == USER_POI_CATEGORY_ID) {
-                updateUserPoiPreviewCache(file.copy(isExpanded = true))
+            val key = PoiCategoryPreviewKey(filePath = path, categoryId = categoryId)
+            val current = _categoryPreviews.value[key]
+            if (!forceRefresh && current != null && (current.isLoading || current.isLoaded)) {
                 return@launch
             }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RoutePoiSearchDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RoutePoiSearchDialog.kt
@@ -3,10 +3,14 @@ package com.glancemap.glancemapwearos.presentation.features.routetools
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -34,7 +38,6 @@ import com.glancemap.glancemapwearos.presentation.features.poi.PoiSearchUiState
 import com.glancemap.glancemapwearos.presentation.ui.WearCustomDialogScrollableColumn
 import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpacer
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
-import com.glancemap.glancemapwearos.presentation.ui.wearDialogWidth
 
 @Composable
 internal fun RoutePoiSearchDialog(
@@ -50,6 +53,16 @@ internal fun RoutePoiSearchDialog(
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusRequester = remember { FocusRequester() }
     var draftQuery by remember(visible) { mutableStateOf(state.query) }
+    val scrollState = rememberScrollState()
+    val topPadding =
+        adaptive.dialogVerticalPadding +
+            adaptive.headerTopSafeInset +
+            if (adaptive.isRound) 18.dp else 0.dp
+    val bottomPadding =
+        adaptive.dialogVerticalPadding +
+            if (adaptive.isRound) 42.dp else 12.dp
+    val controlWidthFraction = if (adaptive.isRound) 0.86f else 1f
+    val buttonMinHeight = 44.dp
 
     LaunchedEffect(visible) {
         if (visible) {
@@ -71,16 +84,17 @@ internal fun RoutePoiSearchDialog(
         Column(
             modifier =
                 Modifier
-                    .wearDialogWidth()
-                    .background(
-                        Color.Black.copy(alpha = 0.92f),
-                        RoundedCornerShape(adaptive.dialogCornerRadius),
-                    ).padding(
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.92f))
+                    .verticalScroll(scrollState)
+                    .padding(
                         horizontal = adaptive.dialogHorizontalPadding,
-                        vertical = adaptive.dialogVerticalPadding,
+                    ).padding(
+                        top = topPadding,
+                        bottom = bottomPadding,
                     ),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top),
         ) {
             Text(
                 text = "Search POI",
@@ -100,7 +114,7 @@ internal fun RoutePoiSearchDialog(
                 cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
                 modifier =
                     Modifier
-                        .fillMaxWidth()
+                        .fillMaxWidth(controlWidthFraction)
                         .focusRequester(focusRequester)
                         .background(
                             Color(0xFF1F1F1F),
@@ -122,7 +136,10 @@ internal fun RoutePoiSearchDialog(
 
             Button(
                 onClick = { onSearch(draftQuery) },
-                modifier = Modifier.fillMaxWidth(),
+                modifier =
+                    Modifier
+                        .fillMaxWidth(controlWidthFraction)
+                        .heightIn(min = buttonMinHeight),
             ) {
                 Text(if (state.isLoading) "Searching..." else "Search")
             }
@@ -141,7 +158,7 @@ internal fun RoutePoiSearchDialog(
                     maxHeight = adaptive.helpDialogMaxHeight * 0.72f,
                     modifier =
                         Modifier
-                            .fillMaxWidth(),
+                            .fillMaxWidth(controlWidthFraction),
                     verticalArrangement = Arrangement.spacedBy(6.dp),
                 ) {
                     state.results.forEach { result ->
@@ -185,7 +202,10 @@ internal fun RoutePoiSearchDialog(
 
             Button(
                 onClick = onDismiss,
-                modifier = Modifier.fillMaxWidth(),
+                modifier =
+                    Modifier
+                        .fillMaxWidth(controlWidthFraction)
+                        .heightIn(min = buttonMinHeight),
                 colors =
                     ButtonDefaults.buttonColors(
                         containerColor = Color.White.copy(alpha = 0.12f),

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RoutePoiSearchDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RoutePoiSearchDialog.kt
@@ -1,16 +1,12 @@
 package com.glancemap.glancemapwearos.presentation.features.routetools
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -27,17 +23,13 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.presentation.features.poi.PoiSearchResultUiState
 import com.glancemap.glancemapwearos.presentation.features.poi.PoiSearchUiState
-import com.glancemap.glancemapwearos.presentation.ui.WearCustomDialogScrollableColumn
-import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpacer
-import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
+import com.glancemap.glancemapwearos.presentation.ui.WearFormDialog
 
 @Composable
 internal fun RoutePoiSearchDialog(
@@ -49,20 +41,9 @@ internal fun RoutePoiSearchDialog(
 ) {
     if (!visible) return
 
-    val adaptive = rememberWearAdaptiveSpec()
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusRequester = remember { FocusRequester() }
     var draftQuery by remember(visible) { mutableStateOf(state.query) }
-    val scrollState = rememberScrollState()
-    val topPadding =
-        adaptive.dialogVerticalPadding +
-            adaptive.headerTopSafeInset +
-            if (adaptive.isRound) 18.dp else 0.dp
-    val bottomPadding =
-        adaptive.dialogVerticalPadding +
-            if (adaptive.isRound) 42.dp else 12.dp
-    val controlWidthFraction = if (adaptive.isRound) 0.86f else 1f
-    val buttonMinHeight = 44.dp
 
     LaunchedEffect(visible) {
         if (visible) {
@@ -77,143 +58,110 @@ internal fun RoutePoiSearchDialog(
         }
     }
 
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false),
-    ) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.92f))
-                    .verticalScroll(scrollState)
-                    .padding(
-                        horizontal = adaptive.dialogHorizontalPadding,
-                    ).padding(
-                        top = topPadding,
-                        bottom = bottomPadding,
-                    ),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top),
-        ) {
-            Text(
-                text = "Search POI",
-                style = MaterialTheme.typography.titleSmall,
-                textAlign = TextAlign.Center,
-            )
-
-            BasicTextField(
-                value = draftQuery,
-                onValueChange = { draftQuery = it.take(48) },
-                singleLine = true,
-                textStyle =
-                    TextStyle(
-                        color = Color.White,
-                        textAlign = TextAlign.Center,
-                    ),
-                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-                modifier =
-                    Modifier
-                        .fillMaxWidth(controlWidthFraction)
-                        .focusRequester(focusRequester)
-                        .background(
-                            Color(0xFF1F1F1F),
-                            RoundedCornerShape(12.dp),
-                        ).padding(horizontal = 12.dp, vertical = 10.dp),
-                decorationBox = { innerTextField ->
-                    if (draftQuery.isBlank()) {
-                        Text(
-                            text = "Type a POI name",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = Color.White.copy(alpha = 0.45f),
-                            textAlign = TextAlign.Center,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                    }
-                    innerTextField()
-                },
-            )
-
-            Button(
-                onClick = { onSearch(draftQuery) },
-                modifier =
-                    Modifier
-                        .fillMaxWidth(controlWidthFraction)
-                        .heightIn(min = buttonMinHeight),
-            ) {
-                Text(if (state.isLoading) "Searching..." else "Search")
-            }
-
-            state.errorMessage?.takeIf { it.isNotBlank() }?.let { message ->
-                Text(
-                    text = message,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = Color(0xFFFFCC80),
+    WearFormDialog(
+        visible = visible,
+        title = "Search POI",
+        onDismiss = onDismiss,
+        backgroundColor = Color.Black.copy(alpha = 0.92f),
+    ) { formTokens ->
+        BasicTextField(
+            value = draftQuery,
+            onValueChange = { draftQuery = it.take(48) },
+            singleLine = true,
+            textStyle =
+                TextStyle(
+                    color = Color.White,
                     textAlign = TextAlign.Center,
-                )
-            }
-
-            if (state.results.isNotEmpty()) {
-                WearCustomDialogScrollableColumn(
-                    maxHeight = adaptive.helpDialogMaxHeight * 0.72f,
-                    modifier =
-                        Modifier
-                            .fillMaxWidth(controlWidthFraction),
-                    verticalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    state.results.forEach { result ->
-                        Button(
-                            onClick = { onSelectResult(result) },
-                            modifier = Modifier.fillMaxWidth(),
-                            colors =
-                                ButtonDefaults.buttonColors(
-                                    containerColor = Color.White.copy(alpha = 0.10f),
-                                    contentColor = Color.White,
-                                ),
-                        ) {
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                Text(
-                                    text = result.name,
-                                    style = MaterialTheme.typography.labelMedium,
-                                    textAlign = TextAlign.Center,
-                                )
-                                Text(
-                                    text =
-                                        result.type.name
-                                            .lowercase()
-                                            .replace('_', ' ')
-                                            .replaceFirstChar { it.uppercase() },
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = Color.White.copy(alpha = 0.70f),
-                                    textAlign = TextAlign.Center,
-                                )
-                                Text(
-                                    text = result.fileName,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = Color.White.copy(alpha = 0.54f),
-                                    textAlign = TextAlign.Center,
-                                )
-                            }
-                        }
-                    }
-                    WearDialogScrollBottomSpacer()
+                ),
+            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+            modifier =
+                formTokens.controlModifier
+                    .focusRequester(focusRequester)
+                    .background(
+                        Color(0xFF1F1F1F),
+                        RoundedCornerShape(12.dp),
+                    ).padding(horizontal = 12.dp, vertical = formTokens.textFieldVerticalPadding),
+            decorationBox = { innerTextField ->
+                if (draftQuery.isBlank()) {
+                    Text(
+                        text = "Type a POI name",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = Color.White.copy(alpha = 0.45f),
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
                 }
-            }
+                innerTextField()
+            },
+        )
 
+        Button(
+            onClick = { onSearch(draftQuery) },
+            modifier =
+                formTokens.controlModifier
+                    .heightIn(min = formTokens.buttonMinHeight),
+        ) {
+            Text(if (state.isLoading) "Searching..." else "Search")
+        }
+
+        state.errorMessage?.takeIf { it.isNotBlank() }?.let { message ->
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodySmall,
+                color = Color(0xFFFFCC80),
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+
+        state.results.forEach { result ->
             Button(
-                onClick = onDismiss,
-                modifier =
-                    Modifier
-                        .fillMaxWidth(controlWidthFraction)
-                        .heightIn(min = buttonMinHeight),
+                onClick = { onSelectResult(result) },
+                modifier = formTokens.controlModifier,
                 colors =
                     ButtonDefaults.buttonColors(
-                        containerColor = Color.White.copy(alpha = 0.12f),
+                        containerColor = Color.White.copy(alpha = 0.10f),
                         contentColor = Color.White,
                     ),
             ) {
-                Text("Close")
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = result.name,
+                        style = MaterialTheme.typography.labelMedium,
+                        textAlign = TextAlign.Center,
+                    )
+                    Text(
+                        text =
+                            result.type.name
+                                .lowercase()
+                                .replace('_', ' ')
+                                .replaceFirstChar { it.uppercase() },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.White.copy(alpha = 0.70f),
+                        textAlign = TextAlign.Center,
+                    )
+                    Text(
+                        text = result.fileName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.White.copy(alpha = 0.54f),
+                        textAlign = TextAlign.Center,
+                    )
+                }
             }
+        }
+
+        Button(
+            onClick = onDismiss,
+            modifier =
+                formTokens.controlModifier
+                    .heightIn(min = formTokens.buttonMinHeight),
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = Color.White.copy(alpha = 0.12f),
+                    contentColor = Color.White,
+                ),
+        ) {
+            Text("Close")
         }
     }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolResultDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolResultDialog.kt
@@ -2,17 +2,12 @@ package com.glancemap.glancemapwearos.presentation.features.routetools
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
@@ -29,9 +24,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
-import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
@@ -39,8 +31,8 @@ import com.glancemap.glancemapwearos.presentation.formatting.DurationFormatter
 import com.glancemap.glancemapwearos.presentation.formatting.UnitFormatter
 import com.glancemap.glancemapwearos.presentation.ui.CompactIconHitTargetButton
 import com.glancemap.glancemapwearos.presentation.ui.RenameValueDialog
-import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
-import com.glancemap.glancemapwearos.presentation.ui.wearDialogWidth
+import com.glancemap.glancemapwearos.presentation.ui.WearActionDialog
+import com.glancemap.glancemapwearos.presentation.ui.WearActionDialogButton
 
 @Composable
 internal fun RouteToolResultDialog(
@@ -56,8 +48,6 @@ internal fun RouteToolResultDialog(
 ) {
     if (!visible || result == null) return
 
-    val adaptive = rememberWearAdaptiveSpec()
-    val scrollState = rememberScrollState()
     var showRenameDialog by remember(result.filePath) { mutableStateOf(false) }
 
     if (showRenameDialog) {
@@ -82,117 +72,90 @@ internal fun RouteToolResultDialog(
     val (lossValue, lossUnit) = UnitFormatter.formatElevation(result.elevationLossMeters, isMetric)
     val etaValue = DurationFormatter.formatDurationShort(result.estimatedDurationSec)
 
-    Dialog(
+    WearActionDialog(
+        visible = true,
+        title = result.message,
         onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false),
-    ) {
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.90f))
-                    .padding(
-                        horizontal = if (adaptive.isRound) 18.dp else 14.dp,
-                        vertical = if (adaptive.isRound) 16.dp else 14.dp,
-                    ),
-            contentAlignment = Alignment.Center,
-        ) {
-            Column(
-                modifier =
-                    Modifier
-                        .wearDialogWidth(roundFraction = 0.9f, squareFraction = 0.94f)
-                        .heightIn(max = adaptive.helpDialogMaxHeight)
-                        .verticalScroll(scrollState)
-                        .padding(
-                            horizontal = adaptive.dialogHorizontalPadding,
-                            vertical = adaptive.dialogVerticalPadding,
-                        ),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(6.dp),
-            ) {
-                Text(
-                    text = result.displayTitle,
-                    modifier = Modifier.fillMaxWidth(),
-                    style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Center,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    CompactIconHitTargetButton(
-                        onClick = onDelete,
-                        visualSize = 34.dp,
-                        containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.85f),
-                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
-                        enabled = !renameInProgress,
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Delete,
-                            contentDescription = "Delete GPX",
-                        )
-                    }
-                    CompactIconHitTargetButton(
-                        onClick = {
-                            onRenameOpen()
-                            showRenameDialog = true
-                        },
-                        visualSize = 34.dp,
-                        containerColor = Color.White.copy(alpha = 0.10f),
-                        contentColor = Color.White,
-                        enabled = !renameInProgress,
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Edit,
-                            contentDescription = "Rename GPX",
-                        )
-                    }
-                }
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    RouteStatTile(
-                        modifier = Modifier.weight(1f),
-                        label = "Dist",
-                        value = "$distanceValue $distanceUnit",
-                    )
-                    RouteStatTile(
-                        modifier = Modifier.weight(1f),
-                        label = "Time",
-                        value = etaValue,
-                    )
-                }
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    RouteStatTile(
-                        modifier = Modifier.weight(1f),
-                        labelIcon = Icons.Default.ArrowUpward,
-                        value = "$gainValue $gainUnit",
-                    )
-                    RouteStatTile(
-                        modifier = Modifier.weight(1f),
-                        labelIcon = Icons.Default.ArrowDownward,
-                        value = "$lossValue $lossUnit",
-                    )
-                }
-
-                Button(
+        backgroundColor = Color.Black.copy(alpha = 0.92f),
+        buttons =
+            listOf(
+                WearActionDialogButton(
+                    text = "Done",
                     onClick = onDismiss,
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .heightIn(min = 48.dp),
-                ) {
-                    Text("Done")
-                }
+                ),
+            ),
+    ) {
+        Text(
+            text = result.displayTitle,
+            modifier = Modifier.fillMaxWidth(),
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            CompactIconHitTargetButton(
+                onClick = onDelete,
+                visualSize = 34.dp,
+                containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.85f),
+                contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                enabled = !renameInProgress,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = "Delete GPX",
+                )
             }
+            CompactIconHitTargetButton(
+                onClick = {
+                    onRenameOpen()
+                    showRenameDialog = true
+                },
+                visualSize = 34.dp,
+                containerColor = Color.White.copy(alpha = 0.10f),
+                contentColor = Color.White,
+                enabled = !renameInProgress,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = "Rename GPX",
+                )
+            }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            RouteStatTile(
+                modifier = Modifier.weight(1f),
+                label = "Dist",
+                value = "$distanceValue $distanceUnit",
+            )
+            RouteStatTile(
+                modifier = Modifier.weight(1f),
+                label = "Time",
+                value = etaValue,
+            )
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            RouteStatTile(
+                modifier = Modifier.weight(1f),
+                labelIcon = Icons.Default.ArrowUpward,
+                value = "$gainValue $gainUnit",
+            )
+            RouteStatTile(
+                modifier = Modifier.weight(1f),
+                labelIcon = Icons.Default.ArrowDownward,
+                value = "$lossValue $lossUnit",
+            )
         }
     }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolsActionPanel.Support.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolsActionPanel.Support.kt
@@ -42,7 +42,9 @@ import androidx.wear.compose.material3.IconButtonDefaults
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.presentation.features.poi.PoiSearchUiState
-import com.glancemap.glancemapwearos.presentation.ui.WearScreenSize
+import com.glancemap.glancemapwearos.presentation.ui.WearActionButtonRole
+import com.glancemap.glancemapwearos.presentation.ui.WearActionDialog
+import com.glancemap.glancemapwearos.presentation.ui.WearActionDialogButton
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 import org.mapsforge.core.model.LatLong
 
@@ -98,17 +100,6 @@ internal fun RouteToolDraftSummaryDialog(
 ) {
     if (!visible || session == null) return
 
-    val adaptive = rememberWearAdaptiveSpec()
-    val bottomActionSafeInset =
-        if (!adaptive.isRound) {
-            3.dp
-        } else {
-            when (adaptive.screenSize) {
-                WearScreenSize.LARGE -> 11.dp
-                WearScreenSize.MEDIUM -> 13.dp
-                WearScreenSize.SMALL -> 15.dp
-            }
-        }
     val isCreate = session.options.toolKind == RouteToolKind.CREATE
     val isReplaceCurrent = session.options.saveBehavior == RouteSaveBehavior.REPLACE_CURRENT
     val title =
@@ -136,180 +127,90 @@ internal fun RouteToolDraftSummaryDialog(
             }
         }
 
-    Dialog(onDismissRequest = onDismiss) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .background(
-                        Color.Black.copy(alpha = 0.86f),
-                        RoundedCornerShape(adaptive.dialogCornerRadius),
-                    ).padding(
-                        horizontal = adaptive.dialogHorizontalPadding,
-                        vertical = adaptive.dialogVerticalPadding,
-                    ),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleSmall,
-                textAlign = TextAlign.Center,
-            )
-            Text(
-                text = supportingLine,
-                style = MaterialTheme.typography.bodySmall,
-                color = Color.White.copy(alpha = 0.84f),
-                textAlign = TextAlign.Center,
-            )
-
-            when {
-                executionMessage != null -> {
-                    Text(
-                        text = executionMessage,
-                        style = MaterialTheme.typography.bodySmall,
-                        textAlign = TextAlign.Center,
-                        color = Color(0xFFFFCC80),
+    val actionButtons =
+        when {
+            executionMessage != null &&
+                session.options.toolKind == RouteToolKind.CREATE &&
+                loopRetryOptions.isNotEmpty() &&
+                onSelectLoopRetryOption != null ->
+                loopRetryOptions.map { option ->
+                    WearActionDialogButton(
+                        text = option.label,
+                        onClick = { onSelectLoopRetryOption(option) },
+                        enabled = !isExecuting,
                     )
-                }
-
-                isCreate -> {
-                    Text(
-                        text = "Ready to generate the GPX.",
-                        style = MaterialTheme.typography.bodySmall,
-                        textAlign = TextAlign.Center,
-                        color = Color(0xFFFFCC80),
-                    )
-                }
-
-                else -> {
-                    Text(
-                        text =
-                            if (session.options.modifyMode == RouteModifyMode.RESHAPE_ROUTE) {
-                                "Preview the rerouted section, then save."
-                            } else if (isReplaceCurrent) {
-                                "This will replace the active GPX."
-                            } else {
-                                "Ready to save the GPX edit."
-                            },
-                        style = MaterialTheme.typography.bodySmall,
-                        textAlign = TextAlign.Center,
-                        color = Color(0xFFFFCC80),
-                    )
-                }
-            }
-            when {
-                executionMessage != null &&
-                    session.options.toolKind == RouteToolKind.CREATE &&
-                    loopRetryOptions.isNotEmpty() &&
-                    onSelectLoopRetryOption != null -> {
-                    Column(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(bottom = bottomActionSafeInset),
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            loopRetryOptions.forEach { option ->
-                                Button(
-                                    onClick = { onSelectLoopRetryOption(option) },
-                                    enabled = !isExecuting,
-                                    modifier = Modifier.weight(1f),
-                                ) {
-                                    Text(option.label)
-                                }
-                            }
-                        }
-                        Button(
-                            onClick = onDismiss,
-                            modifier = Modifier.fillMaxWidth(0.46f),
-                            colors =
-                                ButtonDefaults.buttonColors(
-                                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                                ),
-                        ) {
-                            Text("Back")
-                        }
-                    }
-                }
-
-                session.options.toolKind == RouteToolKind.CREATE && onConfirmCreate != null -> {
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(bottom = bottomActionSafeInset),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Button(
-                            onClick = onDismiss,
-                            modifier = Modifier.weight(1f),
-                            colors =
-                                ButtonDefaults.buttonColors(
-                                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                                ),
-                        ) {
-                            Text("Back")
-                        }
-                        Button(
-                            onClick = onConfirmCreate,
-                            enabled = !isExecuting,
-                            modifier = Modifier.weight(1f),
-                        ) {
-                            Text(actionLabel)
-                        }
-                    }
-                }
-
-                session.options.toolKind == RouteToolKind.MODIFY && onConfirmModify != null -> {
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(bottom = bottomActionSafeInset),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Button(
-                            onClick = onDismiss,
-                            modifier = Modifier.weight(1f),
-                            colors =
-                                ButtonDefaults.buttonColors(
-                                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                                ),
-                        ) {
-                            Text("Back")
-                        }
-                        Button(
-                            onClick = onConfirmModify,
-                            enabled = !isExecuting,
-                            modifier = Modifier.weight(1f),
-                        ) {
-                            Text(actionLabel)
-                        }
-                    }
-                }
-
-                else -> {
-                    Button(
+                } +
+                    WearActionDialogButton(
+                        text = "Back",
                         onClick = onDismiss,
-                        modifier = Modifier.padding(bottom = bottomActionSafeInset),
-                    ) {
-                        Text("Close")
-                    }
-                }
-            }
+                        role = WearActionButtonRole.Secondary,
+                    )
+
+            session.options.toolKind == RouteToolKind.CREATE && onConfirmCreate != null ->
+                listOf(
+                    WearActionDialogButton(
+                        text = actionLabel,
+                        onClick = onConfirmCreate,
+                        enabled = !isExecuting,
+                    ),
+                    WearActionDialogButton(
+                        text = "Back",
+                        onClick = onDismiss,
+                        role = WearActionButtonRole.Secondary,
+                    ),
+                )
+
+            session.options.toolKind == RouteToolKind.MODIFY && onConfirmModify != null ->
+                listOf(
+                    WearActionDialogButton(
+                        text = actionLabel,
+                        onClick = onConfirmModify,
+                        enabled = !isExecuting,
+                    ),
+                    WearActionDialogButton(
+                        text = "Back",
+                        onClick = onDismiss,
+                        role = WearActionButtonRole.Secondary,
+                    ),
+                )
+
+            else ->
+                listOf(
+                    WearActionDialogButton(
+                        text = "Close",
+                        onClick = onDismiss,
+                    ),
+                )
         }
+
+    WearActionDialog(
+        visible = true,
+        title = title,
+        onDismissRequest = onDismiss,
+        backgroundColor = Color.Black.copy(alpha = 0.92f),
+        buttons = actionButtons,
+    ) {
+        Text(
+            text = supportingLine,
+            style = MaterialTheme.typography.bodySmall,
+            color = Color.White.copy(alpha = 0.84f),
+            textAlign = TextAlign.Center,
+        )
+
+        Text(
+            text =
+                when {
+                    executionMessage != null -> executionMessage
+                    isCreate -> "Ready to generate the GPX."
+                    session.options.modifyMode == RouteModifyMode.RESHAPE_ROUTE ->
+                        "Preview the rerouted section, then save."
+                    isReplaceCurrent -> "This will replace the active GPX."
+                    else -> "Ready to save the GPX edit."
+                },
+            style = MaterialTheme.typography.bodySmall,
+            textAlign = TextAlign.Center,
+            color = Color(0xFFFFCC80),
+        )
     }
 }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolsActionPanel.Support.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolsActionPanel.Support.kt
@@ -45,6 +45,7 @@ import com.glancemap.glancemapwearos.presentation.ui.WearActionButtonRole
 import com.glancemap.glancemapwearos.presentation.ui.WearActionDialog
 import com.glancemap.glancemapwearos.presentation.ui.WearActionDialogButton
 import com.glancemap.glancemapwearos.presentation.ui.WearFormDialog
+import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 import org.mapsforge.core.model.LatLong
 
 @Composable
@@ -218,6 +219,28 @@ internal fun RouteToolKindSelector(
     selected: RouteToolKind,
     onSelected: (RouteToolKind) -> Unit,
 ) {
+    val adaptive = rememberWearAdaptiveSpec()
+    if (adaptive.isRound && adaptive.fontScale >= 1.25f) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            RouteSegmentButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = RouteToolKind.CREATE.title,
+                selected = selected == RouteToolKind.CREATE,
+                onClick = { onSelected(RouteToolKind.CREATE) },
+            )
+            RouteSegmentButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = RouteToolKind.MODIFY.title,
+                selected = selected == RouteToolKind.MODIFY,
+                onClick = { onSelected(RouteToolKind.MODIFY) },
+            )
+        }
+        return
+    }
+
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolsActionPanel.Support.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolsActionPanel.Support.kt
@@ -1,3 +1,5 @@
+@file:Suppress("FunctionNaming")
+
 package com.glancemap.glancemapwearos.presentation.features.routetools
 
 import androidx.compose.foundation.ScrollState
@@ -8,11 +10,10 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -32,8 +33,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.Icon
@@ -45,7 +44,7 @@ import com.glancemap.glancemapwearos.presentation.features.poi.PoiSearchUiState
 import com.glancemap.glancemapwearos.presentation.ui.WearActionButtonRole
 import com.glancemap.glancemapwearos.presentation.ui.WearActionDialog
 import com.glancemap.glancemapwearos.presentation.ui.WearActionDialogButton
-import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
+import com.glancemap.glancemapwearos.presentation.ui.WearFormDialog
 import org.mapsforge.core.model.LatLong
 
 @Composable
@@ -647,120 +646,88 @@ internal fun CoordinateEntryDialog(
 ) {
     if (!visible) return
 
-    val adaptive = rememberWearAdaptiveSpec()
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false),
-    ) {
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.62f))
-                    .padding(horizontal = 18.dp),
-            contentAlignment = Alignment.Center,
+    WearFormDialog(
+        visible = true,
+        title = "Coordinates",
+        onDismiss = onDismiss,
+        backgroundColor = Color.Black.copy(alpha = 0.92f),
+    ) { formTokens ->
+        CoordinateValueEditorRow(
+            label = "Lat",
+            value = latitude,
+            onDecrease = { onLatitudeChange(latitude - step.delta) },
+            onIncrease = { onLatitudeChange(latitude + step.delta) },
+            modifier = formTokens.controlModifier,
+        )
+        CoordinateValueEditorRow(
+            label = "Lon",
+            value = longitude,
+            onDecrease = { onLongitudeChange(longitude - step.delta) },
+            onIncrease = { onLongitudeChange(longitude + step.delta) },
+            modifier = formTokens.controlModifier,
+        )
+        Row(
+            modifier = formTokens.controlModifier,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .background(
-                            Color(0xFF141414).copy(alpha = 0.98f),
-                            RoundedCornerShape(adaptive.dialogCornerRadius),
-                        ).padding(
-                            horizontal = adaptive.dialogHorizontalPadding,
-                            vertical = adaptive.dialogVerticalPadding,
-                        ),
+                modifier = Modifier.weight(1f),
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                Text(
-                    text = "Coordinates",
-                    style = MaterialTheme.typography.titleSmall,
-                    textAlign = TextAlign.Center,
-                )
-                CoordinateValueEditorRow(
-                    label = "Lat",
-                    value = latitude,
-                    onDecrease = { onLatitudeChange(latitude - step.delta) },
-                    onIncrease = { onLatitudeChange(latitude + step.delta) },
-                )
-                CoordinateValueEditorRow(
-                    label = "Lon",
-                    value = longitude,
-                    onDecrease = { onLongitudeChange(longitude - step.delta) },
-                    onIncrease = { onLongitudeChange(longitude + step.delta) },
-                )
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(
-                        onClick = { onStepChange(step.previous()) },
-                        colors =
-                            IconButtonDefaults.iconButtonColors(
-                                containerColor = Color.White.copy(alpha = 0.14f),
-                                contentColor = Color.White,
-                            ),
-                    ) {
-                        Icon(Icons.Default.Remove, contentDescription = "Decrease coordinate step")
-                    }
-                    Column(
-                        modifier = Modifier.weight(1f),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        Text("Step", style = MaterialTheme.typography.labelMedium)
-                        Text(step.label, style = MaterialTheme.typography.bodySmall)
-                    }
-                    IconButton(
-                        onClick = { onStepChange(step.next()) },
-                        colors =
-                            IconButtonDefaults.iconButtonColors(
-                                containerColor = Color.White.copy(alpha = 0.14f),
-                                contentColor = Color.White,
-                            ),
-                    ) {
-                        Icon(Icons.Default.Add, contentDescription = "Increase coordinate step")
-                    }
-                }
-                if (hasSeed) {
-                    Button(
-                        onClick = onUseSeed,
-                        modifier = Modifier.fillMaxWidth(),
-                        colors =
-                            ButtonDefaults.buttonColors(
-                                containerColor = Color.White.copy(alpha = 0.10f),
-                                contentColor = Color.White,
-                            ),
-                    ) {
-                        Text("Use map center")
-                    }
-                }
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Button(
-                        onClick = onDismiss,
-                        modifier = Modifier.weight(1f),
-                        colors =
-                            ButtonDefaults.buttonColors(
-                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                            ),
-                    ) {
-                        Text("Cancel")
-                    }
-                    Button(
-                        onClick = onConfirm,
-                        modifier = Modifier.weight(1f),
-                    ) {
-                        Text("Done")
-                    }
-                }
+                Text("Step", style = MaterialTheme.typography.labelMedium)
+                Text(step.label, style = MaterialTheme.typography.bodySmall)
             }
+            IconButton(
+                onClick = { onStepChange(step.previous()) },
+                colors =
+                    IconButtonDefaults.iconButtonColors(
+                        containerColor = Color.White.copy(alpha = 0.14f),
+                        contentColor = Color.White,
+                    ),
+            ) {
+                Icon(Icons.Default.Remove, contentDescription = "Decrease coordinate step")
+            }
+            IconButton(
+                onClick = { onStepChange(step.next()) },
+                colors =
+                    IconButtonDefaults.iconButtonColors(
+                        containerColor = Color.White.copy(alpha = 0.14f),
+                        contentColor = Color.White,
+                    ),
+            ) {
+                Icon(Icons.Default.Add, contentDescription = "Increase coordinate step")
+            }
+        }
+        if (hasSeed) {
+            Button(
+                onClick = onUseSeed,
+                modifier = formTokens.controlModifier.heightIn(min = formTokens.buttonMinHeight),
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = Color.White.copy(alpha = 0.10f),
+                        contentColor = Color.White,
+                    ),
+            ) {
+                Text("Use map center")
+            }
+        }
+        Button(
+            onClick = onConfirm,
+            modifier = formTokens.controlModifier.heightIn(min = formTokens.buttonMinHeight),
+        ) {
+            Text("Done")
+        }
+        Button(
+            onClick = onDismiss,
+            modifier = formTokens.controlModifier.heightIn(min = formTokens.buttonMinHeight),
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                ),
+        ) {
+            Text("Cancel")
         }
     }
 }
@@ -771,9 +738,10 @@ internal fun CoordinateValueEditorRow(
     value: Double,
     onDecrease: () -> Unit,
     onIncrease: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolsActionPanel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolsActionPanel.kt
@@ -1,42 +1,27 @@
 package com.glancemap.glancemapwearos.presentation.features.routetools
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.SwitchButton
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.presentation.features.poi.PoiSearchUiState
 import com.glancemap.glancemapwearos.presentation.ui.WearActionDialog
-import com.glancemap.glancemapwearos.presentation.ui.WearScreenSize
-import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
+import com.glancemap.glancemapwearos.presentation.ui.WearToolPanelDialog
 import org.mapsforge.core.model.LatLong
-
-private const val ROUTE_TOOLS_DRAG_DISMISS_PX = 55f
 
 @Composable
 internal fun RouteToolsActionPanel(
@@ -54,39 +39,6 @@ internal fun RouteToolsActionPanel(
 ) {
     if (!visible) return
 
-    val adaptive = rememberWearAdaptiveSpec()
-    val scrollState = rememberScrollState()
-    val routeToolsBottomActionSafeInset =
-        if (!adaptive.isRound) {
-            0.dp
-        } else {
-            when (adaptive.screenSize) {
-                WearScreenSize.LARGE -> 8.dp
-                WearScreenSize.MEDIUM -> 10.dp
-                WearScreenSize.SMALL -> 12.dp
-            }
-        }
-    val routeToolsContentBottomInset =
-        if (!adaptive.isRound) {
-            8.dp
-        } else {
-            when (adaptive.screenSize) {
-                WearScreenSize.LARGE -> 18.dp
-                WearScreenSize.MEDIUM -> 22.dp
-                WearScreenSize.SMALL -> 26.dp
-            }
-        }
-    val routeToolsIndicatorBottomInset = routeToolsContentBottomInset + 22.dp
-    val routeToolsContentMaxHeight =
-        (
-            adaptive.heightDp.dp -
-                adaptive.dialogVerticalPadding * 2 -
-                3.dp -
-                32.dp -
-                24.dp -
-                routeToolsBottomActionSafeInset -
-                12.dp
-        ).coerceAtLeast(88.dp)
     var showCoordinateEditor by remember(visible) { mutableStateOf(false) }
     var showPoiSearchDialog by remember(visible) { mutableStateOf(false) }
     var coordinateDraftLat by remember(visible) { mutableStateOf(0.0) }
@@ -110,330 +62,248 @@ internal fun RouteToolsActionPanel(
         showCoordinateEditor = true
     }
 
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false),
+    WearToolPanelDialog(
+        visible = true,
+        title = "GPX Tools",
+        onDismiss = onDismiss,
+        backgroundColor = Color.Black.copy(alpha = 0.86f),
     ) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .background(
-                        Color.Black.copy(alpha = 0.90f),
-                        RoundedCornerShape(adaptive.dialogCornerRadius),
-                    ).padding(
-                        horizontal = adaptive.dialogHorizontalPadding,
-                        vertical = adaptive.dialogVerticalPadding,
-                    ),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
+        if (!preflightMessage.isNullOrBlank() && !shouldUsePreflightPopup) {
             Box(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .pointerInput(Unit) {
-                            var totalDrag = 0f
-                            detectVerticalDragGestures(
-                                onDragEnd = { totalDrag = 0f },
-                                onDragCancel = { totalDrag = 0f },
-                            ) { _, dragAmount ->
-                                totalDrag += dragAmount
-                                if (totalDrag > ROUTE_TOOLS_DRAG_DISMISS_PX) {
-                                    onDismiss()
-                                    totalDrag = 0f
-                                }
-                            }
-                        },
-                contentAlignment = Alignment.Center,
+                        .background(
+                            Color(0xFFF6E4A6).copy(alpha = 0.96f),
+                            RoundedCornerShape(14.dp),
+                        ).padding(horizontal = 12.dp, vertical = 10.dp),
             ) {
-                Box(
-                    modifier =
-                        Modifier
-                            .width(26.dp)
-                            .height(3.dp)
-                            .background(Color.White.copy(alpha = 0.42f), RoundedCornerShape(50)),
+                Text(
+                    text = preflightMessage,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color(0xFF3C2500),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
+        }
 
+        RouteToolKindSelector(
+            selected = options.toolKind,
+            onSelected = { kind ->
+                onOptionsChange(options.copy(toolKind = kind))
+            },
+        )
+
+        if (!canModifyActiveGpx && options.requiresSingleActiveGpx) {
             Text(
-                text = "GPX Tools",
-                style = MaterialTheme.typography.titleMedium,
+                text = "Activate exactly one GPX first to use this tool.",
+                style = MaterialTheme.typography.bodySmall,
+                color = Color(0xFFFFCC80),
                 textAlign = TextAlign.Center,
             )
+        }
 
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = routeToolsContentMaxHeight),
-            ) {
-                Column(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(end = 10.dp, bottom = routeToolsContentBottomInset)
-                            .verticalScroll(scrollState),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    if (!preflightMessage.isNullOrBlank() && !shouldUsePreflightPopup) {
-                        Box(
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .background(
-                                        Color(0xFFF6E4A6).copy(alpha = 0.96f),
-                                        RoundedCornerShape(14.dp),
-                                    ).padding(horizontal = 12.dp, vertical = 10.dp),
-                        ) {
-                            Text(
-                                text = preflightMessage,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = Color(0xFF3C2500),
-                                textAlign = TextAlign.Center,
-                                modifier = Modifier.fillMaxWidth(),
-                            )
-                        }
-                    }
+        RouteActionSelector(
+            options = options,
+            canModifyActiveGpx = canModifyActiveGpx,
+            coordinateSeed = coordinateSeed,
+            onOptionsChange = onOptionsChange,
+            onStartSelection = startSelection,
+            onOpenCoordinateEditor = openCoordinateEditor,
+            onOpenPoiSearchDialog = { showPoiSearchDialog = true },
+        )
 
-                    RouteToolKindSelector(
-                        selected = options.toolKind,
-                        onSelected = { kind ->
-                            onOptionsChange(options.copy(toolKind = kind))
-                        },
-                    )
+        if (options.toolKind == RouteToolKind.CREATE &&
+            options.createMode == RouteCreateMode.SEARCH
+        ) {
+            RouteSettingRow(
+                title = "Offline POI",
+                value = poiSearchSummary(poiSearchState),
+                onClick = { showPoiSearchDialog = true },
+            )
+        }
 
-                    if (!canModifyActiveGpx && options.requiresSingleActiveGpx) {
-                        Text(
-                            text = "Activate exactly one GPX first to use this tool.",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = Color(0xFFFFCC80),
-                            textAlign = TextAlign.Center,
-                        )
-                    }
-
-                    RouteActionSelector(
-                        options = options,
-                        canModifyActiveGpx = canModifyActiveGpx,
-                        coordinateSeed = coordinateSeed,
-                        onOptionsChange = onOptionsChange,
-                        onStartSelection = startSelection,
-                        onOpenCoordinateEditor = openCoordinateEditor,
-                        onOpenPoiSearchDialog = { showPoiSearchDialog = true },
-                    )
-
-                    if (options.toolKind == RouteToolKind.CREATE &&
-                        options.createMode == RouteCreateMode.SEARCH
-                    ) {
-                        RouteSettingRow(
-                            title = "Offline POI",
-                            value = poiSearchSummary(poiSearchState),
-                            onClick = { showPoiSearchDialog = true },
-                        )
-                    }
-
-                    if (options.toolKind == RouteToolKind.CREATE &&
-                        options.createMode == RouteCreateMode.COORDINATES
-                    ) {
-                        RouteSettingRow(
-                            title = "Destination",
-                            value = options.coordinatesSummary(),
-                            onClick = { openCoordinateEditor(options) },
-                        )
-                        Button(
-                            onClick = {
-                                val seededOptions = options.seedCoordinateTarget(coordinateSeed)
-                                val lat = seededOptions.coordinateLatitude
-                                val lon = seededOptions.coordinateLongitude
-                                if (lat == null || lon == null) {
-                                    openCoordinateEditor(seededOptions)
-                                } else {
-                                    startSelection(
-                                        RouteToolSession(
-                                            options = seededOptions,
-                                            destination = LatLong(lat, lon),
-                                        ),
-                                    )
-                                }
-                            },
-                            modifier = Modifier.fillMaxWidth(),
-                        ) {
-                            Text("Create route")
-                        }
-                    }
-
-                    if (options.toolKind == RouteToolKind.CREATE &&
-                        options.createMode == RouteCreateMode.LOOP_AROUND_HERE
-                    ) {
-                        LoopTargetModeSelector(
-                            selected = options.loopTargetMode,
-                            onSelected = { targetMode ->
-                                onOptionsChange(options.copy(loopTargetMode = targetMode))
-                            },
-                        )
-                        LoopTargetEditor(
-                            targetMode = options.loopTargetMode,
-                            distanceKm = options.loopDistanceKm,
-                            durationMinutes = options.loopDurationMinutes,
-                            onDecrease = {
-                                onOptionsChange(
-                                    when (options.loopTargetMode) {
-                                        LoopTargetMode.DISTANCE -> {
-                                            options.copy(
-                                                loopDistanceKm =
-                                                    (options.loopDistanceKm - 1)
-                                                        .coerceAtLeast(2),
-                                            )
-                                        }
-
-                                        LoopTargetMode.TIME -> {
-                                            options.copy(
-                                                loopDurationMinutes =
-                                                    (options.loopDurationMinutes - 15)
-                                                        .coerceAtLeast(30),
-                                            )
-                                        }
-                                    },
-                                )
-                            },
-                            onIncrease = {
-                                onOptionsChange(
-                                    when (options.loopTargetMode) {
-                                        LoopTargetMode.DISTANCE -> {
-                                            options.copy(
-                                                loopDistanceKm =
-                                                    (options.loopDistanceKm + 1)
-                                                        .coerceAtMost(60),
-                                            )
-                                        }
-
-                                        LoopTargetMode.TIME -> {
-                                            options.copy(
-                                                loopDurationMinutes =
-                                                    (options.loopDurationMinutes + 15)
-                                                        .coerceAtMost(480),
-                                            )
-                                        }
-                                    },
-                                )
-                            },
-                        )
-                        LoopStartModeSelector(
-                            selected = options.loopStartMode,
-                            onSelected = { startMode ->
-                                onOptionsChange(options.copy(loopStartMode = startMode))
-                            },
-                        )
-                        Button(
-                            onClick = {
-                                startSelection(RouteToolSession(options = options))
-                            },
-                            modifier = Modifier.fillMaxWidth(),
-                        ) {
-                            Text(
-                                if (options.loopStartMode == LoopStartMode.CURRENT_LOCATION) {
-                                    "Create loop"
-                                } else {
-                                    "Pick start on map"
-                                },
-                            )
-                        }
-                    }
-
-                    Text(
-                        text = options.activeSummary,
-                        style = MaterialTheme.typography.bodySmall,
-                        textAlign = TextAlign.Center,
-                        color = Color.White.copy(alpha = 0.84f),
-                    )
-
-                    Text(
-                        text = routeToolsHintText(options),
-                        style = MaterialTheme.typography.labelSmall,
-                        textAlign = TextAlign.Center,
-                        color = Color.White.copy(alpha = 0.68f),
-                    )
-
-                    RouteSettingRow(
-                        title = "Route style",
-                        value = options.routeStyle.title,
-                        onClick = {
-                            onOptionsChange(
-                                options.copy(routeStyle = options.routeStyle.next()),
-                            )
-                        },
-                    )
-                    Text(
-                        text = options.routeStyle.summary,
-                        style = MaterialTheme.typography.labelSmall,
-                        textAlign = TextAlign.Center,
-                        color = Color.White.copy(alpha = 0.72f),
-                    )
-
-                    if (options.toolKind == RouteToolKind.MODIFY) {
-                        RouteSaveBehaviorSelector(
-                            selected = options.saveBehavior,
-                            onSelected = { behavior ->
-                                onOptionsChange(options.copy(saveBehavior = behavior))
-                            },
-                        )
-                    }
-
-                    if (options.toolKind == RouteToolKind.CREATE) {
-                        RouteSettingRow(
-                            title =
-                                if (options.showAdvancedOptions) {
-                                    "Hide options"
-                                } else {
-                                    "More options"
-                                },
-                            value = if (options.showAdvancedOptions) "Advanced" else "Basic",
-                            onClick = {
-                                onOptionsChange(
-                                    options.copy(showAdvancedOptions = !options.showAdvancedOptions),
-                                )
-                            },
-                        )
-                    }
-
-                    if (options.toolKind == RouteToolKind.CREATE && options.showAdvancedOptions) {
-                        SwitchButton(
-                            modifier = Modifier.fillMaxWidth(),
-                            checked = options.useElevation,
-                            onCheckedChange = { enabled ->
-                                onOptionsChange(options.copy(useElevation = enabled))
-                            },
-                            label = { Text("Use elevation") },
-                        )
-                        SwitchButton(
-                            modifier = Modifier.fillMaxWidth(),
-                            checked = options.allowFerries,
-                            onCheckedChange = { enabled ->
-                                onOptionsChange(options.copy(allowFerries = enabled))
-                            },
-                            label = { Text("Allow ferries") },
-                        )
-                    }
-                }
-
-                RouteToolsScrollIndicator(
-                    scrollState = scrollState,
-                    modifier =
-                        Modifier
-                            .align(Alignment.CenterEnd)
-                            .padding(
-                                top = 4.dp,
-                                end = 1.dp,
-                                bottom = routeToolsIndicatorBottomInset,
+        if (options.toolKind == RouteToolKind.CREATE &&
+            options.createMode == RouteCreateMode.COORDINATES
+        ) {
+            RouteSettingRow(
+                title = "Destination",
+                value = options.coordinatesSummary(),
+                onClick = { openCoordinateEditor(options) },
+            )
+            Button(
+                onClick = {
+                    val seededOptions = options.seedCoordinateTarget(coordinateSeed)
+                    val lat = seededOptions.coordinateLatitude
+                    val lon = seededOptions.coordinateLongitude
+                    if (lat == null || lon == null) {
+                        openCoordinateEditor(seededOptions)
+                    } else {
+                        startSelection(
+                            RouteToolSession(
+                                options = seededOptions,
+                                destination = LatLong(lat, lon),
                             ),
+                        )
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Create route")
+            }
+        }
+
+        if (options.toolKind == RouteToolKind.CREATE &&
+            options.createMode == RouteCreateMode.LOOP_AROUND_HERE
+        ) {
+            LoopTargetModeSelector(
+                selected = options.loopTargetMode,
+                onSelected = { targetMode ->
+                    onOptionsChange(options.copy(loopTargetMode = targetMode))
+                },
+            )
+            LoopTargetEditor(
+                targetMode = options.loopTargetMode,
+                distanceKm = options.loopDistanceKm,
+                durationMinutes = options.loopDurationMinutes,
+                onDecrease = {
+                    onOptionsChange(
+                        when (options.loopTargetMode) {
+                            LoopTargetMode.DISTANCE -> {
+                                options.copy(
+                                    loopDistanceKm =
+                                        (options.loopDistanceKm - 1)
+                                            .coerceAtLeast(2),
+                                )
+                            }
+
+                            LoopTargetMode.TIME -> {
+                                options.copy(
+                                    loopDurationMinutes =
+                                        (options.loopDurationMinutes - 15)
+                                            .coerceAtLeast(30),
+                                )
+                            }
+                        },
+                    )
+                },
+                onIncrease = {
+                    onOptionsChange(
+                        when (options.loopTargetMode) {
+                            LoopTargetMode.DISTANCE -> {
+                                options.copy(
+                                    loopDistanceKm =
+                                        (options.loopDistanceKm + 1)
+                                            .coerceAtMost(60),
+                                )
+                            }
+
+                            LoopTargetMode.TIME -> {
+                                options.copy(
+                                    loopDurationMinutes =
+                                        (options.loopDurationMinutes + 15)
+                                            .coerceAtMost(480),
+                                )
+                            }
+                        },
+                    )
+                },
+            )
+            LoopStartModeSelector(
+                selected = options.loopStartMode,
+                onSelected = { startMode ->
+                    onOptionsChange(options.copy(loopStartMode = startMode))
+                },
+            )
+            Button(
+                onClick = {
+                    startSelection(RouteToolSession(options = options))
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    if (options.loopStartMode == LoopStartMode.CURRENT_LOCATION) {
+                        "Create loop"
+                    } else {
+                        "Pick start on map"
+                    },
                 )
             }
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .height(routeToolsBottomActionSafeInset),
+        }
+
+        Text(
+            text = options.activeSummary,
+            style = MaterialTheme.typography.bodySmall,
+            textAlign = TextAlign.Center,
+            color = Color.White.copy(alpha = 0.84f),
+        )
+
+        Text(
+            text = routeToolsHintText(options),
+            style = MaterialTheme.typography.labelSmall,
+            textAlign = TextAlign.Center,
+            color = Color.White.copy(alpha = 0.68f),
+        )
+
+        RouteSettingRow(
+            title = "Route style",
+            value = options.routeStyle.title,
+            onClick = {
+                onOptionsChange(
+                    options.copy(routeStyle = options.routeStyle.next()),
+                )
+            },
+        )
+        Text(
+            text = options.routeStyle.summary,
+            style = MaterialTheme.typography.labelSmall,
+            textAlign = TextAlign.Center,
+            color = Color.White.copy(alpha = 0.72f),
+        )
+
+        if (options.toolKind == RouteToolKind.MODIFY) {
+            RouteSaveBehaviorSelector(
+                selected = options.saveBehavior,
+                onSelected = { behavior ->
+                    onOptionsChange(options.copy(saveBehavior = behavior))
+                },
+            )
+        }
+
+        if (options.toolKind == RouteToolKind.CREATE) {
+            RouteSettingRow(
+                title =
+                    if (options.showAdvancedOptions) {
+                        "Hide options"
+                    } else {
+                        "More options"
+                    },
+                value = if (options.showAdvancedOptions) "Advanced" else "Basic",
+                onClick = {
+                    onOptionsChange(
+                        options.copy(showAdvancedOptions = !options.showAdvancedOptions),
+                    )
+                },
+            )
+        }
+
+        if (options.toolKind == RouteToolKind.CREATE && options.showAdvancedOptions) {
+            SwitchButton(
+                modifier = Modifier.fillMaxWidth(),
+                checked = options.useElevation,
+                onCheckedChange = { enabled ->
+                    onOptionsChange(options.copy(useElevation = enabled))
+                },
+                label = { Text("Use elevation") },
+            )
+            SwitchButton(
+                modifier = Modifier.fillMaxWidth(),
+                checked = options.allowFerries,
+                onCheckedChange = { enabled ->
+                    onOptionsChange(options.copy(allowFerries = enabled))
+                },
+                label = { Text("Allow ferries") },
             )
         }
     }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolsActionPanel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolsActionPanel.kt
@@ -26,12 +26,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.wear.compose.material3.AlertDialog
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.SwitchButton
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.presentation.features.poi.PoiSearchUiState
+import com.glancemap.glancemapwearos.presentation.ui.WearActionDialog
 import com.glancemap.glancemapwearos.presentation.ui.WearScreenSize
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 import org.mapsforge.core.model.LatLong
@@ -439,21 +439,13 @@ internal fun RouteToolsActionPanel(
     }
 
     if (!preflightMessage.isNullOrBlank() && shouldUsePreflightPopup && showPreflightPopup) {
-        AlertDialog(
+        WearActionDialog(
             visible = true,
+            title = "Routing Missing",
+            message = preflightMessage,
+            confirmText = "OK",
+            onConfirm = { showPreflightPopup = false },
             onDismissRequest = { showPreflightPopup = false },
-            title = { Text("Routing Missing") },
-            text = {
-                Text(
-                    text = preflightMessage,
-                    textAlign = TextAlign.Center,
-                )
-            },
-            confirmButton = {
-                Button(onClick = { showPreflightPopup = false }) {
-                    Text("OK")
-                }
-            },
         )
     }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/CompassSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/CompassSettingsScreen.kt
@@ -1,8 +1,5 @@
 package com.glancemap.glancemapwearos.presentation.features.settings
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.Composable
@@ -15,11 +12,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material3.AlertDialog
 import androidx.wear.compose.material3.Button
@@ -31,7 +26,6 @@ import com.glancemap.glancemapwearos.domain.sensors.CompassProviderType
 import com.glancemap.glancemapwearos.domain.sensors.CompassViewModel
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.material.Chip
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
@@ -45,7 +39,6 @@ fun CompassSettingsScreen(
 ) {
     val listTokens = rememberSettingsListTokens()
     val adaptive = rememberWearAdaptiveSpec()
-    val listState = rememberSettingsScalingLazyListState(topPadding = listTokens.topPadding)
     var showCalibrationDialog by remember { mutableStateOf(false) }
     var showCompassModePicker by remember { mutableStateOf(false) }
     var showProviderPicker by remember { mutableStateOf(false) }
@@ -318,132 +311,117 @@ fun CompassSettingsScreen(
         }
     }
 
-    ScreenScaffold(scrollState = listState) {
-        ScalingLazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            state = listState,
-            contentPadding =
-                PaddingValues(
-                    start = listTokens.horizontalPadding,
-                    end = listTokens.horizontalPadding,
-                    top = listTokens.topPadding,
-                    bottom = listTokens.bottomPadding,
-                ),
-            verticalArrangement = Arrangement.spacedBy(listTokens.itemSpacing),
-            anchorType = SettingsListAnchorType,
-            autoCentering = SettingsListAutoCentering,
-        ) {
-            item { GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings) }
+    WearSettingsListScreen(listTokens = listTokens) {
+        item { GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings) }
+        item {
+            SettingsPickerChip(
+                label = "Orientation provider",
+                secondaryLabel =
+                    compassProviderStatusLabel(
+                        requestedMode = compassProviderModeSetting,
+                        activeProviderType = activeProviderType,
+                    ),
+                onClick = { showProviderPicker = true },
+            )
+        }
+        item {
+            SettingsPickerChip(
+                label = "North mode",
+                secondaryLabel =
+                    northReferenceStatusSecondaryLabel(
+                        requestedMode = northReferenceMode,
+                        status = northReferenceStatus,
+                    ),
+                onClick = { showNorthModePicker = true },
+            )
+        }
+        if (showSensorControls) {
             item {
-                SettingsPickerChip(
-                    label = "Orientation provider",
-                    secondaryLabel =
-                        compassProviderStatusLabel(
-                            requestedMode = compassProviderModeSetting,
-                            activeProviderType = activeProviderType,
-                        ),
-                    onClick = { showProviderPicker = true },
+                Text(
+                    "Setup",
+                    style = MaterialTheme.typography.titleMedium,
                 )
             }
             item {
                 SettingsPickerChip(
-                    label = "North mode",
-                    secondaryLabel =
-                        northReferenceStatusSecondaryLabel(
-                            requestedMode = northReferenceMode,
-                            status = northReferenceStatus,
-                        ),
-                    onClick = { showNorthModePicker = true },
+                    label = "Compass mode",
+                    secondaryLabel = compassSettingsModeLabel(compassSettingsMode),
+                    onClick = { showCompassModePicker = true },
                 )
             }
-            if (showSensorControls) {
+            if (showCompassConeAccuracyColorsSetting) {
                 item {
-                    Text(
-                        "Setup",
-                        style = MaterialTheme.typography.titleMedium,
+                    SettingsToggleChip(
+                        checked = compassConeAccuracyColorsEnabled,
+                        onCheckedChanged = { viewModel.setCompassConeAccuracyColorsEnabled(it) },
+                        label = "▽ Accuracy colors",
+                        secondaryLabel = "If off, cone stays green",
+                    )
+                }
+            }
+            item {
+                Text("Custom compass", style = MaterialTheme.typography.titleMedium)
+            }
+            item {
+                Chip(
+                    label = "Recalibrate Compass",
+                    onClick = { showCalibrationDialog = true },
+                )
+            }
+            item {
+                SettingsToggleChip(
+                    checked = promptForCalibration,
+                    onCheckedChanged = { viewModel.setPromptForCalibration(it) },
+                    label = calibrationAlertsLabel,
+                    secondaryLabel = calibrationAlertsSecondary,
+                )
+            }
+            item {
+                Chip(
+                    label = "Run source test",
+                    secondaryLabel = "Checks still + turn response",
+                    onClick = {
+                        compatibilityState = CompatibilityTestUiState()
+                        compatibilityRunToken += 1
+                        showCompatibilityDialog = true
+                    },
+                )
+            }
+            item {
+                Text("Advanced", style = MaterialTheme.typography.titleMedium)
+            }
+            item {
+                SettingsSectionChip(
+                    label = "Advanced options",
+                    onClick = { showAdvancedSection = !showAdvancedSection },
+                )
+            }
+            if (showAdvancedSection) {
+                item {
+                    SensorStatusPanel(
+                        status = headingSourceStatus,
+                        northReferenceStatus = northReferenceStatus,
                     )
                 }
                 item {
                     SettingsPickerChip(
-                        label = "Compass mode",
-                        secondaryLabel = compassSettingsModeLabel(compassSettingsMode),
-                        onClick = { showCompassModePicker = true },
+                        label = "Heading source",
+                        secondaryLabel = headingSourceModeLabel(headingSourceModeSetting),
+                        onClick = { showHeadingSourcePicker = true },
                     )
-                }
-                if (showCompassConeAccuracyColorsSetting) {
-                    item {
-                        SettingsToggleChip(
-                            checked = compassConeAccuracyColorsEnabled,
-                            onCheckedChanged = { viewModel.setCompassConeAccuracyColorsEnabled(it) },
-                            label = "▽ Accuracy colors",
-                            secondaryLabel = "If off, cone stays green",
-                        )
-                    }
-                }
-                item {
-                    Text("Custom compass", style = MaterialTheme.typography.titleMedium)
-                }
-                item {
-                    Chip(
-                        label = "Recalibrate Compass",
-                        onClick = { showCalibrationDialog = true },
-                    )
-                }
-                item {
-                    SettingsToggleChip(
-                        checked = promptForCalibration,
-                        onCheckedChanged = { viewModel.setPromptForCalibration(it) },
-                        label = calibrationAlertsLabel,
-                        secondaryLabel = calibrationAlertsSecondary,
-                    )
-                }
-                item {
-                    Chip(
-                        label = "Run source test",
-                        secondaryLabel = "Checks still + turn response",
-                        onClick = {
-                            compatibilityState = CompatibilityTestUiState()
-                            compatibilityRunToken += 1
-                            showCompatibilityDialog = true
-                        },
-                    )
-                }
-                item {
-                    Text("Advanced", style = MaterialTheme.typography.titleMedium)
-                }
-                item {
-                    SettingsSectionChip(
-                        label = "Advanced options",
-                        onClick = { showAdvancedSection = !showAdvancedSection },
-                    )
-                }
-                if (showAdvancedSection) {
-                    item {
-                        SensorStatusPanel(
-                            status = headingSourceStatus,
-                            northReferenceStatus = northReferenceStatus,
-                        )
-                    }
-                    item {
-                        SettingsPickerChip(
-                            label = "Heading source",
-                            secondaryLabel = headingSourceModeLabel(headingSourceModeSetting),
-                            onClick = { showHeadingSourcePicker = true },
-                        )
-                    }
                 }
             }
-            item {
-                Text("Help", style = MaterialTheme.typography.titleMedium)
-            }
-            item {
-                Chip(
-                    label = "Compass help",
-                    secondaryLabel = "How to test compass",
-                    icon = { Icon(imageVector = Icons.Filled.Info, contentDescription = null) },
-                    onClick = { showInfoDialog = true },
-                )
-            }
+        }
+        item {
+            Text("Help", style = MaterialTheme.typography.titleMedium)
+        }
+        item {
+            Chip(
+                label = "Compass help",
+                secondaryLabel = "How to test compass",
+                icon = { Icon(imageVector = Icons.Filled.Info, contentDescription = null) },
+                onClick = { showInfoDialog = true },
+            )
         }
     }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/CompassSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/CompassSettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.glancemap.glancemapwearos.presentation.features.settings
 
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.Composable
@@ -12,6 +13,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -24,6 +27,7 @@ import com.glancemap.glancemapwearos.data.repository.SettingsRepository
 import com.glancemap.glancemapwearos.domain.sensors.CompassHeadingSourceMode
 import com.glancemap.glancemapwearos.domain.sensors.CompassProviderType
 import com.glancemap.glancemapwearos.domain.sensors.CompassViewModel
+import com.glancemap.glancemapwearos.presentation.ui.WearInfoDialog
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.material.Chip
@@ -551,11 +555,12 @@ fun CompassSettingsScreen(
         },
     )
 
-    AlertDialog(
+    WearInfoDialog(
         visible = showInfoDialog,
-        onDismissRequest = { showInfoDialog = false },
-        title = { Text("Compass help") },
-        text = {
+        title = "Compass help",
+        onDismiss = { showInfoDialog = false },
+    ) {
+        item {
             Text(
                 "Recommended setup: Google Fused + True north.\n\n" +
                     "Quick test: stand still, face a clear landmark, then switch North-up / Compass.\n" +
@@ -568,12 +573,9 @@ fun CompassSettingsScreen(
                     "Custom mode prefers Rotation vector when available,\n" +
                     "and gives you Recalibrate Compass, source test,\n" +
                     "heading source selection, and accuracy-color options.",
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
             )
-        },
-        confirmButton = {
-            Button(onClick = { showInfoDialog = false }) {
-                Text("Close")
-            }
-        },
-    )
+        }
+    }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/CompassSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/CompassSettingsScreen.kt
@@ -19,14 +19,15 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.wear.compose.material.Icon
-import androidx.wear.compose.material3.AlertDialog
-import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.data.repository.SettingsRepository
 import com.glancemap.glancemapwearos.domain.sensors.CompassHeadingSourceMode
 import com.glancemap.glancemapwearos.domain.sensors.CompassProviderType
 import com.glancemap.glancemapwearos.domain.sensors.CompassViewModel
+import com.glancemap.glancemapwearos.presentation.ui.WearActionButtonRole
+import com.glancemap.glancemapwearos.presentation.ui.WearActionDialog
+import com.glancemap.glancemapwearos.presentation.ui.WearActionDialogButton
 import com.glancemap.glancemapwearos.presentation.ui.WearInfoDialog
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
@@ -472,88 +473,86 @@ fun CompassSettingsScreen(
         },
     )
 
-    AlertDialog(
-        visible = showCompatibilityDialog,
-        onDismissRequest = {
-            if (!isCompatibilityRunning) {
-                showCompatibilityDialog = false
-                compatibilityState = CompatibilityTestUiState()
-            }
-        },
-        title = { Text("Custom sensor test") },
-        text = {
-            val result = compatibilityState.result
-            val error = compatibilityState.errorMessage
+    if (showCompatibilityDialog) {
+        val result = compatibilityState.result
+        val error = compatibilityState.errorMessage
+        val compatibilityMessage =
             when {
-                isCompatibilityRunning -> {
-                    Text(
-                        "${compatibilityState.progressLabel}\n" +
-                            "Step ${compatibilityState.stepIndex}/${compatibilityState.totalSteps}\n" +
-                            "Follow the on-screen step for best result.",
-                    )
-                }
-                error != null -> {
-                    Text(error)
-                }
-                result != null -> {
-                    Text(
-                        "Recommended custom settings:\n" +
-                            "Compass mode: ${result.recommendedCompassModeLabel()}\n" +
-                            result.recommendedHeadingSourceLine() +
-                            "North mode: Keep True north for maps\n" +
-                            "Magnetic north only if you want to match a magnetic compass.\n\n" +
-                            "This test checks source availability, still-watch stability,\n" +
-                            "and slow turn response.\n" +
-                            "It does not detect true vs magnetic north.\n\n" +
-                            "Results:\n" +
-                            result.candidateSummaryLines(),
-                    )
-                }
-                else -> {
-                    Text("Preparing test...")
-                }
+                isCompatibilityRunning ->
+                    "${compatibilityState.progressLabel}\n" +
+                        "Step ${compatibilityState.stepIndex}/${compatibilityState.totalSteps}\n" +
+                        "Follow the on-screen step for best result."
+                error != null -> error
+                result != null ->
+                    "Recommended custom settings:\n" +
+                        "Compass mode: ${result.recommendedCompassModeLabel()}\n" +
+                        result.recommendedHeadingSourceLine() +
+                        "North mode: Keep True north for maps\n" +
+                        "Magnetic north only if you want to match a magnetic compass.\n\n" +
+                        "This test checks source availability, still-watch stability,\n" +
+                        "and slow turn response.\n" +
+                        "It does not detect true vs magnetic north.\n\n" +
+                        "Results:\n" +
+                        result.candidateSummaryLines()
+                else -> "Preparing test..."
             }
-        },
-        confirmButton = {
-            if (!isCompatibilityRunning && compatibilityState.result != null) {
-                Button(
-                    onClick = {
-                        val recommended =
-                            compatibilityState.result?.recommendedMode
-                                ?: return@Button
-                        when (recommended) {
-                            CompassHeadingSourceMode.AUTO -> {
-                                viewModel.setCompassSettingsMode(SettingsRepository.COMPASS_SETTINGS_MODE_AUTOMATIC)
-                                viewModel.setCompassHeadingSourceMode(
-                                    SettingsRepository.COMPASS_HEADING_SOURCE_AUTO,
-                                )
-                            }
-                            else -> {
-                                viewModel.setCompassSettingsMode(SettingsRepository.COMPASS_SETTINGS_MODE_ADVANCED)
-                                viewModel.setCompassHeadingSourceMode(
-                                    headingSourceSettingFromMode(recommended),
-                                )
-                            }
-                        }
-                        showCompatibilityDialog = false
-                        compatibilityState = CompatibilityTestUiState()
-                    },
-                ) {
-                    Text("Apply")
+        val closeCompatibilityDialog = {
+            showCompatibilityDialog = false
+            compatibilityState = CompatibilityTestUiState()
+        }
+        WearActionDialog(
+            visible = true,
+            title = "Custom sensor test",
+            onDismissRequest = {
+                if (!isCompatibilityRunning) {
+                    closeCompatibilityDialog()
                 }
-            }
-        },
-        dismissButton = {
-            Button(
-                onClick = {
-                    showCompatibilityDialog = false
-                    compatibilityState = CompatibilityTestUiState()
+            },
+            buttons =
+                buildList {
+                    if (!isCompatibilityRunning && result != null) {
+                        add(
+                            WearActionDialogButton(
+                                text = "Apply",
+                                onClick = {
+                                    when (result.recommendedMode) {
+                                        CompassHeadingSourceMode.AUTO -> {
+                                            viewModel.setCompassSettingsMode(
+                                                SettingsRepository.COMPASS_SETTINGS_MODE_AUTOMATIC,
+                                            )
+                                            viewModel.setCompassHeadingSourceMode(
+                                                SettingsRepository.COMPASS_HEADING_SOURCE_AUTO,
+                                            )
+                                        }
+                                        else -> {
+                                            viewModel.setCompassSettingsMode(
+                                                SettingsRepository.COMPASS_SETTINGS_MODE_ADVANCED,
+                                            )
+                                            viewModel.setCompassHeadingSourceMode(
+                                                headingSourceSettingFromMode(result.recommendedMode),
+                                            )
+                                        }
+                                    }
+                                    closeCompatibilityDialog()
+                                },
+                            ),
+                        )
+                    }
+                    add(
+                        WearActionDialogButton(
+                            text = if (isCompatibilityRunning) "Cancel" else "Close",
+                            onClick = closeCompatibilityDialog,
+                            role = WearActionButtonRole.Secondary,
+                        ),
+                    )
                 },
-            ) {
-                Text(if (isCompatibilityRunning) "Cancel" else "Close")
-            }
-        },
-    )
+        ) {
+            Text(
+                text = compatibilityMessage,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
 
     WearInfoDialog(
         visible = showInfoDialog,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/DebuggingSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/DebuggingSettingsScreen.kt
@@ -5,20 +5,11 @@ package com.glancemap.glancemapwearos.presentation.features.settings
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
-import androidx.compose.foundation.background
-import androidx.compose.foundation.focusable
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.Composable
@@ -31,16 +22,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.input.rotary.onPreRotaryScrollEvent
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
 import androidx.core.content.FileProvider
-import androidx.wear.compose.material3.AlertDialog
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.IconButton
@@ -61,13 +46,9 @@ import com.glancemap.glancemapwearos.core.service.diagnostics.MapHotPathDiagnost
 import com.glancemap.glancemapwearos.domain.sensors.CompassViewModel
 import com.glancemap.glancemapwearos.presentation.features.navigate.motion.MarkerMotionTelemetry
 import com.glancemap.glancemapwearos.presentation.features.routetools.RouteToolBusySpinner
-import com.glancemap.glancemapwearos.presentation.ui.WearCustomDialogScrollableColumn
-import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpacer
-import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollableColumn
+import com.glancemap.glancemapwearos.presentation.ui.WearInfoDialog
 import com.glancemap.glancemapwearos.presentation.ui.WearScreenSize
-import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearScreenSize
-import com.glancemap.glancemapwearos.presentation.ui.wearDialogWidth
 import com.glancemap.shared.transfer.TransferDataLayerContract
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.material.Chip
@@ -77,11 +58,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlin.math.abs
 
 private const val DEBUG_HELP_PREFS = "debug_settings_help_prefs"
 private const val DEBUG_EXPORT_INFO_SHOWN_KEY = "debug_export_info_shown"
-private const val DEBUG_INFO_DRAG_DISMISS_PX = 55f
 private const val CLEAN_CAPTURE_DEFAULT_LABEL = "Clear all captured logs"
 private const val CLEAN_CAPTURE_CLEARED_LABEL = "All captured logs have been cleared."
 private const val CLEAN_CAPTURE_RESET_DELAY_MS = 3500L
@@ -498,9 +477,6 @@ private fun DiagnosticsExportStatusDialog(
 ) {
     if (mode == null) return
 
-    val adaptive = rememberWearAdaptiveSpec()
-    val scrollState = rememberScrollState()
-    val focusRequester = remember { FocusRequester() }
     val dismissible = mode != DiagnosticsExportDialogMode.GENERATING
     val title =
         if (mode == DiagnosticsExportDialogMode.GENERATING) {
@@ -510,101 +486,37 @@ private fun DiagnosticsExportStatusDialog(
         } else {
             "Diagnostic ready - check your phone"
         }
-    LaunchedEffect(mode) {
-        focusRequester.requestFocus()
-    }
 
-    Dialog(
-        onDismissRequest = {
-            if (dismissible) {
-                onDismiss()
-            }
-        },
+    WearInfoDialog(
+        visible = true,
+        title = title,
+        onDismiss = onDismiss,
+        dismissible = dismissible,
     ) {
-        androidx.compose.foundation.layout.Column(
-            modifier =
-                Modifier
-                    .wearDialogWidth()
-                    .background(
-                        Color.Black.copy(alpha = 0.82f),
-                        RoundedCornerShape(adaptive.dialogCornerRadius),
-                    ).padding(
-                        horizontal = adaptive.dialogHorizontalPadding,
-                        vertical = adaptive.dialogVerticalPadding,
-                    ),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(6.dp),
-        ) {
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .pointerInput(dismissible) {
-                            if (!dismissible) return@pointerInput
-                            var totalDrag = 0f
-                            detectVerticalDragGestures(
-                                onDragEnd = { totalDrag = 0f },
-                                onDragCancel = { totalDrag = 0f },
-                            ) { _, dragAmount ->
-                                totalDrag += dragAmount
-                                if (totalDrag > DEBUG_INFO_DRAG_DISMISS_PX) {
-                                    onDismiss()
-                                    totalDrag = 0f
-                                }
-                            }
-                        },
-                contentAlignment = Alignment.Center,
-            ) {
-                Box(
+        if (mode == DiagnosticsExportDialogMode.GENERATING) {
+            item {
+                RouteToolBusySpinner(size = 30.dp)
+            }
+        }
+        item {
+            Text(
+                text = message,
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        if (dismissible) {
+            item {
+                Button(
+                    onClick = onDismiss,
                     modifier =
                         Modifier
-                            .width(26.dp)
-                            .height(3.dp)
-                            .background(Color.White.copy(alpha = 0.42f), RoundedCornerShape(50)),
-                )
-            }
-
-            WearCustomDialogScrollableColumn(
-                maxHeight = adaptive.helpDialogMaxHeight,
-                modifier = Modifier.fillMaxWidth(),
-                contentModifier =
-                    Modifier
-                        .onPreRotaryScrollEvent { event ->
-                            val consumed = scrollState.dispatchRawDelta(event.verticalScrollPixels)
-                            abs(consumed) > 0.5f
-                        }.focusRequester(focusRequester)
-                        .focusable(),
-                scrollState = scrollState,
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                if (mode == DiagnosticsExportDialogMode.GENERATING) {
-                    RouteToolBusySpinner(size = 30.dp)
+                            .fillMaxWidth()
+                            .heightIn(min = 48.dp),
+                ) {
+                    Text("OK")
                 }
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleMedium,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                Text(
-                    text = message,
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                if (dismissible) {
-                    Button(
-                        onClick = onDismiss,
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .heightIn(min = 48.dp),
-                    ) {
-                        Text("OK")
-                    }
-                }
-                WearDialogScrollBottomSpacer()
             }
         }
     }
@@ -616,33 +528,23 @@ private fun DiagnosticsExportInfoDialog(
     onDismiss: () -> Unit,
 ) {
     if (!visible) return
-    val adaptive = rememberWearAdaptiveSpec()
 
-    AlertDialog(
+    WearInfoDialog(
         visible = visible,
-        onDismissRequest = onDismiss,
-        title = { Text("Diagnostics Export") },
-        text = {
-            WearDialogScrollableColumn(
-                maxHeight = adaptive.helpDialogMaxHeight,
-                modifier =
-                    Modifier
-                        .fillMaxWidth(),
-                scrollable = false,
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Text(
-                    text =
-                        "After export, check your phone.\n" +
-                            "It opens the email draft with diagnostics attached.\n" +
-                            "If you closed the phone prompt, come back here and tap Resend.",
-                    textAlign = TextAlign.Center,
-                )
-                WearDialogScrollBottomSpacer()
-            }
-        },
-    )
+        title = "Diagnostics Export",
+        onDismiss = onDismiss,
+    ) {
+        item {
+            Text(
+                text =
+                    "After export, check your phone.\n" +
+                        "It opens the email draft with diagnostics attached.\n" +
+                        "If you closed the phone prompt, come back here and tap Resend.",
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
 }
 
 private fun buildRetryReadyLabel(count: Int): String {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/DebuggingSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/DebuggingSettingsScreen.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -42,7 +40,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.core.content.FileProvider
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.material3.AlertDialog
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.Icon
@@ -73,7 +70,6 @@ import com.glancemap.glancemapwearos.presentation.ui.rememberWearScreenSize
 import com.glancemap.glancemapwearos.presentation.ui.wearDialogWidth
 import com.glancemap.shared.transfer.TransferDataLayerContract
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.compose.material.ToggleChip
 import com.google.android.horologist.compose.material.ToggleChipToggleControl
@@ -135,7 +131,6 @@ fun DebuggingSettingsScreen(
         }
     val hasExportedDiagnostics = exportedDiagnosticsCount > 0
 
-    val listState = rememberSettingsScalingLazyListState(topPadding = listTokens.topPadding)
     val infoButtonSize =
         when (screenSize) {
             WearScreenSize.LARGE -> 24.dp
@@ -197,315 +192,299 @@ fun DebuggingSettingsScreen(
         helpPrefs.edit().putBoolean(DEBUG_EXPORT_INFO_SHOWN_KEY, true).apply()
     }
 
-    ScreenScaffold(scrollState = listState) {
-        DiagnosticsExportInfoDialog(
-            visible = showExportInfoDialog,
-            onDismiss = { dismissExportInfoDialog() },
-        )
-        DiagnosticsExportStatusDialog(
-            mode = exportDialogMode,
-            message = exportDialogMessage,
-            onDismiss = { exportDialogMode = null },
-        )
+    DiagnosticsExportInfoDialog(
+        visible = showExportInfoDialog,
+        onDismiss = { dismissExportInfoDialog() },
+    )
+    DiagnosticsExportStatusDialog(
+        mode = exportDialogMode,
+        message = exportDialogMessage,
+        onDismiss = { exportDialogMode = null },
+    )
 
-        ScalingLazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            state = listState,
-            contentPadding =
-                PaddingValues(
-                    start = listTokens.horizontalPadding,
-                    end = listTokens.horizontalPadding,
-                    top = listTokens.topPadding,
-                    bottom = listTokens.bottomPadding,
-                ),
-            verticalArrangement = Arrangement.spacedBy(listTokens.itemSpacing),
-            anchorType = SettingsListAnchorType,
-            autoCentering = SettingsListAutoCentering,
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            item {
-                Box(
-                    modifier = Modifier.fillMaxWidth(),
-                    contentAlignment = Alignment.Center,
+    WearSettingsListScreen(listTokens = listTokens, horizontalAlignment = Alignment.CenterHorizontally) {
+        item {
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center,
+            ) {
+                IconButton(
+                    onClick = { showExportInfoDialog = true },
+                    modifier =
+                        Modifier
+                            .size(infoButtonSize)
+                            .wrapContentSize(align = Alignment.Center),
+                    colors =
+                        IconButtonDefaults.iconButtonColors(
+                            containerColor = Color.Black.copy(alpha = 0.7f),
+                            contentColor = Color.White,
+                        ),
                 ) {
-                    IconButton(
-                        onClick = { showExportInfoDialog = true },
-                        modifier =
-                            Modifier
-                                .size(infoButtonSize)
-                                .wrapContentSize(align = Alignment.Center),
-                        colors =
-                            IconButtonDefaults.iconButtonColors(
-                                containerColor = Color.Black.copy(alpha = 0.7f),
-                                contentColor = Color.White,
-                            ),
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.Info,
-                            contentDescription = "Diagnostics export info",
-                            modifier = Modifier.size(infoIconSize),
-                        )
-                    }
+                    Icon(
+                        imageVector = Icons.Filled.Info,
+                        contentDescription = "Diagnostics export info",
+                        modifier = Modifier.size(infoIconSize),
+                    )
                 }
             }
+        }
 
-            item {
-                GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
-            }
+        item {
+            GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
+        }
 
-            item {
-                Chip(
-                    label = "1. Clean Previous Logs",
-                    secondaryLabel =
-                        if (exportInProgress) {
-                            "Export in progress..."
-                        } else {
-                            cleanCaptureStatus
-                        },
-                    onClick = {
-                        if (exportInProgress) return@Chip
-                        DebugTelemetry.clear()
-                        MarkerMotionTelemetry.clear()
-                        EnergyDiagnostics.clear()
-                        DemDownloadDiagnostics.clear()
-                        FieldMarkerDiagnostics.clear()
-                        GnssDiagnostics.clear()
-                        MapHotPathDiagnostics.clear()
-                        CrashDiagnosticsStore.clear(context)
-                        DiagnosticsExporter.clearExportedFiles(context)
-                        exportedDiagnosticsCount = 0
-                        cleanCaptureStatus = CLEAN_CAPTURE_CLEARED_LABEL
-                        cleanCaptureResetToken += 1L
-                        diagnosticsExportStatus = "Cleared. Start capture."
+        item {
+            Chip(
+                label = "1. Clean Previous Logs",
+                secondaryLabel =
+                    if (exportInProgress) {
+                        "Export in progress..."
+                    } else {
+                        cleanCaptureStatus
                     },
-                )
-            }
+                onClick = {
+                    if (exportInProgress) return@Chip
+                    DebugTelemetry.clear()
+                    MarkerMotionTelemetry.clear()
+                    EnergyDiagnostics.clear()
+                    DemDownloadDiagnostics.clear()
+                    FieldMarkerDiagnostics.clear()
+                    GnssDiagnostics.clear()
+                    MapHotPathDiagnostics.clear()
+                    CrashDiagnosticsStore.clear(context)
+                    DiagnosticsExporter.clearExportedFiles(context)
+                    exportedDiagnosticsCount = 0
+                    cleanCaptureStatus = CLEAN_CAPTURE_CLEARED_LABEL
+                    cleanCaptureResetToken += 1L
+                    diagnosticsExportStatus = "Cleared. Start capture."
+                },
+            )
+        }
 
+        item {
+            ToggleChip(
+                checked = gpsDebugTelemetry,
+                onCheckedChanged = {
+                    if (exportInProgress) return@ToggleChip
+                    viewModel.setGpsDebugTelemetry(it)
+                    FieldMarkerDiagnostics.recordMarker(
+                        type = if (it) "capture_start" else "capture_stop",
+                        note = "source=capture_toggle",
+                    )
+                    diagnosticsExportStatus =
+                        if (it) {
+                            "Capturing..."
+                        } else if (hasExportedDiagnostics) {
+                            buildRetryReadyLabel(exportedDiagnosticsCount)
+                        } else if (DebugTelemetry.size() > 0) {
+                            "Send to phone"
+                        } else {
+                            "Capture off."
+                        }
+                },
+                label = "2. Start Capturing",
+                secondaryLabel =
+                    if (gpsDebugTelemetry) {
+                        "Capturing..."
+                    } else if (exportInProgress) {
+                        "Export in progress..."
+                    } else {
+                        "Off - tap to start"
+                    },
+                toggleControl = ToggleChipToggleControl.Switch,
+            )
+        }
+
+        if (gpsDebugTelemetry) {
             item {
                 ToggleChip(
-                    checked = gpsDebugTelemetry,
+                    checked = gpsDebugTelemetryPopupEnabled,
                     onCheckedChanged = {
                         if (exportInProgress) return@ToggleChip
-                        viewModel.setGpsDebugTelemetry(it)
-                        FieldMarkerDiagnostics.recordMarker(
-                            type = if (it) "capture_start" else "capture_stop",
-                            note = "source=capture_toggle",
-                        )
-                        diagnosticsExportStatus =
-                            if (it) {
-                                "Capturing..."
-                            } else if (hasExportedDiagnostics) {
-                                buildRetryReadyLabel(exportedDiagnosticsCount)
-                            } else if (DebugTelemetry.size() > 0) {
-                                "Send to phone"
-                            } else {
-                                "Capture off."
-                            }
+                        viewModel.setGpsDebugTelemetryPopupEnabled(it)
                     },
-                    label = "2. Start Capturing",
+                    label = "Debug popup",
                     secondaryLabel =
-                        if (gpsDebugTelemetry) {
-                            "Capturing..."
-                        } else if (exportInProgress) {
-                            "Export in progress..."
+                        if (gpsDebugTelemetryPopupEnabled) {
+                            "On while capturing"
                         } else {
-                            "Off - tap to start"
+                            "Off while capturing"
                         },
                     toggleControl = ToggleChipToggleControl.Switch,
                 )
             }
+        }
 
-            if (gpsDebugTelemetry) {
-                item {
-                    ToggleChip(
-                        checked = gpsDebugTelemetryPopupEnabled,
-                        onCheckedChanged = {
-                            if (exportInProgress) return@ToggleChip
-                            viewModel.setGpsDebugTelemetryPopupEnabled(it)
-                        },
-                        label = "Debug popup",
-                        secondaryLabel =
-                            if (gpsDebugTelemetryPopupEnabled) {
-                                "On while capturing"
-                            } else {
-                                "Off while capturing"
-                            },
-                        toggleControl = ToggleChipToggleControl.Switch,
-                    )
-                }
-            }
-
-            item {
-                Chip(
-                    label =
-                        if (hasExportedDiagnostics && !gpsDebugTelemetry) {
-                            "3. Resend Diagnostic"
-                        } else {
-                            "3. Export Diagnostic"
-                        },
-                    secondaryLabel =
-                        if (exportInProgress) {
-                            "Exporting..."
-                        } else if (gpsDebugTelemetry) {
-                            "Stop & export"
-                        } else {
-                            diagnosticsExportStatus
-                        },
-                    onClick = {
-                        if (exportInProgress) return@Chip
-                        coroutineScope.launch {
-                            exportInProgress = true
-                            exportDialogMode = DiagnosticsExportDialogMode.GENERATING
-                            exportDialogMessage = "Generating diagnostics file..."
-                            val captureWasEnabled = DebugTelemetry.isEnabled()
-                            try {
-                                val hasBufferedLogs = DebugTelemetry.size() > 0
-                                val hasExistingExport =
-                                    withContext(Dispatchers.IO) {
-                                        DiagnosticsExporter.latestExportFile(context) != null
-                                    }
-                                val canExport = captureWasEnabled || hasBufferedLogs || hasExistingExport
-                                if (!canExport) {
-                                    exportDialogMode = null
-                                    diagnosticsExportStatus = "No logs to export. Start capturing first."
-                                    return@launch
+        item {
+            Chip(
+                label =
+                    if (hasExportedDiagnostics && !gpsDebugTelemetry) {
+                        "3. Resend Diagnostic"
+                    } else {
+                        "3. Export Diagnostic"
+                    },
+                secondaryLabel =
+                    if (exportInProgress) {
+                        "Exporting..."
+                    } else if (gpsDebugTelemetry) {
+                        "Stop & export"
+                    } else {
+                        diagnosticsExportStatus
+                    },
+                onClick = {
+                    if (exportInProgress) return@Chip
+                    coroutineScope.launch {
+                        exportInProgress = true
+                        exportDialogMode = DiagnosticsExportDialogMode.GENERATING
+                        exportDialogMessage = "Generating diagnostics file..."
+                        val captureWasEnabled = DebugTelemetry.isEnabled()
+                        try {
+                            val hasBufferedLogs = DebugTelemetry.size() > 0
+                            val hasExistingExport =
+                                withContext(Dispatchers.IO) {
+                                    DiagnosticsExporter.latestExportFile(context) != null
                                 }
-
-                                diagnosticsExportStatus = "Preparing file..."
-
-                                // Freeze capture state immediately to avoid session churn while exporting.
-                                if (captureWasEnabled) {
-                                    viewModel.setGpsDebugTelemetry(false)
-                                    DebugTelemetry.setEnabled(false)
-                                }
-
-                                val diagnosticsFile =
-                                    withContext(Dispatchers.IO) {
-                                        DiagnosticsExporter.export(
-                                            context = context,
-                                            settings =
-                                                DiagnosticsSettingsSnapshot(
-                                                    gpsIntervalMs = gpsIntervalMs,
-                                                    watchGpsOnly = isWatchGpsOnly,
-                                                    keepAppOpen = keepAppOpen,
-                                                    gpsInAmbientMode = gpsInAmbientMode,
-                                                    gpsDebugTelemetry = captureWasEnabled,
-                                                    gpsPassiveLocationExperiment = gpsPassiveLocationExperiment,
-                                                    backButtonExitsNavigation = backButtonExitsNavigation,
-                                                ),
-                                            reuseLatestIfAvailable = !captureWasEnabled,
-                                        )
-                                    }
-                                exportedDiagnosticsCount =
-                                    withContext(Dispatchers.IO) {
-                                        DiagnosticsExporter.exportedFileCount(context)
-                                    }
-                                exportDialogMessage = "Sending diagnostics to your phone..."
-
-                                val subject =
-                                    "${TransferDataLayerContract.DIAGNOSTICS_SUBJECT_PREFIX} ${diagnosticsFile.nameWithoutExtension}"
-
-                                // Prefer phone handoff first because many watches have no mail/share app.
-                                val handedOff =
-                                    withContext(Dispatchers.IO) {
-                                        DiagnosticsEmailHandoff.sendToPhone(
-                                            context = context,
-                                            diagnosticsFile = diagnosticsFile,
-                                            subject = subject,
-                                        )
-                                    }
-                                if (handedOff) {
-                                    diagnosticsExportStatus = "Check phone. Use button 3 to resend."
-                                    exportDialogMode = DiagnosticsExportDialogMode.CHECK_PHONE
-                                    exportDialogMessage =
-                                        "If you closed the phone prompt, tap button 3 again to resend."
-                                    return@launch
-                                }
+                            val canExport = captureWasEnabled || hasBufferedLogs || hasExistingExport
+                            if (!canExport) {
                                 exportDialogMode = null
+                                diagnosticsExportStatus = "No logs to export. Start capturing first."
+                                return@launch
+                            }
 
-                                val uri =
-                                    FileProvider.getUriForFile(
-                                        context,
-                                        "${context.packageName}.fileprovider",
-                                        diagnosticsFile,
+                            diagnosticsExportStatus = "Preparing file..."
+
+                            // Freeze capture state immediately to avoid session churn while exporting.
+                            if (captureWasEnabled) {
+                                viewModel.setGpsDebugTelemetry(false)
+                                DebugTelemetry.setEnabled(false)
+                            }
+
+                            val diagnosticsFile =
+                                withContext(Dispatchers.IO) {
+                                    DiagnosticsExporter.export(
+                                        context = context,
+                                        settings =
+                                            DiagnosticsSettingsSnapshot(
+                                                gpsIntervalMs = gpsIntervalMs,
+                                                watchGpsOnly = isWatchGpsOnly,
+                                                keepAppOpen = keepAppOpen,
+                                                gpsInAmbientMode = gpsInAmbientMode,
+                                                gpsDebugTelemetry = captureWasEnabled,
+                                                gpsPassiveLocationExperiment = gpsPassiveLocationExperiment,
+                                                backButtonExitsNavigation = backButtonExitsNavigation,
+                                            ),
+                                        reuseLatestIfAvailable = !captureWasEnabled,
                                     )
+                                }
+                            exportedDiagnosticsCount =
+                                withContext(Dispatchers.IO) {
+                                    DiagnosticsExporter.exportedFileCount(context)
+                                }
+                            exportDialogMessage = "Sending diagnostics to your phone..."
 
-                                val shareIntent =
-                                    Intent(Intent.ACTION_SEND).apply {
-                                        type = "text/plain"
-                                        putExtra(
-                                            Intent.EXTRA_EMAIL,
-                                            arrayOf(TransferDataLayerContract.DIAGNOSTICS_SUPPORT_EMAIL),
-                                        )
-                                        putExtra(Intent.EXTRA_SUBJECT, subject)
-                                        putExtra(Intent.EXTRA_TEXT, "Diagnostics export attached from watch.")
-                                        putExtra(Intent.EXTRA_STREAM, uri)
-                                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                                    }
+                            val subject =
+                                "${TransferDataLayerContract.DIAGNOSTICS_SUBJECT_PREFIX} ${diagnosticsFile.nameWithoutExtension}"
 
-                                val hasWatchTargets =
-                                    context.packageManager.queryIntentActivities(shareIntent, 0).isNotEmpty()
-                                if (!hasWatchTargets) {
+                            // Prefer phone handoff first because many watches have no mail/share app.
+                            val handedOff =
+                                withContext(Dispatchers.IO) {
+                                    DiagnosticsEmailHandoff.sendToPhone(
+                                        context = context,
+                                        diagnosticsFile = diagnosticsFile,
+                                        subject = subject,
+                                    )
+                                }
+                            if (handedOff) {
+                                diagnosticsExportStatus = "Check phone. Use button 3 to resend."
+                                exportDialogMode = DiagnosticsExportDialogMode.CHECK_PHONE
+                                exportDialogMessage =
+                                    "If you closed the phone prompt, tap button 3 again to resend."
+                                return@launch
+                            }
+                            exportDialogMode = null
+
+                            val uri =
+                                FileProvider.getUriForFile(
+                                    context,
+                                    "${context.packageName}.fileprovider",
+                                    diagnosticsFile,
+                                )
+
+                            val shareIntent =
+                                Intent(Intent.ACTION_SEND).apply {
+                                    type = "text/plain"
+                                    putExtra(
+                                        Intent.EXTRA_EMAIL,
+                                        arrayOf(TransferDataLayerContract.DIAGNOSTICS_SUPPORT_EMAIL),
+                                    )
+                                    putExtra(Intent.EXTRA_SUBJECT, subject)
+                                    putExtra(Intent.EXTRA_TEXT, "Diagnostics export attached from watch.")
+                                    putExtra(Intent.EXTRA_STREAM, uri)
+                                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                }
+
+                            val hasWatchTargets =
+                                context.packageManager.queryIntentActivities(shareIntent, 0).isNotEmpty()
+                            if (!hasWatchTargets) {
+                                diagnosticsExportStatus = buildRetryReadyLabel(exportedDiagnosticsCount)
+                                exportDialogMode = DiagnosticsExportDialogMode.FAILED
+                                exportDialogMessage =
+                                    "Couldn't send diagnostics to your phone.\n" +
+                                    "Tap Resend Diagnostic to try again."
+                                return@launch
+                            }
+
+                            val chooser =
+                                Intent.createChooser(shareIntent, "Send diagnostics").apply {
+                                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                }
+                            runCatching { context.startActivity(chooser) }
+                                .onSuccess {
+                                    diagnosticsExportStatus =
+                                        if (captureWasEnabled) {
+                                            "Confirm send on phone. Capture off."
+                                        } else {
+                                            "Confirm send on phone."
+                                        }
+                                }.onFailure {
                                     diagnosticsExportStatus = buildRetryReadyLabel(exportedDiagnosticsCount)
                                     exportDialogMode = DiagnosticsExportDialogMode.FAILED
                                     exportDialogMessage =
-                                        "Couldn't send diagnostics to your phone.\n" +
-                                        "Tap Resend Diagnostic to try again."
-                                    return@launch
+                                        "Export failed.\nTap Resend Diagnostic to try again."
                                 }
-
-                                val chooser =
-                                    Intent.createChooser(shareIntent, "Send diagnostics").apply {
-                                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                                    }
-                                runCatching { context.startActivity(chooser) }
-                                    .onSuccess {
-                                        diagnosticsExportStatus =
-                                            if (captureWasEnabled) {
-                                                "Confirm send on phone. Capture off."
-                                            } else {
-                                                "Confirm send on phone."
-                                            }
-                                    }.onFailure {
-                                        diagnosticsExportStatus = buildRetryReadyLabel(exportedDiagnosticsCount)
-                                        exportDialogMode = DiagnosticsExportDialogMode.FAILED
-                                        exportDialogMessage =
-                                            "Export failed.\nTap Resend Diagnostic to try again."
-                                    }
-                            } catch (_: ActivityNotFoundException) {
-                                diagnosticsExportStatus = buildRetryReadyLabel(exportedDiagnosticsCount)
-                                exportDialogMode = DiagnosticsExportDialogMode.FAILED
-                                exportDialogMessage =
-                                    "Export failed.\nTap Resend Diagnostic to try again."
-                            } catch (_: Exception) {
-                                diagnosticsExportStatus = buildRetryReadyLabel(exportedDiagnosticsCount)
-                                exportDialogMode = DiagnosticsExportDialogMode.FAILED
-                                exportDialogMessage =
-                                    "Export failed.\nTap Resend Diagnostic to try again."
-                            } finally {
-                                viewModel.setGpsDebugTelemetry(false)
-                                DebugTelemetry.setEnabled(false)
-                                if (exportDialogMode == DiagnosticsExportDialogMode.GENERATING) {
-                                    exportDialogMode = null
-                                }
-                                exportInProgress = false
+                        } catch (_: ActivityNotFoundException) {
+                            diagnosticsExportStatus = buildRetryReadyLabel(exportedDiagnosticsCount)
+                            exportDialogMode = DiagnosticsExportDialogMode.FAILED
+                            exportDialogMessage =
+                                "Export failed.\nTap Resend Diagnostic to try again."
+                        } catch (_: Exception) {
+                            diagnosticsExportStatus = buildRetryReadyLabel(exportedDiagnosticsCount)
+                            exportDialogMode = DiagnosticsExportDialogMode.FAILED
+                            exportDialogMessage =
+                                "Export failed.\nTap Resend Diagnostic to try again."
+                        } finally {
+                            viewModel.setGpsDebugTelemetry(false)
+                            DebugTelemetry.setEnabled(false)
+                            if (exportDialogMode == DiagnosticsExportDialogMode.GENERATING) {
+                                exportDialogMode = null
                             }
+                            exportInProgress = false
                         }
+                    }
+                },
+            )
+        }
+
+        if (BuildConfig.DEBUG) {
+            item {
+                Chip(
+                    label = "Force close app",
+                    secondaryLabel = "Debug crash test",
+                    onClick = {
+                        DebugTelemetry.log("DiagnosticsFlow", "manual_force_close_requested")
+                        error("Manual force close from debugging settings")
                     },
                 )
-            }
-
-            if (BuildConfig.DEBUG) {
-                item {
-                    Chip(
-                        label = "Force close app",
-                        secondaryLabel = "Debug crash test",
-                        onClick = {
-                            DebugTelemetry.log("DiagnosticsFlow", "manual_force_close_requested")
-                            error("Manual force close from debugging settings")
-                        },
-                    )
-                }
             }
         }
     }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/GpsSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/GpsSettingsScreen.kt
@@ -5,10 +5,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -19,11 +16,9 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.material.ToggleChip
 import com.google.android.horologist.compose.material.ToggleChipToggleControl
 
@@ -75,110 +70,92 @@ fun GpsSettingsScreen(
             },
         )
 
-    val listState = rememberSettingsScalingLazyListState(topPadding = listTokens.topPadding)
+    WearSettingsListScreen(listTokens = listTokens, horizontalAlignment = Alignment.CenterHorizontally) {
+        item {
+            GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
+        }
 
-    ScreenScaffold(scrollState = listState) {
-        ScalingLazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            state = listState,
-            contentPadding =
-                PaddingValues(
-                    start = listTokens.horizontalPadding,
-                    end = listTokens.horizontalPadding,
-                    top = listTokens.topPadding,
-                    bottom = listTokens.bottomPadding,
-                ),
-            verticalArrangement = Arrangement.spacedBy(listTokens.itemSpacing),
-            anchorType = SettingsListAnchorType,
-            autoCentering = SettingsListAutoCentering,
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            item {
-                GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
-            }
-
-            item {
-                ToggleChip(
-                    checked = isWatchGpsOnly,
-                    onCheckedChanged = { viewModel.setWatchGpsOnly(it) },
-                    label = "GPS Source",
-                    secondaryLabel =
-                        when {
-                            isWatchGpsOnly && !hasFineLocationPermission ->
-                                "Watch Only (enable Precise)"
-                            isWatchGpsOnly -> "Watch Only (more ⚡)"
-                            else -> "Auto (Watch + Phone)"
-                        },
-                    toggleControl = ToggleChipToggleControl.Switch,
-                )
-            }
-
-            item {
-                GpsIntervalSummary(
-                    primaryText = "GPS interval is fixed to 3s while the screen is on.",
-                    secondaryText = "This keeps walking motion smooth without pushing battery too hard.",
-                )
-            }
-
-            if (gpsDebugTelemetry) {
-                item {
-                    ToggleChip(
-                        checked = gpsPassiveLocationExperiment,
-                        onCheckedChanged = { viewModel.setGpsPassiveLocationExperiment(it) },
-                        label = "Use GPS from other apps",
-                        secondaryLabel =
-                            if (gpsPassiveLocationExperiment) {
-                                "On during capture"
-                            } else {
-                                "Off during capture"
-                            },
-                        toggleControl = ToggleChipToggleControl.Switch,
-                    )
-                }
-            }
-
-            item {
-                ToggleChip(
-                    checked = gpsInAmbientMode,
-                    onCheckedChanged = { enable ->
-                        if (enable) {
-                            // No background permission. Just ensure foreground location permission exists.
-                            if (hasLocationPermission) {
-                                viewModel.setGpsInAmbientMode(true)
-                            } else {
-                                locationPermissionLauncher.launch(
-                                    arrayOf(
-                                        Manifest.permission.ACCESS_FINE_LOCATION,
-                                        Manifest.permission.ACCESS_COARSE_LOCATION,
-                                    ),
-                                )
-                            }
-                        } else {
-                            viewModel.setGpsInAmbientMode(false)
-                        }
+        item {
+            ToggleChip(
+                checked = isWatchGpsOnly,
+                onCheckedChanged = { viewModel.setWatchGpsOnly(it) },
+                label = "GPS Source",
+                secondaryLabel =
+                    when {
+                        isWatchGpsOnly && !hasFineLocationPermission ->
+                            "Watch Only (enable Precise)"
+                        isWatchGpsOnly -> "Watch Only (more ⚡)"
+                        else -> "Auto (Watch + Phone)"
                     },
-                    label = "GPS AOD/Screen Off",
+                toggleControl = ToggleChipToggleControl.Switch,
+            )
+        }
+
+        item {
+            GpsIntervalSummary(
+                primaryText = "GPS interval is fixed to 3s while the screen is on.",
+                secondaryText = "This keeps walking motion smooth without pushing battery too hard.",
+            )
+        }
+
+        if (gpsDebugTelemetry) {
+            item {
+                ToggleChip(
+                    checked = gpsPassiveLocationExperiment,
+                    onCheckedChanged = { viewModel.setGpsPassiveLocationExperiment(it) },
+                    label = "Use GPS from other apps",
                     secondaryLabel =
-                        when {
-                            gpsInAmbientMode && hasLocationPermission -> "On (more ⚡)"
-                            gpsInAmbientMode && !hasLocationPermission -> "Needs location permission"
-                            else -> "Off (saves battery)"
+                        if (gpsPassiveLocationExperiment) {
+                            "On during capture"
+                        } else {
+                            "Off during capture"
                         },
                     toggleControl = ToggleChipToggleControl.Switch,
                 )
             }
+        }
 
-            item {
-                GpsIntervalSummary(
-                    primaryText = "AOD/Screen Off uses a fixed 60s interval when enabled.",
-                    secondaryText =
-                        if (gpsInAmbientMode) {
-                            "Ambient updates stay available, but at a battery-friendly pace."
+        item {
+            ToggleChip(
+                checked = gpsInAmbientMode,
+                onCheckedChanged = { enable ->
+                    if (enable) {
+                        // No background permission. Just ensure foreground location permission exists.
+                        if (hasLocationPermission) {
+                            viewModel.setGpsInAmbientMode(true)
                         } else {
-                            "Turn on AOD/Screen Off above if you want background location updates."
-                        },
-                )
-            }
+                            locationPermissionLauncher.launch(
+                                arrayOf(
+                                    Manifest.permission.ACCESS_FINE_LOCATION,
+                                    Manifest.permission.ACCESS_COARSE_LOCATION,
+                                ),
+                            )
+                        }
+                    } else {
+                        viewModel.setGpsInAmbientMode(false)
+                    }
+                },
+                label = "GPS AOD/Screen Off",
+                secondaryLabel =
+                    when {
+                        gpsInAmbientMode && hasLocationPermission -> "On (more ⚡)"
+                        gpsInAmbientMode && !hasLocationPermission -> "Needs location permission"
+                        else -> "Off (saves battery)"
+                    },
+                toggleControl = ToggleChipToggleControl.Switch,
+            )
+        }
+
+        item {
+            GpsIntervalSummary(
+                primaryText = "AOD/Screen Off uses a fixed 60s interval when enabled.",
+                secondaryText =
+                    if (gpsInAmbientMode) {
+                        "Ambient updates stay available, but at a battery-friendly pace."
+                    } else {
+                        "Turn on AOD/Screen Off above if you want background location updates."
+                    },
+            )
         }
     }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/GpxSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/GpxSettingsScreen.kt
@@ -6,9 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -32,7 +30,6 @@ import androidx.compose.ui.platform.LocalLocale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.IconButton
 import androidx.wear.compose.material3.IconButtonDefaults
@@ -44,7 +41,6 @@ import com.glancemap.glancemapwearos.data.repository.SettingsRepository
 import com.glancemap.glancemapwearos.presentation.ui.WearScreenSize
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearScreenSize
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.compose.layout.ScreenScaffold
 import kotlin.math.roundToInt
 
 private const val KMPH_TO_MPS = 1f / 3.6f
@@ -90,7 +86,6 @@ fun GpxSettingsScreen(
             Color.Red,
         )
 
-    val listState = rememberSettingsScalingLazyListState(topPadding = listTokens.topPadding)
     val groupSpacing =
         when (screenSize) {
             WearScreenSize.LARGE -> 8.dp
@@ -121,339 +116,323 @@ fun GpxSettingsScreen(
             WearScreenSize.MEDIUM -> 3.dp
             WearScreenSize.SMALL -> 2.dp
         }
-    ScreenScaffold(scrollState = listState) {
-        ScalingLazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            state = listState,
-            contentPadding =
-                PaddingValues(
-                    start = listTokens.horizontalPadding,
-                    end = listTokens.horizontalPadding,
-                    top = listTokens.topPadding,
-                    bottom = listTokens.bottomPadding,
-                ),
-            verticalArrangement = Arrangement.spacedBy(listTokens.itemSpacing),
-            anchorType = SettingsListAnchorType,
-            autoCentering = SettingsListAutoCentering,
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            item {
-                GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
-            }
+    WearSettingsListScreen(listTokens = listTokens, horizontalAlignment = Alignment.CenterHorizontally) {
+        item {
+            GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
+        }
 
-            item {
-                SettingsToggleChip(
-                    checked = isGpxInspectionEnabled,
-                    onCheckedChanged = { viewModel.setGpxInspectionEnabled(it) },
-                    label = "Route Analyzer",
-                    secondaryLabel = "Long press on track",
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-            item {
-                FlatSpeedSetting(
-                    speedMps = gpxFlatSpeedMps,
-                    isMetric = isMetric,
-                    onSpeedChange = viewModel::setGpxFlatSpeedMps,
-                )
-            }
-            item {
-                SettingsToggleChip(
-                    checked = gpxAdvancedEtaEnabled,
-                    onCheckedChanged = viewModel::setGpxAdvancedEtaEnabled,
-                    label = "Advanced ETA",
-                    secondaryLabel =
-                        if (gpxAdvancedEtaEnabled) {
-                            "Use uphill/downhill rates"
-                        } else {
-                            "Flat speed only"
-                        },
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-            if (gpxAdvancedEtaEnabled) {
-                item {
-                    AdjustableElevationFilterSetting(
-                        label = "Uphill Rate",
-                        valueText =
-                            formatVerticalRate(
-                                metersPerHour = gpxUphillVerticalMetersPerHour,
-                                isMetric = isMetric,
-                            ),
-                        canDecrease =
-                            gpxUphillVerticalMetersPerHour >
-                                SettingsRepository.MIN_GPX_VERTICAL_METERS_PER_HOUR,
-                        canIncrease =
-                            gpxUphillVerticalMetersPerHour <
-                                SettingsRepository.MAX_GPX_UPHILL_VERTICAL_METERS_PER_HOUR,
-                        onDecrease = {
-                            viewModel.setGpxUphillVerticalMetersPerHour(
-                                stepVerticalRateMetersPerHour(
-                                    currentMetersPerHour = gpxUphillVerticalMetersPerHour,
-                                    isMetric = isMetric,
-                                    increase = false,
-                                    minMetersPerHour = SettingsRepository.MIN_GPX_VERTICAL_METERS_PER_HOUR,
-                                    maxMetersPerHour = SettingsRepository.MAX_GPX_UPHILL_VERTICAL_METERS_PER_HOUR,
-                                ),
-                            )
-                        },
-                        onIncrease = {
-                            viewModel.setGpxUphillVerticalMetersPerHour(
-                                stepVerticalRateMetersPerHour(
-                                    currentMetersPerHour = gpxUphillVerticalMetersPerHour,
-                                    isMetric = isMetric,
-                                    increase = true,
-                                    minMetersPerHour = SettingsRepository.MIN_GPX_VERTICAL_METERS_PER_HOUR,
-                                    maxMetersPerHour = SettingsRepository.MAX_GPX_UPHILL_VERTICAL_METERS_PER_HOUR,
-                                ),
-                            )
-                        },
-                    )
-                }
-                item {
-                    AdjustableElevationFilterSetting(
-                        label = "Downhill Rate",
-                        valueText =
-                            formatVerticalRate(
-                                metersPerHour = gpxDownhillVerticalMetersPerHour,
-                                isMetric = isMetric,
-                            ),
-                        canDecrease =
-                            gpxDownhillVerticalMetersPerHour >
-                                SettingsRepository.MIN_GPX_VERTICAL_METERS_PER_HOUR,
-                        canIncrease =
-                            gpxDownhillVerticalMetersPerHour <
-                                SettingsRepository.MAX_GPX_DOWNHILL_VERTICAL_METERS_PER_HOUR,
-                        onDecrease = {
-                            viewModel.setGpxDownhillVerticalMetersPerHour(
-                                stepVerticalRateMetersPerHour(
-                                    currentMetersPerHour = gpxDownhillVerticalMetersPerHour,
-                                    isMetric = isMetric,
-                                    increase = false,
-                                    minMetersPerHour = SettingsRepository.MIN_GPX_VERTICAL_METERS_PER_HOUR,
-                                    maxMetersPerHour = SettingsRepository.MAX_GPX_DOWNHILL_VERTICAL_METERS_PER_HOUR,
-                                ),
-                            )
-                        },
-                        onIncrease = {
-                            viewModel.setGpxDownhillVerticalMetersPerHour(
-                                stepVerticalRateMetersPerHour(
-                                    currentMetersPerHour = gpxDownhillVerticalMetersPerHour,
-                                    isMetric = isMetric,
-                                    increase = true,
-                                    minMetersPerHour = SettingsRepository.MIN_GPX_VERTICAL_METERS_PER_HOUR,
-                                    maxMetersPerHour = SettingsRepository.MAX_GPX_DOWNHILL_VERTICAL_METERS_PER_HOUR,
-                                ),
-                            )
-                        },
-                    )
-                }
-                item {
-                    Text(
-                        text = "Flat speed still drives easy terrain. Uphill and downhill rates only limit steeper climbs and descents.",
-                        style = MaterialTheme.typography.bodySmall,
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 12.dp),
-                    )
-                }
-            }
-            item {
-                SettingsPickerChip(
-                    label = "Color Mode",
-                    secondaryLabel =
-                        when (trackColorMode) {
-                            SettingsRepository.GPX_TRACK_COLOR_MODE_ELEVATION -> "Elevation"
-                            else -> "Solid color"
-                        },
-                    onClick = { showTrackColorModeDialog = true },
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-            if (trackColorMode == SettingsRepository.GPX_TRACK_COLOR_MODE_SOLID) {
-                item {
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(groupSpacing),
-                    ) {
-                        Text(
-                            text = "Track Color",
-                            style = MaterialTheme.typography.titleMedium,
-                        )
-
-                        SimpleColorPicker(
-                            colors = colorPalette,
-                            selectedColor = Color(trackColor),
-                            itemSpacing = colorPickerSpacing,
-                            buttonSize = colorButtonSize,
-                            selectedIconSize = selectedIconSize,
-                            onColorSelected = { color ->
-                                viewModel.setGpxTrackColor(color.toArgb())
-                            },
-                        )
-                    }
-                }
-            }
-            item {
-                SettingsToggleChip(
-                    checked = trackDirectionArrowsEnabled,
-                    onCheckedChanged = viewModel::setGpxTrackDirectionArrowsEnabled,
-                    label = "Track direction",
-                    secondaryLabel = if (trackDirectionArrowsEnabled) "Hide arrows" else "Show arrows",
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-            item {
-                TrackWidthSetting(
-                    label = "Track Width",
-                    value = trackWidth,
-                    onValueChange = { newWidth ->
-                        viewModel.setGpxTrackWidth(newWidth)
+        item {
+            SettingsToggleChip(
+                checked = isGpxInspectionEnabled,
+                onCheckedChanged = { viewModel.setGpxInspectionEnabled(it) },
+                label = "Route Analyzer",
+                secondaryLabel = "Long press on track",
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        item {
+            FlatSpeedSetting(
+                speedMps = gpxFlatSpeedMps,
+                isMetric = isMetric,
+                onSpeedChange = viewModel::setGpxFlatSpeedMps,
+            )
+        }
+        item {
+            SettingsToggleChip(
+                checked = gpxAdvancedEtaEnabled,
+                onCheckedChanged = viewModel::setGpxAdvancedEtaEnabled,
+                label = "Advanced ETA",
+                secondaryLabel =
+                    if (gpxAdvancedEtaEnabled) {
+                        "Use uphill/downhill rates"
+                    } else {
+                        "Flat speed only"
                     },
-                    spacing = trackWidthSpacing,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        if (gpxAdvancedEtaEnabled) {
+            item {
+                AdjustableElevationFilterSetting(
+                    label = "Uphill Rate",
+                    valueText =
+                        formatVerticalRate(
+                            metersPerHour = gpxUphillVerticalMetersPerHour,
+                            isMetric = isMetric,
+                        ),
+                    canDecrease =
+                        gpxUphillVerticalMetersPerHour >
+                            SettingsRepository.MIN_GPX_VERTICAL_METERS_PER_HOUR,
+                    canIncrease =
+                        gpxUphillVerticalMetersPerHour <
+                            SettingsRepository.MAX_GPX_UPHILL_VERTICAL_METERS_PER_HOUR,
+                    onDecrease = {
+                        viewModel.setGpxUphillVerticalMetersPerHour(
+                            stepVerticalRateMetersPerHour(
+                                currentMetersPerHour = gpxUphillVerticalMetersPerHour,
+                                isMetric = isMetric,
+                                increase = false,
+                                minMetersPerHour = SettingsRepository.MIN_GPX_VERTICAL_METERS_PER_HOUR,
+                                maxMetersPerHour = SettingsRepository.MAX_GPX_UPHILL_VERTICAL_METERS_PER_HOUR,
+                            ),
+                        )
+                    },
+                    onIncrease = {
+                        viewModel.setGpxUphillVerticalMetersPerHour(
+                            stepVerticalRateMetersPerHour(
+                                currentMetersPerHour = gpxUphillVerticalMetersPerHour,
+                                isMetric = isMetric,
+                                increase = true,
+                                minMetersPerHour = SettingsRepository.MIN_GPX_VERTICAL_METERS_PER_HOUR,
+                                maxMetersPerHour = SettingsRepository.MAX_GPX_UPHILL_VERTICAL_METERS_PER_HOUR,
+                            ),
+                        )
+                    },
                 )
             }
             item {
-                TrackOpacitySetting(
-                    label = "Track Opacity",
-                    valuePercent = trackOpacityPercent,
-                    onValueChange = viewModel::setGpxTrackOpacityPercent,
-                    spacing = trackWidthSpacing,
+                AdjustableElevationFilterSetting(
+                    label = "Downhill Rate",
+                    valueText =
+                        formatVerticalRate(
+                            metersPerHour = gpxDownhillVerticalMetersPerHour,
+                            isMetric = isMetric,
+                        ),
+                    canDecrease =
+                        gpxDownhillVerticalMetersPerHour >
+                            SettingsRepository.MIN_GPX_VERTICAL_METERS_PER_HOUR,
+                    canIncrease =
+                        gpxDownhillVerticalMetersPerHour <
+                            SettingsRepository.MAX_GPX_DOWNHILL_VERTICAL_METERS_PER_HOUR,
+                    onDecrease = {
+                        viewModel.setGpxDownhillVerticalMetersPerHour(
+                            stepVerticalRateMetersPerHour(
+                                currentMetersPerHour = gpxDownhillVerticalMetersPerHour,
+                                isMetric = isMetric,
+                                increase = false,
+                                minMetersPerHour = SettingsRepository.MIN_GPX_VERTICAL_METERS_PER_HOUR,
+                                maxMetersPerHour = SettingsRepository.MAX_GPX_DOWNHILL_VERTICAL_METERS_PER_HOUR,
+                            ),
+                        )
+                    },
+                    onIncrease = {
+                        viewModel.setGpxDownhillVerticalMetersPerHour(
+                            stepVerticalRateMetersPerHour(
+                                currentMetersPerHour = gpxDownhillVerticalMetersPerHour,
+                                isMetric = isMetric,
+                                increase = true,
+                                minMetersPerHour = SettingsRepository.MIN_GPX_VERTICAL_METERS_PER_HOUR,
+                                maxMetersPerHour = SettingsRepository.MAX_GPX_DOWNHILL_VERTICAL_METERS_PER_HOUR,
+                            ),
+                        )
+                    },
                 )
             }
             item {
                 Text(
-                    text = "Fine-tune how GPX ascent and descent are calculated. Most tracks can stay on the defaults.",
+                    text = "Flat speed still drives easy terrain. Uphill and downhill rates only limit steeper climbs and descents.",
                     style = MaterialTheme.typography.bodySmall,
-                    textAlign = TextAlign.Center,
                     modifier =
                         Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 12.dp),
                 )
             }
+        }
+        item {
+            SettingsPickerChip(
+                label = "Color Mode",
+                secondaryLabel =
+                    when (trackColorMode) {
+                        SettingsRepository.GPX_TRACK_COLOR_MODE_ELEVATION -> "Elevation"
+                        else -> "Solid color"
+                    },
+                onClick = { showTrackColorModeDialog = true },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        if (trackColorMode == SettingsRepository.GPX_TRACK_COLOR_MODE_SOLID) {
+            item {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(groupSpacing),
+                ) {
+                    Text(
+                        text = "Track Color",
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+
+                    SimpleColorPicker(
+                        colors = colorPalette,
+                        selectedColor = Color(trackColor),
+                        itemSpacing = colorPickerSpacing,
+                        buttonSize = colorButtonSize,
+                        selectedIconSize = selectedIconSize,
+                        onColorSelected = { color ->
+                            viewModel.setGpxTrackColor(color.toArgb())
+                        },
+                    )
+                }
+            }
+        }
+        item {
+            SettingsToggleChip(
+                checked = trackDirectionArrowsEnabled,
+                onCheckedChanged = viewModel::setGpxTrackDirectionArrowsEnabled,
+                label = "Track direction",
+                secondaryLabel = if (trackDirectionArrowsEnabled) "Hide arrows" else "Show arrows",
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        item {
+            TrackWidthSetting(
+                label = "Track Width",
+                value = trackWidth,
+                onValueChange = { newWidth ->
+                    viewModel.setGpxTrackWidth(newWidth)
+                },
+                spacing = trackWidthSpacing,
+            )
+        }
+        item {
+            TrackOpacitySetting(
+                label = "Track Opacity",
+                valuePercent = trackOpacityPercent,
+                onValueChange = viewModel::setGpxTrackOpacityPercent,
+                spacing = trackWidthSpacing,
+            )
+        }
+        item {
+            Text(
+                text = "Fine-tune how GPX ascent and descent are calculated. Most tracks can stay on the defaults.",
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = TextAlign.Center,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp),
+            )
+        }
+        item {
+            SettingsToggleChip(
+                checked = showAdvancedElevationFilter,
+                onCheckedChanged = { showAdvancedElevationFilter = it },
+                label = "Advanced Filter",
+                secondaryLabel = "Tune GPX elevation totals",
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        if (showAdvancedElevationFilter) {
             item {
                 SettingsToggleChip(
-                    checked = showAdvancedElevationFilter,
-                    onCheckedChanged = { showAdvancedElevationFilter = it },
-                    label = "Advanced Filter",
-                    secondaryLabel = "Tune GPX elevation totals",
+                    checked = gpxElevationAutoAdjustPerGpx,
+                    onCheckedChanged = viewModel::setGpxElevationAutoAdjustPerGpx,
+                    label = "Auto-adjust per GPX",
+                    secondaryLabel =
+                        if (gpxElevationAutoAdjustPerGpx) {
+                            "Use sliders as baseline"
+                        } else {
+                            "Apply sliders exactly"
+                        },
                     modifier = Modifier.fillMaxWidth(),
                 )
             }
-            if (showAdvancedElevationFilter) {
-                item {
-                    SettingsToggleChip(
-                        checked = gpxElevationAutoAdjustPerGpx,
-                        onCheckedChanged = viewModel::setGpxElevationAutoAdjustPerGpx,
-                        label = "Auto-adjust per GPX",
-                        secondaryLabel =
-                            if (gpxElevationAutoAdjustPerGpx) {
-                                "Use sliders as baseline"
-                            } else {
-                                "Apply sliders exactly"
-                            },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                }
-                item {
-                    AdjustableElevationFilterSetting(
-                        label = GpxElevationFilterUi.SMOOTHING_LABEL,
-                        valueText =
-                            GpxElevationFilterUi.formatSmoothingDistance(
-                                gpxElevationSmoothingDistanceMeters,
-                            ),
-                        canDecrease =
-                            gpxElevationSmoothingDistanceMeters >
-                                GpxElevationFilterDefaults.MIN_SMOOTHING_DISTANCE_METERS,
-                        canIncrease =
-                            gpxElevationSmoothingDistanceMeters <
-                                GpxElevationFilterDefaults.MAX_SMOOTHING_DISTANCE_METERS,
-                        onDecrease = {
-                            viewModel.setGpxElevationSmoothingDistanceMeters(
-                                gpxElevationSmoothingDistanceMeters -
-                                    GpxElevationFilterDefaults.STEP_SMOOTHING_DISTANCE_METERS,
-                            )
+            item {
+                AdjustableElevationFilterSetting(
+                    label = GpxElevationFilterUi.SMOOTHING_LABEL,
+                    valueText =
+                        GpxElevationFilterUi.formatSmoothingDistance(
+                            gpxElevationSmoothingDistanceMeters,
+                        ),
+                    canDecrease =
+                        gpxElevationSmoothingDistanceMeters >
+                            GpxElevationFilterDefaults.MIN_SMOOTHING_DISTANCE_METERS,
+                    canIncrease =
+                        gpxElevationSmoothingDistanceMeters <
+                            GpxElevationFilterDefaults.MAX_SMOOTHING_DISTANCE_METERS,
+                    onDecrease = {
+                        viewModel.setGpxElevationSmoothingDistanceMeters(
+                            gpxElevationSmoothingDistanceMeters -
+                                GpxElevationFilterDefaults.STEP_SMOOTHING_DISTANCE_METERS,
+                        )
+                    },
+                    onIncrease = {
+                        viewModel.setGpxElevationSmoothingDistanceMeters(
+                            gpxElevationSmoothingDistanceMeters +
+                                GpxElevationFilterDefaults.STEP_SMOOTHING_DISTANCE_METERS,
+                        )
+                    },
+                )
+            }
+            item {
+                AdjustableElevationFilterSetting(
+                    label = GpxElevationFilterUi.NOISE_THRESHOLD_LABEL,
+                    valueText =
+                        GpxElevationFilterUi.formatThreshold(
+                            gpxElevationNeutralDiffThresholdMeters,
+                        ),
+                    canDecrease =
+                        gpxElevationNeutralDiffThresholdMeters >
+                            GpxElevationFilterDefaults.MIN_NEUTRAL_DIFF_THRESHOLD_METERS,
+                    canIncrease =
+                        gpxElevationNeutralDiffThresholdMeters <
+                            GpxElevationFilterDefaults.MAX_NEUTRAL_DIFF_THRESHOLD_METERS,
+                    onDecrease = {
+                        viewModel.setGpxElevationNeutralDiffThresholdMeters(
+                            gpxElevationNeutralDiffThresholdMeters -
+                                GpxElevationFilterDefaults.STEP_NEUTRAL_DIFF_THRESHOLD_METERS,
+                        )
+                    },
+                    onIncrease = {
+                        viewModel.setGpxElevationNeutralDiffThresholdMeters(
+                            gpxElevationNeutralDiffThresholdMeters +
+                                GpxElevationFilterDefaults.STEP_NEUTRAL_DIFF_THRESHOLD_METERS,
+                        )
+                    },
+                )
+            }
+            item {
+                AdjustableElevationFilterSetting(
+                    label = GpxElevationFilterUi.TREND_THRESHOLD_LABEL,
+                    valueText =
+                        GpxElevationFilterUi.formatThreshold(
+                            gpxElevationTrendActivationThresholdMeters,
+                        ),
+                    canDecrease =
+                        gpxElevationTrendActivationThresholdMeters >
+                            GpxElevationFilterDefaults.MIN_TREND_ACTIVATION_THRESHOLD_METERS,
+                    canIncrease =
+                        gpxElevationTrendActivationThresholdMeters <
+                            GpxElevationFilterDefaults.MAX_TREND_ACTIVATION_THRESHOLD_METERS,
+                    onDecrease = {
+                        viewModel.setGpxElevationTrendActivationThresholdMeters(
+                            gpxElevationTrendActivationThresholdMeters -
+                                GpxElevationFilterDefaults.STEP_TREND_ACTIVATION_THRESHOLD_METERS,
+                        )
+                    },
+                    onIncrease = {
+                        viewModel.setGpxElevationTrendActivationThresholdMeters(
+                            gpxElevationTrendActivationThresholdMeters +
+                                GpxElevationFilterDefaults.STEP_TREND_ACTIVATION_THRESHOLD_METERS,
+                        )
+                    },
+                )
+            }
+            item {
+                Text(
+                    text =
+                        if (gpxElevationAutoAdjustPerGpx) {
+                            "Auto-adjust can nudge these values depending on the GPX."
+                        } else {
+                            "These values are applied exactly to every GPX."
                         },
-                        onIncrease = {
-                            viewModel.setGpxElevationSmoothingDistanceMeters(
-                                gpxElevationSmoothingDistanceMeters +
-                                    GpxElevationFilterDefaults.STEP_SMOOTHING_DISTANCE_METERS,
-                            )
-                        },
-                    )
-                }
-                item {
-                    AdjustableElevationFilterSetting(
-                        label = GpxElevationFilterUi.NOISE_THRESHOLD_LABEL,
-                        valueText =
-                            GpxElevationFilterUi.formatThreshold(
-                                gpxElevationNeutralDiffThresholdMeters,
-                            ),
-                        canDecrease =
-                            gpxElevationNeutralDiffThresholdMeters >
-                                GpxElevationFilterDefaults.MIN_NEUTRAL_DIFF_THRESHOLD_METERS,
-                        canIncrease =
-                            gpxElevationNeutralDiffThresholdMeters <
-                                GpxElevationFilterDefaults.MAX_NEUTRAL_DIFF_THRESHOLD_METERS,
-                        onDecrease = {
-                            viewModel.setGpxElevationNeutralDiffThresholdMeters(
-                                gpxElevationNeutralDiffThresholdMeters -
-                                    GpxElevationFilterDefaults.STEP_NEUTRAL_DIFF_THRESHOLD_METERS,
-                            )
-                        },
-                        onIncrease = {
-                            viewModel.setGpxElevationNeutralDiffThresholdMeters(
-                                gpxElevationNeutralDiffThresholdMeters +
-                                    GpxElevationFilterDefaults.STEP_NEUTRAL_DIFF_THRESHOLD_METERS,
-                            )
-                        },
-                    )
-                }
-                item {
-                    AdjustableElevationFilterSetting(
-                        label = GpxElevationFilterUi.TREND_THRESHOLD_LABEL,
-                        valueText =
-                            GpxElevationFilterUi.formatThreshold(
-                                gpxElevationTrendActivationThresholdMeters,
-                            ),
-                        canDecrease =
-                            gpxElevationTrendActivationThresholdMeters >
-                                GpxElevationFilterDefaults.MIN_TREND_ACTIVATION_THRESHOLD_METERS,
-                        canIncrease =
-                            gpxElevationTrendActivationThresholdMeters <
-                                GpxElevationFilterDefaults.MAX_TREND_ACTIVATION_THRESHOLD_METERS,
-                        onDecrease = {
-                            viewModel.setGpxElevationTrendActivationThresholdMeters(
-                                gpxElevationTrendActivationThresholdMeters -
-                                    GpxElevationFilterDefaults.STEP_TREND_ACTIVATION_THRESHOLD_METERS,
-                            )
-                        },
-                        onIncrease = {
-                            viewModel.setGpxElevationTrendActivationThresholdMeters(
-                                gpxElevationTrendActivationThresholdMeters +
-                                    GpxElevationFilterDefaults.STEP_TREND_ACTIVATION_THRESHOLD_METERS,
-                            )
-                        },
-                    )
-                }
-                item {
-                    Text(
-                        text =
-                            if (gpxElevationAutoAdjustPerGpx) {
-                                "Auto-adjust can nudge these values depending on the GPX."
-                            } else {
-                                "These values are applied exactly to every GPX."
-                            },
-                        style = MaterialTheme.typography.bodySmall,
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 12.dp),
-                    )
-                }
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 12.dp),
+                )
             }
         }
     }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/LicensesScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/LicensesScreen.kt
@@ -1,46 +1,25 @@
 package com.glancemap.glancemapwearos.presentation.features.settings
 
 import android.content.Context
-import androidx.compose.foundation.background
-import androidx.compose.foundation.focusable
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.input.rotary.onPreRotaryScrollEvent
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
 import androidx.core.content.pm.PackageInfoCompat
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
-import com.glancemap.glancemapwearos.presentation.ui.WearCustomDialogScrollableColumn
-import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpacer
-import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
-import com.glancemap.glancemapwearos.presentation.ui.wearDialogWidth
+import com.glancemap.glancemapwearos.presentation.ui.WearInfoDialog
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.material.Chip
-import kotlin.math.abs
 
 @OptIn(ExperimentalHorologistApi::class)
 @Composable
@@ -296,8 +275,6 @@ private data class LicenseDocument(
     val assetPath: String,
 )
 
-private const val LICENSE_DIALOG_DRAG_DISMISS_PX = 55f
-
 @OptIn(ExperimentalHorologistApi::class)
 @Composable
 private fun LicenseDocumentDialog(
@@ -305,85 +282,22 @@ private fun LicenseDocumentDialog(
     onDismiss: () -> Unit,
 ) {
     val context = LocalContext.current
-    val adaptive = rememberWearAdaptiveSpec()
-    val scrollState = rememberScrollState()
-    val focusRequester = remember { FocusRequester() }
     val documentText =
         remember(document.assetPath) {
             loadTextAsset(context, document.assetPath)
         }
-    LaunchedEffect(document.assetPath) {
-        focusRequester.requestFocus()
-    }
 
-    Dialog(onDismissRequest = onDismiss) {
-        Column(
-            modifier =
-                Modifier
-                    .wearDialogWidth()
-                    .background(
-                        Color.Black.copy(alpha = 0.82f),
-                        RoundedCornerShape(adaptive.dialogCornerRadius),
-                    ).padding(
-                        horizontal = adaptive.dialogHorizontalPadding,
-                        vertical = adaptive.dialogVerticalPadding,
-                    ),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .pointerInput(Unit) {
-                            var totalDrag = 0f
-                            detectVerticalDragGestures(
-                                onDragEnd = { totalDrag = 0f },
-                                onDragCancel = { totalDrag = 0f },
-                            ) { _, dragAmount ->
-                                totalDrag += dragAmount
-                                if (totalDrag > LICENSE_DIALOG_DRAG_DISMISS_PX) {
-                                    onDismiss()
-                                    totalDrag = 0f
-                                }
-                            }
-                        },
-            ) {
-                Box(
-                    modifier =
-                        Modifier
-                            .width(26.dp)
-                            .height(3.dp)
-                            .background(Color.White.copy(alpha = 0.42f), RoundedCornerShape(50))
-                            .align(Alignment.Center),
-                )
-            }
-            WearCustomDialogScrollableColumn(
-                maxHeight = adaptive.helpDialogMaxHeight,
-                modifier =
-                    Modifier
-                        .fillMaxWidth(),
-                contentModifier =
-                    Modifier
-                        .onPreRotaryScrollEvent { event ->
-                            val consumed = scrollState.dispatchRawDelta(event.verticalScrollPixels)
-                            abs(consumed) > 0.5f
-                        }.focusRequester(focusRequester)
-                        .focusable(),
-                scrollState = scrollState,
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Text(
-                    text = document.title,
-                    style = MaterialTheme.typography.titleMedium,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                Text(
-                    text = documentText,
-                    style = MaterialTheme.typography.bodySmall,
-                )
-                WearDialogScrollBottomSpacer()
-            }
+    WearInfoDialog(
+        visible = true,
+        title = document.title,
+        onDismiss = onDismiss,
+    ) {
+        item {
+            Text(
+                text = documentText,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
     }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/LicensesScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/LicensesScreen.kt
@@ -7,9 +7,7 @@ import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -34,7 +32,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.core.content.pm.PackageInfoCompat
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.presentation.ui.WearCustomDialogScrollableColumn
@@ -42,7 +39,6 @@ import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpace
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 import com.glancemap.glancemapwearos.presentation.ui.wearDialogWidth
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.material.Chip
 import kotlin.math.abs
 
@@ -60,247 +56,230 @@ fun LicensesScreen(onOpenGeneralSettings: () -> Unit) {
             expandedBottom = 68.dp,
         )
     var selectedDocument by remember { mutableStateOf<LicenseDocument?>(null) }
-    val listState = rememberSettingsScalingLazyListState(topPadding = listTokens.topPadding)
 
-    ScreenScaffold(scrollState = listState) {
-        ScalingLazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            state = listState,
-            contentPadding =
-                PaddingValues(
-                    start = listTokens.horizontalPadding,
-                    end = listTokens.horizontalPadding,
-                    top = listTokens.topPadding,
-                    bottom = listTokens.bottomPadding,
-                ),
-            verticalArrangement = Arrangement.spacedBy(listTokens.itemSpacing),
-            anchorType = SettingsListAnchorType,
-            autoCentering = SettingsListAutoCentering,
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            item {
-                GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
-            }
-            item {
-                Text(
-                    text = "Credits & Legal",
-                    style = MaterialTheme.typography.titleMedium,
-                    textAlign = TextAlign.Center,
-                )
-            }
-            item {
-                Text(
-                    text = "Thanks to OpenAndroMaps, Elevate, OpenHiking, Tiramisu, Hike, Ride & Sight, OpenStreetMap, Refuges.info, Overpass, Mapsforge and BRouter.",
-                    style = MaterialTheme.typography.bodySmall,
-                    textAlign = TextAlign.Center,
-                )
-            }
-            item {
-                Text(
-                    text = appVersionLabel,
-                    style = MaterialTheme.typography.bodySmall,
-                    textAlign = TextAlign.Center,
-                )
-            }
-            item {
-                Chip(
-                    modifier = Modifier.fillMaxWidth(),
-                    label = "Privacy Policy",
-                    secondaryLabel = "Data access, sharing and retention",
-                    onClick = {
-                        selectedDocument =
-                            LicenseDocument(
-                                title = "Privacy Policy",
-                                assetPath = "licenses/PRIVACY_POLICY.md",
-                            )
-                    },
-                )
-            }
-            item {
-                Chip(
-                    modifier = Modifier.fillMaxWidth(),
-                    label = "Safety & Limits",
-                    secondaryLabel = "Map/theme errors and personal responsibility",
-                    onClick = {
-                        selectedDocument =
-                            LicenseDocument(
-                                title = "Safety & Limitations",
-                                assetPath = "licenses/SAFETY_AND_LIMITATIONS.md",
-                            )
-                    },
-                )
-            }
-            item {
-                Chip(
-                    modifier = Modifier.fillMaxWidth(),
-                    label = "Credits & Thanks",
-                    secondaryLabel = "Main contributors and projects",
-                    onClick = {
-                        selectedDocument =
-                            LicenseDocument(
-                                title = "Credits & Thanks",
-                                assetPath = "licenses/CREDITS_AND_THANKS.md",
-                            )
-                    },
-                )
-            }
-            item {
-                Chip(
-                    modifier = Modifier.fillMaxWidth(),
-                    label = "AI Acknowledgment",
-                    secondaryLabel = "Human creators and transparency",
-                    onClick = {
-                        selectedDocument =
-                            LicenseDocument(
-                                title = "AI & Creator Acknowledgment",
-                                assetPath = "licenses/AI_ACKNOWLEDGEMENT.md",
-                            )
-                    },
-                )
-            }
-            item {
-                Chip(
-                    modifier = Modifier.fillMaxWidth(),
-                    label = "Companion Sources",
-                    secondaryLabel = "Map, GPX and refuge websites",
-                    onClick = {
-                        selectedDocument =
-                            LicenseDocument(
-                                title = "Companion External Sources",
-                                assetPath = "licenses/COMPANION_EXTERNAL_SOURCES.md",
-                            )
-                    },
-                )
-            }
-            item {
-                Chip(
-                    modifier = Modifier.fillMaxWidth(),
-                    label = "Compliance Status",
-                    secondaryLabel = "Release checklist and pending items",
-                    onClick = {
-                        selectedDocument =
-                            LicenseDocument(
-                                title = "Compliance Status",
-                                assetPath = "licenses/COMPLIANCE_STATUS.md",
-                            )
-                    },
-                )
-            }
-            item {
-                Chip(
-                    modifier = Modifier.fillMaxWidth(),
-                    label = "Open Source Notices",
-                    secondaryLabel = "Libraries and OSS licenses",
-                    onClick = {
-                        selectedDocument =
-                            LicenseDocument(
-                                title = "Open Source Notices",
-                                assetPath = "licenses/THIRD_PARTY_NOTICES.md",
-                            )
-                    },
-                )
-            }
-            item {
-                Chip(
-                    modifier = Modifier.fillMaxWidth(),
-                    label = "OpenHiking Theme",
-                    secondaryLabel = "Bundled hiking theme details",
-                    onClick = {
-                        selectedDocument =
-                            LicenseDocument(
-                                title = "OpenHiking Theme",
-                                assetPath = "licenses/OPENHIKING_THEME.md",
-                            )
-                    },
-                )
-            }
-            item {
-                Chip(
-                    modifier = Modifier.fillMaxWidth(),
-                    label = "French Kiss Theme",
-                    secondaryLabel = "Bundled IGN-style theme details",
-                    onClick = {
-                        selectedDocument =
-                            LicenseDocument(
-                                title = "French Kiss Theme",
-                                assetPath = "licenses/FRENCH_KISS_THEME.md",
-                            )
-                    },
-                )
-            }
-            item {
-                Chip(
-                    modifier = Modifier.fillMaxWidth(),
-                    label = "Tiramisu Theme",
-                    secondaryLabel = "Bundled cycle/hike theme details",
-                    onClick = {
-                        selectedDocument =
-                            LicenseDocument(
-                                title = "Tiramisu Theme",
-                                assetPath = "licenses/TIRAMISU_THEME.md",
-                            )
-                    },
-                )
-            }
-            item {
-                Chip(
-                    modifier = Modifier.fillMaxWidth(),
-                    label = "Hike, Ride & Sight",
-                    secondaryLabel = "Bundled overlay-rich theme details",
-                    onClick = {
-                        selectedDocument =
-                            LicenseDocument(
-                                title = "Hike, Ride & Sight Theme",
-                                assetPath = "licenses/HIKE_RIDE_SIGHT_THEME.md",
-                            )
-                    },
-                )
-            }
-            item {
-                Chip(
-                    modifier = Modifier.fillMaxWidth(),
-                    label = "Voluntary Theme",
-                    secondaryLabel = "Bundled OS-inspired theme details",
-                    onClick = {
-                        selectedDocument =
-                            LicenseDocument(
-                                title = "Voluntary Theme",
-                                assetPath = "licenses/VOLUNTARY_THEME.md",
-                            )
-                    },
-                )
-            }
-            item {
-                Chip(
-                    modifier = Modifier.fillMaxWidth(),
-                    label = "Data & Asset Attribution",
-                    secondaryLabel = "OSM, Elevate, bundled themes, DEM, icons",
-                    onClick = {
-                        selectedDocument =
-                            LicenseDocument(
-                                title = "Data & Asset Attribution",
-                                assetPath = "licenses/DATA_AND_ASSET_ATTRIBUTION.md",
-                            )
-                    },
-                )
-            }
-            item {
-                Chip(
-                    modifier = Modifier.fillMaxWidth(),
-                    label = "Service Terms & API Usage",
-                    secondaryLabel = "Provider terms and usage limits",
-                    onClick = {
-                        selectedDocument =
-                            LicenseDocument(
-                                title = "Service Terms & API Usage",
-                                assetPath = "licenses/SERVICE_TERMS_AND_API_USAGE.md",
-                            )
-                    },
-                )
-            }
-            item {
-                Spacer(modifier = Modifier.height(72.dp))
-            }
+    WearSettingsListScreen(listTokens = listTokens, horizontalAlignment = Alignment.CenterHorizontally) {
+        item {
+            GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
+        }
+        item {
+            Text(
+                text = "Credits & Legal",
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Center,
+            )
+        }
+        item {
+            Text(
+                text = "Thanks to OpenAndroMaps, Elevate, OpenHiking, Tiramisu, Hike, Ride & Sight, OpenStreetMap, Refuges.info, Overpass, Mapsforge and BRouter.",
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = TextAlign.Center,
+            )
+        }
+        item {
+            Text(
+                text = appVersionLabel,
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = TextAlign.Center,
+            )
+        }
+        item {
+            Chip(
+                modifier = Modifier.fillMaxWidth(),
+                label = "Privacy Policy",
+                secondaryLabel = "Data access, sharing and retention",
+                onClick = {
+                    selectedDocument =
+                        LicenseDocument(
+                            title = "Privacy Policy",
+                            assetPath = "licenses/PRIVACY_POLICY.md",
+                        )
+                },
+            )
+        }
+        item {
+            Chip(
+                modifier = Modifier.fillMaxWidth(),
+                label = "Safety & Limits",
+                secondaryLabel = "Map/theme errors and personal responsibility",
+                onClick = {
+                    selectedDocument =
+                        LicenseDocument(
+                            title = "Safety & Limitations",
+                            assetPath = "licenses/SAFETY_AND_LIMITATIONS.md",
+                        )
+                },
+            )
+        }
+        item {
+            Chip(
+                modifier = Modifier.fillMaxWidth(),
+                label = "Credits & Thanks",
+                secondaryLabel = "Main contributors and projects",
+                onClick = {
+                    selectedDocument =
+                        LicenseDocument(
+                            title = "Credits & Thanks",
+                            assetPath = "licenses/CREDITS_AND_THANKS.md",
+                        )
+                },
+            )
+        }
+        item {
+            Chip(
+                modifier = Modifier.fillMaxWidth(),
+                label = "AI Acknowledgment",
+                secondaryLabel = "Human creators and transparency",
+                onClick = {
+                    selectedDocument =
+                        LicenseDocument(
+                            title = "AI & Creator Acknowledgment",
+                            assetPath = "licenses/AI_ACKNOWLEDGEMENT.md",
+                        )
+                },
+            )
+        }
+        item {
+            Chip(
+                modifier = Modifier.fillMaxWidth(),
+                label = "Companion Sources",
+                secondaryLabel = "Map, GPX and refuge websites",
+                onClick = {
+                    selectedDocument =
+                        LicenseDocument(
+                            title = "Companion External Sources",
+                            assetPath = "licenses/COMPANION_EXTERNAL_SOURCES.md",
+                        )
+                },
+            )
+        }
+        item {
+            Chip(
+                modifier = Modifier.fillMaxWidth(),
+                label = "Compliance Status",
+                secondaryLabel = "Release checklist and pending items",
+                onClick = {
+                    selectedDocument =
+                        LicenseDocument(
+                            title = "Compliance Status",
+                            assetPath = "licenses/COMPLIANCE_STATUS.md",
+                        )
+                },
+            )
+        }
+        item {
+            Chip(
+                modifier = Modifier.fillMaxWidth(),
+                label = "Open Source Notices",
+                secondaryLabel = "Libraries and OSS licenses",
+                onClick = {
+                    selectedDocument =
+                        LicenseDocument(
+                            title = "Open Source Notices",
+                            assetPath = "licenses/THIRD_PARTY_NOTICES.md",
+                        )
+                },
+            )
+        }
+        item {
+            Chip(
+                modifier = Modifier.fillMaxWidth(),
+                label = "OpenHiking Theme",
+                secondaryLabel = "Bundled hiking theme details",
+                onClick = {
+                    selectedDocument =
+                        LicenseDocument(
+                            title = "OpenHiking Theme",
+                            assetPath = "licenses/OPENHIKING_THEME.md",
+                        )
+                },
+            )
+        }
+        item {
+            Chip(
+                modifier = Modifier.fillMaxWidth(),
+                label = "French Kiss Theme",
+                secondaryLabel = "Bundled IGN-style theme details",
+                onClick = {
+                    selectedDocument =
+                        LicenseDocument(
+                            title = "French Kiss Theme",
+                            assetPath = "licenses/FRENCH_KISS_THEME.md",
+                        )
+                },
+            )
+        }
+        item {
+            Chip(
+                modifier = Modifier.fillMaxWidth(),
+                label = "Tiramisu Theme",
+                secondaryLabel = "Bundled cycle/hike theme details",
+                onClick = {
+                    selectedDocument =
+                        LicenseDocument(
+                            title = "Tiramisu Theme",
+                            assetPath = "licenses/TIRAMISU_THEME.md",
+                        )
+                },
+            )
+        }
+        item {
+            Chip(
+                modifier = Modifier.fillMaxWidth(),
+                label = "Hike, Ride & Sight",
+                secondaryLabel = "Bundled overlay-rich theme details",
+                onClick = {
+                    selectedDocument =
+                        LicenseDocument(
+                            title = "Hike, Ride & Sight Theme",
+                            assetPath = "licenses/HIKE_RIDE_SIGHT_THEME.md",
+                        )
+                },
+            )
+        }
+        item {
+            Chip(
+                modifier = Modifier.fillMaxWidth(),
+                label = "Voluntary Theme",
+                secondaryLabel = "Bundled OS-inspired theme details",
+                onClick = {
+                    selectedDocument =
+                        LicenseDocument(
+                            title = "Voluntary Theme",
+                            assetPath = "licenses/VOLUNTARY_THEME.md",
+                        )
+                },
+            )
+        }
+        item {
+            Chip(
+                modifier = Modifier.fillMaxWidth(),
+                label = "Data & Asset Attribution",
+                secondaryLabel = "OSM, Elevate, bundled themes, DEM, icons",
+                onClick = {
+                    selectedDocument =
+                        LicenseDocument(
+                            title = "Data & Asset Attribution",
+                            assetPath = "licenses/DATA_AND_ASSET_ATTRIBUTION.md",
+                        )
+                },
+            )
+        }
+        item {
+            Chip(
+                modifier = Modifier.fillMaxWidth(),
+                label = "Service Terms & API Usage",
+                secondaryLabel = "Provider terms and usage limits",
+                onClick = {
+                    selectedDocument =
+                        LicenseDocument(
+                            title = "Service Terms & API Usage",
+                            assetPath = "licenses/SERVICE_TERMS_AND_API_USAGE.md",
+                        )
+                },
+            )
+        }
+        item {
+            Spacer(modifier = Modifier.height(72.dp))
         }
     }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/MapDisplaySettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/MapDisplaySettingsScreen.kt
@@ -2,9 +2,6 @@
 
 package com.glancemap.glancemapwearos.presentation.features.settings
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.UnfoldMore
 import androidx.compose.runtime.Composable
@@ -16,12 +13,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import com.glancemap.glancemapwearos.data.repository.SettingsRepository
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.compose.layout.ScreenScaffold
 
-@OptIn(ExperimentalHorologistApi::class)
 @Composable
 fun MapDisplaySettingsScreen(
     viewModel: SettingsViewModel,
@@ -35,7 +28,6 @@ fun MapDisplaySettingsScreen(
     val mapZoomButtonsMode by viewModel.mapZoomButtonsMode.collectAsState()
     val gpsAccuracyCircleEnabled by viewModel.gpsAccuracyCircleEnabled.collectAsState()
 
-    val listState = rememberSettingsScalingLazyListState(topPadding = listTokens.topPadding)
     val northIndicatorModes = listOf("ALWAYS", "COMPASS_ONLY", "NORTH_UP_ONLY", "NEVER")
     val markerStyles =
         listOf(
@@ -74,75 +66,59 @@ fun MapDisplaySettingsScreen(
             zoomButtonModes.map { it to zoomButtonsModeLabel(it) }
         }
 
-    ScreenScaffold(scrollState = listState) {
-        ScalingLazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            state = listState,
-            contentPadding =
-                PaddingValues(
-                    start = listTokens.horizontalPadding,
-                    end = listTokens.horizontalPadding,
-                    top = listTokens.topPadding,
-                    bottom = listTokens.bottomPadding,
-                ),
-            verticalArrangement = Arrangement.spacedBy(listTokens.itemSpacing),
-            anchorType = SettingsListAnchorType,
-            autoCentering = SettingsListAutoCentering,
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            item {
-                GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
-            }
-            item {
-                SettingsToggleChip(
-                    checked = showTimeInNavigate,
-                    onCheckedChanged = { viewModel.setShowTimeInNavigate(it) },
-                    label = "Show time on map",
-                    modifier = Modifier.testTag(TAG_MAP_DISPLAY_SHOW_TIME_CHIP),
-                )
-            }
-            if (showTimeInNavigate) {
-                item {
-                    SettingsPickerChip(
-                        label = "Time format",
-                        onClick = { showTimeFormatPicker = true },
-                        iconImageVector = Icons.Filled.UnfoldMore,
-                        secondaryLabel = timeFormatLabel(navigateTimeFormat),
-                    )
-                }
-            }
+    WearSettingsListScreen(listTokens = listTokens, horizontalAlignment = Alignment.CenterHorizontally) {
+        item {
+            GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
+        }
+        item {
+            SettingsToggleChip(
+                checked = showTimeInNavigate,
+                onCheckedChanged = { viewModel.setShowTimeInNavigate(it) },
+                label = "Show time on map",
+                modifier = Modifier.testTag(TAG_MAP_DISPLAY_SHOW_TIME_CHIP),
+            )
+        }
+        if (showTimeInNavigate) {
             item {
                 SettingsPickerChip(
-                    label = "North indicator",
-                    onClick = { showNorthIndicatorPicker = true },
+                    label = "Time format",
+                    onClick = { showTimeFormatPicker = true },
                     iconImageVector = Icons.Filled.UnfoldMore,
-                    secondaryLabel = northIndicatorModeLabel(northIndicatorMode),
+                    secondaryLabel = timeFormatLabel(navigateTimeFormat),
                 )
             }
-            item {
-                SettingsPickerChip(
-                    label = "Zoom buttons",
-                    onClick = { showZoomButtonsPicker = true },
-                    iconImageVector = Icons.Filled.UnfoldMore,
-                    secondaryLabel = zoomButtonsModeLabel(mapZoomButtonsMode),
-                )
-            }
-            item {
-                SettingsPickerChip(
-                    label = "Marker style",
-                    onClick = { showMarkerStylePicker = true },
-                    iconImageVector = Icons.Filled.UnfoldMore,
-                    secondaryLabel = markerStyleLabel(navigationMarkerStyle),
-                )
-            }
-            item {
-                SettingsToggleChip(
-                    checked = gpsAccuracyCircleEnabled,
-                    onCheckedChanged = { viewModel.setGpsAccuracyCircleEnabled(it) },
-                    label = "GPS accuracy circle",
-                    secondaryLabel = "Show uncertainty radius",
-                )
-            }
+        }
+        item {
+            SettingsPickerChip(
+                label = "North indicator",
+                onClick = { showNorthIndicatorPicker = true },
+                iconImageVector = Icons.Filled.UnfoldMore,
+                secondaryLabel = northIndicatorModeLabel(northIndicatorMode),
+            )
+        }
+        item {
+            SettingsPickerChip(
+                label = "Zoom buttons",
+                onClick = { showZoomButtonsPicker = true },
+                iconImageVector = Icons.Filled.UnfoldMore,
+                secondaryLabel = zoomButtonsModeLabel(mapZoomButtonsMode),
+            )
+        }
+        item {
+            SettingsPickerChip(
+                label = "Marker style",
+                onClick = { showMarkerStylePicker = true },
+                iconImageVector = Icons.Filled.UnfoldMore,
+                secondaryLabel = markerStyleLabel(navigationMarkerStyle),
+            )
+        }
+        item {
+            SettingsToggleChip(
+                checked = gpsAccuracyCircleEnabled,
+                onCheckedChanged = { viewModel.setGpsAccuracyCircleEnabled(it) },
+                label = "GPS accuracy circle",
+                secondaryLabel = "Show uncertainty radius",
+            )
         }
     }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/MapSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/MapSettingsScreen.kt
@@ -1,9 +1,6 @@
 package com.glancemap.glancemapwearos.presentation.features.settings
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -14,7 +11,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.navigation.NavHostController
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Slider
@@ -27,7 +23,6 @@ import com.glancemap.glancemapwearos.presentation.features.maps.DemSetupReason
 import com.glancemap.glancemapwearos.presentation.features.maps.theme.ThemeViewModel
 import com.glancemap.glancemapwearos.presentation.navigation.WatchRoutes
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.compose.layout.ScreenScaffold
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalHorologistApi::class)
@@ -83,8 +78,6 @@ fun MapSettingsScreen(
         }
     val reliefOverlaySecondaryLabel = if (reliefOverlayEnabled) "On" else "Off"
 
-    val listState = rememberSettingsScalingLazyListState(topPadding = listTokens.topPadding)
-
     DemSetupBottomSheet(
         visible = showDemSetupDialog,
         reason = demSetupReason,
@@ -94,154 +87,138 @@ fun MapSettingsScreen(
         },
     )
 
-    ScreenScaffold(scrollState = listState) {
-        ScalingLazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            state = listState,
-            contentPadding =
-                PaddingValues(
-                    start = listTokens.horizontalPadding,
-                    end = listTokens.horizontalPadding,
-                    top = listTokens.topPadding,
-                    bottom = listTokens.bottomPadding,
-                ),
-            verticalArrangement = Arrangement.spacedBy(listTokens.itemSpacing),
-            anchorType = SettingsListAnchorType,
-            autoCentering = SettingsListAutoCentering,
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            item {
-                GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
-            }
-            item {
-                SettingsPickerChip(
-                    modifier = Modifier.fillMaxWidth(),
-                    label = "Position marker",
-                    iconImageVector = Icons.Filled.UnfoldMore,
-                    secondaryLabel =
-                        if (navigationMarkerAnchorMode == SettingsRepository.NAVIGATION_MARKER_ANCHOR_LOWER) {
-                            "Bottom"
-                        } else {
-                            "Middle"
-                        },
-                    onClick = { showMarkerPositionPicker = true },
-                )
-            }
-            item {
-                SettingsToggleChip(
-                    checked = autoRecenterEnabled,
-                    onCheckedChanged = {
-                        viewModel.setAutoRecenterEnabled(it)
+    WearSettingsListScreen(listTokens = listTokens, horizontalAlignment = Alignment.CenterHorizontally) {
+        item {
+            GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
+        }
+        item {
+            SettingsPickerChip(
+                modifier = Modifier.fillMaxWidth(),
+                label = "Position marker",
+                iconImageVector = Icons.Filled.UnfoldMore,
+                secondaryLabel =
+                    if (navigationMarkerAnchorMode == SettingsRepository.NAVIGATION_MARKER_ANCHOR_LOWER) {
+                        "Bottom"
+                    } else {
+                        "Middle"
                     },
-                    label = "Auto recenter",
-                )
-            }
-            if (autoRecenterEnabled) {
-                item {
-                    RecenterDelaySetting(autoRecenterDelay) { newDelay ->
-                        viewModel.setAutoRecenterDelay(newDelay)
-                    }
+                onClick = { showMarkerPositionPicker = true },
+            )
+        }
+        item {
+            SettingsToggleChip(
+                checked = autoRecenterEnabled,
+                onCheckedChanged = {
+                    viewModel.setAutoRecenterEnabled(it)
+                },
+                label = "Auto recenter",
+            )
+        }
+        if (autoRecenterEnabled) {
+            item {
+                RecenterDelaySetting(autoRecenterDelay) { newDelay ->
+                    viewModel.setAutoRecenterDelay(newDelay)
                 }
             }
-            item {
-                SettingsToggleChip(
-                    checked = liveElevation,
-                    onCheckedChanged = { enabled ->
-                        if (!enabled) {
-                            viewModel.setLiveElevation(false)
-                        } else {
-                            scope.launch {
-                                val demReady = themeViewModel.isDemReadyForMap(selectedMapPath)
-                                if (demReady) {
-                                    viewModel.setLiveElevation(true)
-                                } else {
-                                    viewModel.setLiveElevation(false)
-                                    demSetupReason = DemSetupReason.LIVE_ELEVATION
-                                    showDemSetupDialog = true
-                                }
+        }
+        item {
+            SettingsToggleChip(
+                checked = liveElevation,
+                onCheckedChanged = { enabled ->
+                    if (!enabled) {
+                        viewModel.setLiveElevation(false)
+                    } else {
+                        scope.launch {
+                            val demReady = themeViewModel.isDemReadyForMap(selectedMapPath)
+                            if (demReady) {
+                                viewModel.setLiveElevation(true)
+                            } else {
+                                viewModel.setLiveElevation(false)
+                                demSetupReason = DemSetupReason.LIVE_ELEVATION
+                                showDemSetupDialog = true
                             }
                         }
-                    },
-                    label = "Live elevation",
-                    secondaryLabel = if (liveElevation) "On" else "Off",
-                )
-            }
-            item {
-                SettingsToggleChip(
-                    checked = liveDistance,
-                    onCheckedChanged = { viewModel.setLiveDistance(it) },
-                    label = "Live distance",
-                    secondaryLabel = if (liveDistance) "On" else "Off",
-                )
-            }
-            item {
-                SettingsToggleChip(
-                    checked = hillShadingChecked,
-                    enabled = hillShadingSupported,
-                    onCheckedChanged = { enabled ->
-                        if (!enabled) {
-                            themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_HILL_SHADING_ID, false)
-                        } else {
-                            scope.launch {
-                                val demReady = themeViewModel.isDemReadyForMap(selectedMapPath)
-                                if (demReady) {
-                                    themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_HILL_SHADING_ID, true)
-                                } else {
-                                    themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_HILL_SHADING_ID, false)
-                                    demSetupReason = DemSetupReason.HILL_SHADING
-                                    showDemSetupDialog = true
-                                }
+                    }
+                },
+                label = "Live elevation",
+                secondaryLabel = if (liveElevation) "On" else "Off",
+            )
+        }
+        item {
+            SettingsToggleChip(
+                checked = liveDistance,
+                onCheckedChanged = { viewModel.setLiveDistance(it) },
+                label = "Live distance",
+                secondaryLabel = if (liveDistance) "On" else "Off",
+            )
+        }
+        item {
+            SettingsToggleChip(
+                checked = hillShadingChecked,
+                enabled = hillShadingSupported,
+                onCheckedChanged = { enabled ->
+                    if (!enabled) {
+                        themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_HILL_SHADING_ID, false)
+                    } else {
+                        scope.launch {
+                            val demReady = themeViewModel.isDemReadyForMap(selectedMapPath)
+                            if (demReady) {
+                                themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_HILL_SHADING_ID, true)
+                            } else {
+                                themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_HILL_SHADING_ID, false)
+                                demSetupReason = DemSetupReason.HILL_SHADING
+                                showDemSetupDialog = true
                             }
                         }
-                    },
-                    label = "Hill shading",
-                    secondaryLabel = hillShadingSecondaryLabel,
-                )
-            }
-            item {
-                SettingsToggleChip(
-                    checked = reliefOverlayEnabled,
-                    onCheckedChanged = { enabled ->
-                        if (!enabled) {
-                            themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_RELIEF_OVERLAY_ID, false)
-                        } else {
-                            scope.launch {
-                                val demReady = themeViewModel.isDemReadyForMap(selectedMapPath)
-                                if (demReady) {
-                                    themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_RELIEF_OVERLAY_ID, true)
-                                } else {
-                                    themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_RELIEF_OVERLAY_ID, false)
-                                    demSetupReason = DemSetupReason.SLOPE_OVERLAY
-                                    showDemSetupDialog = true
-                                }
+                    }
+                },
+                label = "Hill shading",
+                secondaryLabel = hillShadingSecondaryLabel,
+            )
+        }
+        item {
+            SettingsToggleChip(
+                checked = reliefOverlayEnabled,
+                onCheckedChanged = { enabled ->
+                    if (!enabled) {
+                        themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_RELIEF_OVERLAY_ID, false)
+                    } else {
+                        scope.launch {
+                            val demReady = themeViewModel.isDemReadyForMap(selectedMapPath)
+                            if (demReady) {
+                                themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_RELIEF_OVERLAY_ID, true)
+                            } else {
+                                themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_RELIEF_OVERLAY_ID, false)
+                                demSetupReason = DemSetupReason.SLOPE_OVERLAY
+                                showDemSetupDialog = true
                             }
                         }
-                    },
-                    label = "Slope overlay",
-                    secondaryLabel = reliefOverlaySecondaryLabel,
-                )
-            }
-            item {
-                SettingsSectionChip(
-                    label = "Theme",
-                    secondaryLabel = "Open theme settings",
-                    onClick = { navController.navigate(WatchRoutes.THEME_SETTINGS) },
-                )
-            }
-            item {
-                SettingsSectionChip(
-                    label = "Display",
-                    secondaryLabel = "Open display settings",
-                    onClick = { navController.navigate(WatchRoutes.MAP_DISPLAY_SETTINGS) },
-                )
-            }
-            item {
-                SettingsSectionChip(
-                    label = "Zoom",
-                    secondaryLabel = "Open zoom settings",
-                    onClick = { navController.navigate(WatchRoutes.MAP_ZOOM_SETTINGS) },
-                )
-            }
+                    }
+                },
+                label = "Slope overlay",
+                secondaryLabel = reliefOverlaySecondaryLabel,
+            )
+        }
+        item {
+            SettingsSectionChip(
+                label = "Theme",
+                secondaryLabel = "Open theme settings",
+                onClick = { navController.navigate(WatchRoutes.THEME_SETTINGS) },
+            )
+        }
+        item {
+            SettingsSectionChip(
+                label = "Display",
+                secondaryLabel = "Open display settings",
+                onClick = { navController.navigate(WatchRoutes.MAP_DISPLAY_SETTINGS) },
+            )
+        }
+        item {
+            SettingsSectionChip(
+                label = "Zoom",
+                secondaryLabel = "Open zoom settings",
+                onClick = { navController.navigate(WatchRoutes.MAP_ZOOM_SETTINGS) },
+            )
         }
     }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/MapZoomSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/MapZoomSettingsScreen.kt
@@ -2,10 +2,7 @@
 
 package com.glancemap.glancemapwearos.presentation.features.settings
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -20,7 +17,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Slider
@@ -28,12 +24,9 @@ import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.core.maps.mapZoomScaleStepsMeters
 import com.glancemap.glancemapwearos.core.maps.nearestMetricScaleStepIndex
 import com.glancemap.glancemapwearos.core.maps.sanitizeMapZoomScaleMeters
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.compose.layout.ScreenScaffold
 import java.util.Locale
 import kotlin.math.roundToInt
 
-@OptIn(ExperimentalHorologistApi::class)
 @Composable
 fun MapZoomSettingsScreen(
     viewModel: SettingsViewModel,
@@ -48,70 +41,52 @@ fun MapZoomSettingsScreen(
     val isMetric by viewModel.isMetric.collectAsState()
     var showCrownDirectionPicker by remember { mutableStateOf(false) }
 
-    val listState = rememberSettingsScalingLazyListState(topPadding = listTokens.topPadding)
-
-    ScreenScaffold(scrollState = listState) {
-        ScalingLazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            state = listState,
-            contentPadding =
-                PaddingValues(
-                    start = listTokens.horizontalPadding,
-                    end = listTokens.horizontalPadding,
-                    top = listTokens.topPadding,
-                    bottom = listTokens.bottomPadding,
-                ),
-            verticalArrangement = Arrangement.spacedBy(listTokens.itemSpacing),
-            anchorType = SettingsListAnchorType,
-            autoCentering = SettingsListAutoCentering,
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
+    WearSettingsListScreen(listTokens = listTokens, horizontalAlignment = Alignment.CenterHorizontally) {
+        item {
+            GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
+        }
+        item {
+            SettingsToggleChip(
+                checked = crownZoomEnabled,
+                onCheckedChanged = { viewModel.setCrownZoomEnabled(it) },
+                label = "Crown zoom",
+                secondaryLabel = if (crownZoomEnabled) "Enabled" else "Disabled",
+            )
+        }
+        if (crownZoomEnabled) {
             item {
-                GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
-            }
-            item {
-                SettingsToggleChip(
-                    checked = crownZoomEnabled,
-                    onCheckedChanged = { viewModel.setCrownZoomEnabled(it) },
-                    label = "Crown zoom",
-                    secondaryLabel = if (crownZoomEnabled) "Enabled" else "Disabled",
+                SettingsPickerChip(
+                    modifier = Modifier.fillMaxWidth(),
+                    label = "Crown direction",
+                    iconImageVector = Icons.Filled.UnfoldMore,
+                    secondaryLabel = if (crownZoomInverted) "Inverted" else "Normal",
+                    onClick = { showCrownDirectionPicker = true },
                 )
             }
-            if (crownZoomEnabled) {
-                item {
-                    SettingsPickerChip(
-                        modifier = Modifier.fillMaxWidth(),
-                        label = "Crown direction",
-                        iconImageVector = Icons.Filled.UnfoldMore,
-                        secondaryLabel = if (crownZoomInverted) "Inverted" else "Normal",
-                        onClick = { showCrownDirectionPicker = true },
-                    )
-                }
-            }
-            item {
-                ScaleDistanceSetting(
-                    label = "Default scale",
-                    value = zoomDefaultScaleMeters,
-                    isMetric = isMetric,
-                    onValueChange = viewModel::setMapZoomDefaultScaleMeters,
-                )
-            }
-            item {
-                ScaleDistanceSetting(
-                    label = "Farthest out",
-                    value = zoomMinScaleMeters,
-                    isMetric = isMetric,
-                    onValueChange = viewModel::setMapZoomMinScaleMeters,
-                )
-            }
-            item {
-                ScaleDistanceSetting(
-                    label = "Closest in",
-                    value = zoomMaxScaleMeters,
-                    isMetric = isMetric,
-                    onValueChange = viewModel::setMapZoomMaxScaleMeters,
-                )
-            }
+        }
+        item {
+            ScaleDistanceSetting(
+                label = "Default scale",
+                value = zoomDefaultScaleMeters,
+                isMetric = isMetric,
+                onValueChange = viewModel::setMapZoomDefaultScaleMeters,
+            )
+        }
+        item {
+            ScaleDistanceSetting(
+                label = "Farthest out",
+                value = zoomMinScaleMeters,
+                isMetric = isMetric,
+                onValueChange = viewModel::setMapZoomMinScaleMeters,
+            )
+        }
+        item {
+            ScaleDistanceSetting(
+                label = "Closest in",
+                value = zoomMaxScaleMeters,
+                isMetric = isMetric,
+                onValueChange = viewModel::setMapZoomMaxScaleMeters,
+            )
         }
     }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/OptionPickerDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/OptionPickerDialog.kt
@@ -5,12 +5,10 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -31,10 +29,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.presentation.ui.WearLazyListScreenEdgeScrollIndicator
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
-import com.glancemap.glancemapwearos.presentation.ui.wearDialogWidth
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.material.ToggleChip
 import com.google.android.horologist.compose.material.ToggleChipToggleControl
@@ -66,93 +64,91 @@ internal fun <T> OptionPickerDialog(
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
         Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center,
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.78f)),
         ) {
-            Column(
+            LazyColumn(
                 modifier =
                     Modifier
-                        .wearDialogWidth()
-                        .background(
-                            Color.Black.copy(alpha = 0.82f),
-                            RoundedCornerShape(adaptive.dialogCornerRadius),
-                        ).padding(
-                            horizontal = adaptive.dialogHorizontalPadding,
-                            vertical = adaptive.dialogVerticalPadding,
-                        ),
+                        .fillMaxSize()
+                        .onPreRotaryScrollEvent { event ->
+                            val consumed = listState.dispatchRawDelta(event.verticalScrollPixels)
+                            abs(consumed) > 0.5f
+                        }.focusRequester(focusRequester)
+                        .focusable(),
+                state = listState,
+                contentPadding =
+                    PaddingValues(
+                        start = adaptive.dialogHorizontalPadding,
+                        top = adaptive.dialogVerticalPadding + 18.dp,
+                        end = adaptive.dialogHorizontalPadding + 10.dp,
+                        bottom = adaptive.dialogVerticalPadding + 42.dp,
+                    ),
                 verticalArrangement = Arrangement.spacedBy(6.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                userScrollEnabled = true,
             ) {
-                Box(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .pointerInput(Unit) {
-                                var totalDrag = 0f
-                                detectVerticalDragGestures(
-                                    onDragEnd = { totalDrag = 0f },
-                                    onDragCancel = { totalDrag = 0f },
-                                ) { _, dragAmount ->
-                                    totalDrag += dragAmount
-                                    if (totalDrag > PICKER_DRAG_DISMISS_PX) {
-                                        onDismiss()
-                                        totalDrag = 0f
-                                    }
-                                }
-                            },
-                ) {
+                item {
                     Box(
                         modifier =
                             Modifier
-                                .width(26.dp)
-                                .height(3.dp)
-                                .background(Color.White.copy(alpha = 0.42f), RoundedCornerShape(50))
-                                .align(Alignment.Center),
-                    )
+                                .fillMaxWidth()
+                                .height(12.dp)
+                                .pointerInput(Unit) {
+                                    var totalDrag = 0f
+                                    detectVerticalDragGestures(
+                                        onDragEnd = { totalDrag = 0f },
+                                        onDragCancel = { totalDrag = 0f },
+                                    ) { _, dragAmount ->
+                                        totalDrag += dragAmount
+                                        if (totalDrag > PICKER_DRAG_DISMISS_PX) {
+                                            onDismiss()
+                                            totalDrag = 0f
+                                        }
+                                    }
+                                },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Box(
+                            modifier =
+                                Modifier
+                                    .width(26.dp)
+                                    .height(3.dp)
+                                    .background(Color.White.copy(alpha = 0.42f), RoundedCornerShape(50)),
+                        )
+                    }
                 }
-                Text(
-                    text = title,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                Box(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .heightIn(min = 64.dp, max = adaptive.helpDialogMaxHeight),
-                ) {
-                    LazyColumn(
+
+                item {
+                    Text(
+                        text = title,
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.titleLarge,
                         modifier =
                             Modifier
                                 .fillMaxWidth()
-                                .onPreRotaryScrollEvent { event ->
-                                    val consumed = listState.dispatchRawDelta(event.verticalScrollPixels)
-                                    abs(consumed) > 0.5f
-                                }.focusRequester(focusRequester)
-                                .focusable()
-                                .padding(end = 10.dp),
-                        state = listState,
-                        contentPadding = PaddingValues(bottom = adaptive.dialogVerticalPadding + 24.dp),
-                        verticalArrangement = Arrangement.spacedBy(6.dp),
-                        userScrollEnabled = true,
-                    ) {
-                        items(options) { (value, label) ->
-                            ToggleChip(
-                                modifier = Modifier.fillMaxWidth(),
-                                checked = value == selectedValue,
-                                onCheckedChanged = { checked ->
-                                    if (value == selectedValue) {
-                                        onDismiss()
-                                        return@ToggleChip
-                                    }
-                                    if (!checked) return@ToggleChip
-                                    onSelect(value)
-                                    onDismiss()
-                                },
-                                label = label,
-                                toggleControl = ToggleChipToggleControl.Radio,
-                            )
-                        }
-                    }
+                                .padding(horizontal = 6.dp),
+                    )
+                }
+
+                items(options) { (value, label) ->
+                    ToggleChip(
+                        modifier = Modifier.fillMaxWidth(),
+                        checked = value == selectedValue,
+                        onCheckedChanged = { checked ->
+                            if (value == selectedValue) {
+                                onDismiss()
+                                return@ToggleChip
+                            }
+                            if (!checked) return@ToggleChip
+                            onSelect(value)
+                            onDismiss()
+                        },
+                        label = label,
+                        toggleControl = ToggleChipToggleControl.Radio,
+                    )
                 }
             }
             WearLazyListScreenEdgeScrollIndicator(listState = listState)

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/PoiSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/PoiSettingsScreen.kt
@@ -2,8 +2,6 @@ package com.glancemap.glancemapwearos.presentation.features.settings
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -19,14 +17,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Slider
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.data.repository.SettingsRepository
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.compose.layout.ScreenScaffold
 
 @OptIn(ExperimentalHorologistApi::class)
 @Composable
@@ -67,74 +63,56 @@ fun PoiSettingsScreen(
             )
         }
 
-    val listState = rememberSettingsScalingLazyListState(topPadding = listTokens.topPadding)
-
-    ScreenScaffold(scrollState = listState) {
-        ScalingLazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            state = listState,
-            contentPadding =
-                PaddingValues(
-                    start = listTokens.horizontalPadding,
-                    end = listTokens.horizontalPadding,
-                    top = listTokens.topPadding,
-                    bottom = listTokens.bottomPadding,
-                ),
-            verticalArrangement = Arrangement.spacedBy(listTokens.itemSpacing),
-            anchorType = SettingsListAnchorType,
-            autoCentering = SettingsListAutoCentering,
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            item {
-                GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
-            }
-            item {
-                SettingsPickerChip(
-                    label = "POI icon size",
-                    secondaryLabel = poiIconSizeLabel(poiIconSizePx),
-                    iconImageVector = Icons.Filled.UnfoldMore,
-                    onClick = { showIconSizePicker = true },
-                )
-            }
-            item {
-                SettingsPickerChip(
-                    label = "POI marker style",
-                    secondaryLabel = poiMarkerStyleLabel(poiMarkerStyle),
-                    iconImageVector = Icons.Filled.UnfoldMore,
-                    onClick = { showMarkerStylePicker = true },
-                )
-            }
-            item {
-                SettingsPickerChip(
-                    label = "POI list tap action",
-                    secondaryLabel =
-                        if (poiTapToCenterEnabled) {
-                            "Open Navigate at POI"
-                        } else {
-                            "Disabled"
-                        },
-                    iconImageVector = Icons.Filled.UnfoldMore,
-                    onClick = { showTapActionPicker = true },
-                )
-            }
-            item {
-                PoiPopupTimeoutSettings(
-                    autoTimeoutEnabled = !poiPopupManualCloseOnly,
-                    poiPopupTimeoutSeconds = poiPopupTimeoutSeconds,
-                    onAutoTimeoutToggle = { enabled ->
-                        viewModel.setPoiPopupManualCloseOnly(!enabled)
+    WearSettingsListScreen(listTokens = listTokens, horizontalAlignment = Alignment.CenterHorizontally) {
+        item {
+            GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
+        }
+        item {
+            SettingsPickerChip(
+                label = "POI icon size",
+                secondaryLabel = poiIconSizeLabel(poiIconSizePx),
+                iconImageVector = Icons.Filled.UnfoldMore,
+                onClick = { showIconSizePicker = true },
+            )
+        }
+        item {
+            SettingsPickerChip(
+                label = "POI marker style",
+                secondaryLabel = poiMarkerStyleLabel(poiMarkerStyle),
+                iconImageVector = Icons.Filled.UnfoldMore,
+                onClick = { showMarkerStylePicker = true },
+            )
+        }
+        item {
+            SettingsPickerChip(
+                label = "POI list tap action",
+                secondaryLabel =
+                    if (poiTapToCenterEnabled) {
+                        "Open Navigate at POI"
+                    } else {
+                        "Disabled"
                     },
-                    onTimeoutChange = { target ->
-                        val clamped =
-                            target
-                                .coerceAtLeast(SettingsRepository.POI_POPUP_TIMEOUT_MIN_SECONDS)
-                                .coerceAtMost(SettingsRepository.POI_POPUP_TIMEOUT_MAX_SECONDS)
-                        if (clamped != poiPopupTimeoutSeconds) {
-                            viewModel.setPoiPopupTimeoutSeconds(clamped)
-                        }
-                    },
-                )
-            }
+                iconImageVector = Icons.Filled.UnfoldMore,
+                onClick = { showTapActionPicker = true },
+            )
+        }
+        item {
+            PoiPopupTimeoutSettings(
+                autoTimeoutEnabled = !poiPopupManualCloseOnly,
+                poiPopupTimeoutSeconds = poiPopupTimeoutSeconds,
+                onAutoTimeoutToggle = { enabled ->
+                    viewModel.setPoiPopupManualCloseOnly(!enabled)
+                },
+                onTimeoutChange = { target ->
+                    val clamped =
+                        target
+                            .coerceAtLeast(SettingsRepository.POI_POPUP_TIMEOUT_MIN_SECONDS)
+                            .coerceAtMost(SettingsRepository.POI_POPUP_TIMEOUT_MAX_SECONDS)
+                    if (clamped != poiPopupTimeoutSeconds) {
+                        viewModel.setPoiPopupTimeoutSeconds(clamped)
+                    }
+                },
+            )
         }
     }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/ResetDefaultsConfirmScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/ResetDefaultsConfirmScreen.kt
@@ -1,77 +1,40 @@
+@file:Suppress("FunctionNaming")
+
 package com.glancemap.glancemapwearos.presentation.features.settings
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.compose.layout.ScreenScaffold
-import com.google.android.horologist.compose.material.Chip
+import com.glancemap.glancemapwearos.presentation.ui.WearActionButtonRole
+import com.glancemap.glancemapwearos.presentation.ui.WearActionDialogButton
+import com.glancemap.glancemapwearos.presentation.ui.WearActionScreen
 
-@OptIn(ExperimentalHorologistApi::class)
 @Composable
 fun ResetDefaultsConfirmScreen(
     onCancel: () -> Unit,
     onConfirmReset: () -> Unit,
 ) {
-    val listTokens =
-        rememberSettingsListTokens(
-            compactTop = 48.dp,
-            standardTop = 52.dp,
-            expandedTop = 56.dp,
-            compactBottom = 76.dp,
-            standardBottom = 84.dp,
-            expandedBottom = 92.dp,
-        )
-    val listState = rememberSettingsScalingLazyListState(topPadding = listTokens.topPadding)
-
-    ScreenScaffold(scrollState = listState) {
-        ScalingLazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            state = listState,
-            contentPadding =
-                PaddingValues(
-                    start = listTokens.horizontalPadding,
-                    end = listTokens.horizontalPadding,
-                    top = listTokens.topPadding,
-                    bottom = listTokens.bottomPadding,
-                ),
-            verticalArrangement = Arrangement.spacedBy(listTokens.itemSpacing),
-            anchorType = SettingsListAnchorType,
-            autoCentering = SettingsListAutoCentering,
-        ) {
-            item {
-                Text(
-                    text = "Reset to defaults",
-                    style = MaterialTheme.typography.titleMedium,
-                    textAlign = TextAlign.Center,
-                )
-            }
-            item {
-                Text(
-                    text = "This resets settings and theme preferences.",
-                    textAlign = TextAlign.Center,
-                )
-            }
-            item {
-                Chip(
-                    label = "Reset now",
-                    secondaryLabel = "Cannot be undone",
+    WearActionScreen(
+        title = "Reset to defaults",
+        buttons =
+            listOf(
+                WearActionDialogButton(
+                    text = "Reset now",
                     onClick = onConfirmReset,
-                )
-            }
-            item {
-                Chip(
-                    label = "Cancel",
+                    role = WearActionButtonRole.Destructive,
+                ),
+                WearActionDialogButton(
+                    text = "Cancel",
                     onClick = onCancel,
-                )
-            }
-        }
+                    role = WearActionButtonRole.Secondary,
+                ),
+            ),
+    ) {
+        Text(
+            text = "This resets settings and theme preferences.",
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+        )
     }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/SettingsScreen.kt
@@ -8,14 +8,13 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.navigation.NavHostController
-import androidx.wear.compose.material3.AlertDialog
-import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.core.service.transfer.storage.StalePartialTransferCleaner
 import com.glancemap.glancemapwearos.presentation.features.gpx.GpxViewModel
 import com.glancemap.glancemapwearos.presentation.features.maps.MapViewModel
 import com.glancemap.glancemapwearos.presentation.navigation.WatchRoutes
+import com.glancemap.glancemapwearos.presentation.ui.WearActionDialog
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -206,127 +205,107 @@ fun SettingsScreen(
         onSelect = { selectedMetric -> viewModel.setMetric(selectedMetric) },
     )
 
-    AlertDialog(
+    WearActionDialog(
         visible = showClearCacheDialog,
         onDismissRequest = {
             if (!isClearingCache) {
                 showClearCacheDialog = false
             }
         },
-        title = { Text("Clear cache") },
-        text = {
-            Text(
-                "Removes temporary map, GPX, relief and theme caches. Imported maps, GPX and DEM files stay on the watch.",
-            )
-        },
-        confirmButton = {
-            Button(
-                onClick = {
-                    if (isClearingCache) return@Button
-                    isClearingCache = true
-                    scope.launch {
-                        runCatching {
-                            val result = mapViewModel.clearDerivedCaches()
-                            gpxViewModel.clearDerivedCaches()
-                            result
-                        }.onSuccess { result ->
-                            val deletedMb =
-                                if (result.deletedBytes > 0L) {
-                                    " (${(result.deletedBytes / (1024.0 * 1024.0)).let { String.format(java.util.Locale.US, "%.1f", it) }} MB)"
-                                } else {
-                                    ""
-                                }
-                            Toast
-                                .makeText(
-                                    context,
-                                    "Cache cleared$deletedMb",
-                                    Toast.LENGTH_SHORT,
-                                ).show()
-                        }.onFailure {
-                            Toast
-                                .makeText(
-                                    context,
-                                    "Cache cleanup failed",
-                                    Toast.LENGTH_SHORT,
-                                ).show()
-                        }
-                        isClearingCache = false
-                        showClearCacheDialog = false
+        title = "Clear cache",
+        message =
+            "Removes temporary map, GPX, relief and theme caches. " +
+                "Imported maps, GPX and DEM files stay on the watch.",
+        confirmText = if (isClearingCache) "Clearing..." else "Clear",
+        confirmEnabled = !isClearingCache,
+        onConfirm = {
+            if (!isClearingCache) {
+                isClearingCache = true
+                scope.launch {
+                    runCatching {
+                        val result = mapViewModel.clearDerivedCaches()
+                        gpxViewModel.clearDerivedCaches()
+                        result
+                    }.onSuccess { result ->
+                        val deletedMb =
+                            if (result.deletedBytes > 0L) {
+                                " (${(result.deletedBytes / (1024.0 * 1024.0)).let { String.format(java.util.Locale.US, "%.1f", it) }} MB)"
+                            } else {
+                                ""
+                            }
+                        Toast
+                            .makeText(
+                                context,
+                                "Cache cleared$deletedMb",
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                    }.onFailure {
+                        Toast
+                            .makeText(
+                                context,
+                                "Cache cleanup failed",
+                                Toast.LENGTH_SHORT,
+                            ).show()
                     }
-                },
-            ) {
-                Text(if (isClearingCache) "Clearing..." else "Clear")
+                    isClearingCache = false
+                    showClearCacheDialog = false
+                }
             }
         },
-        dismissButton = {
-            Button(
-                onClick = { showClearCacheDialog = false },
-                enabled = !isClearingCache,
-            ) {
-                Text("Cancel")
-            }
-        },
+        dismissText = "Cancel",
+        dismissEnabled = !isClearingCache,
+        onDismiss = { showClearCacheDialog = false },
     )
 
-    AlertDialog(
+    WearActionDialog(
         visible = showClearPartialTransfersDialog,
         onDismissRequest = {
             if (!isClearingPartialFiles) {
                 showClearPartialTransfersDialog = false
             }
         },
-        title = { Text("Clear partial transfers") },
-        text = {
-            Text(
-                "Deletes ${partialSummary.count} partial transfer file(s) and frees ${formatStorageSize(partialSummary.totalBytes)}. Finished files stay on the watch.",
-            )
-        },
-        confirmButton = {
-            Button(
-                onClick = {
-                    if (isClearingPartialFiles) return@Button
-                    isClearingPartialFiles = true
-                    scope.launch {
-                        runCatching {
-                            withContext(Dispatchers.IO) {
-                                StalePartialTransferCleaner.clearAll(context)
-                            }
-                        }.onSuccess { result ->
-                            Toast
-                                .makeText(
-                                    context,
-                                    if (result.removedFiles > 0) {
-                                        "Cleared ${result.removedFiles} partial file(s)"
-                                    } else {
-                                        "No partial transfer files"
-                                    },
-                                    Toast.LENGTH_SHORT,
-                                ).show()
-                        }.onFailure {
-                            Toast
-                                .makeText(
-                                    context,
-                                    "Partial transfer cleanup failed",
-                                    Toast.LENGTH_SHORT,
-                                ).show()
+        title = "Clear partial transfers",
+        message =
+            "Deletes ${partialSummary.count} partial transfer file(s) and frees " +
+                "${formatStorageSize(partialSummary.totalBytes)}. Finished files stay on the watch.",
+        confirmText = if (isClearingPartialFiles) "Clearing..." else "Clear",
+        confirmEnabled = !isClearingPartialFiles,
+        onConfirm = {
+            if (!isClearingPartialFiles) {
+                isClearingPartialFiles = true
+                scope.launch {
+                    runCatching {
+                        withContext(Dispatchers.IO) {
+                            StalePartialTransferCleaner.clearAll(context)
                         }
-                        isClearingPartialFiles = false
-                        showClearPartialTransfersDialog = false
-                        refreshPartialSummary()
+                    }.onSuccess { result ->
+                        Toast
+                            .makeText(
+                                context,
+                                if (result.removedFiles > 0) {
+                                    "Cleared ${result.removedFiles} partial file(s)"
+                                } else {
+                                    "No partial transfer files"
+                                },
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                    }.onFailure {
+                        Toast
+                            .makeText(
+                                context,
+                                "Partial transfer cleanup failed",
+                                Toast.LENGTH_SHORT,
+                            ).show()
                     }
-                },
-            ) {
-                Text(if (isClearingPartialFiles) "Clearing..." else "Clear")
+                    isClearingPartialFiles = false
+                    showClearPartialTransfersDialog = false
+                    refreshPartialSummary()
+                }
             }
         },
-        dismissButton = {
-            Button(
-                onClick = { showClearPartialTransfersDialog = false },
-                enabled = !isClearingPartialFiles,
-            ) {
-                Text("Cancel")
-            }
-        },
+        dismissText = "Cancel",
+        dismissEnabled = !isClearingPartialFiles,
+        onDismiss = { showClearPartialTransfersDialog = false },
     )
 }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/SettingsScreen.kt
@@ -1,18 +1,13 @@
 package com.glancemap.glancemapwearos.presentation.features.settings
 
 import android.widget.Toast
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Gavel
 import androidx.compose.material.icons.filled.UnfoldMore
 import androidx.compose.runtime.*
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.navigation.NavHostController
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.material3.AlertDialog
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.MaterialTheme
@@ -22,7 +17,6 @@ import com.glancemap.glancemapwearos.presentation.features.gpx.GpxViewModel
 import com.glancemap.glancemapwearos.presentation.features.maps.MapViewModel
 import com.glancemap.glancemapwearos.presentation.navigation.WatchRoutes
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.compose.layout.ScreenScaffold
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -48,7 +42,6 @@ fun SettingsScreen(
     var partialSummary by remember {
         mutableStateOf(StalePartialTransferCleaner.PartialFilesSummary(count = 0, totalBytes = 0L))
     }
-    val listState = rememberSettingsScalingLazyListState(topPadding = listTokens.topPadding)
     val isMetric by viewModel.isMetric.collectAsState()
     val backButtonExitsNavigation by viewModel.backButtonExitsNavigation.collectAsState()
     val unitOptions =
@@ -82,140 +75,125 @@ fun SettingsScreen(
             else -> "${partialSummary.count} files · ${formatStorageSize(partialSummary.totalBytes)}"
         }
 
-    ScreenScaffold(scrollState = listState) {
-        ScalingLazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            state = listState,
-            contentPadding =
-                PaddingValues(
-                    start = listTokens.horizontalPadding,
-                    end = listTokens.horizontalPadding,
-                    top = listTokens.topPadding,
-                    bottom = listTokens.bottomPadding,
-                ),
-            verticalArrangement = Arrangement.spacedBy(listTokens.itemSpacing),
-            anchorType = SettingsListAnchorType,
-            autoCentering = SettingsListAutoCentering,
-        ) {
-            item {
-                Text(
-                    "General",
-                    style = MaterialTheme.typography.titleMedium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-            item {
-                SettingsPickerChip(
-                    label = "Units",
-                    secondaryLabel = if (isMetric) "Metric" else "Imperial",
-                    iconImageVector = Icons.Filled.UnfoldMore,
-                    onClick = { showUnitsPicker = true },
-                )
-            }
-            item {
-                SettingsSectionChip(
-                    label = "GPS settings",
-                    onClick = { navController.navigate(WatchRoutes.GPS_SETTINGS) },
-                )
-            }
-            item {
-                SettingsSectionChip(
-                    label = "Compass settings",
-                    onClick = { navController.navigate(WatchRoutes.COMPASS_SETTINGS) },
-                )
-            }
+    WearSettingsListScreen(listTokens = listTokens) {
+        item {
+            Text(
+                "General",
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        item {
+            SettingsPickerChip(
+                label = "Units",
+                secondaryLabel = if (isMetric) "Metric" else "Imperial",
+                iconImageVector = Icons.Filled.UnfoldMore,
+                onClick = { showUnitsPicker = true },
+            )
+        }
+        item {
+            SettingsSectionChip(
+                label = "GPS settings",
+                onClick = { navController.navigate(WatchRoutes.GPS_SETTINGS) },
+            )
+        }
+        item {
+            SettingsSectionChip(
+                label = "Compass settings",
+                onClick = { navController.navigate(WatchRoutes.COMPASS_SETTINGS) },
+            )
+        }
 
-            item { Text("Screen settings", style = MaterialTheme.typography.titleMedium) }
-            item {
-                SettingsSectionChip(
-                    label = "POI settings",
-                    onClick = { navController.navigate(WatchRoutes.POI_SETTINGS) },
-                )
-            }
-            item {
-                SettingsSectionChip(
-                    label = "GPX settings",
-                    onClick = { navController.navigate(WatchRoutes.GPX_SETTINGS) },
-                )
-            }
-            item {
-                SettingsSectionChip(
-                    label = "Map settings",
-                    onClick = { navController.navigate(WatchRoutes.MAP_SETTINGS) },
-                )
-            }
-            item {
-                DownloadSettingsSectionChip(
-                    onClick = { navController.navigate(WatchRoutes.DOWNLOAD_SETTINGS) },
-                )
-            }
+        item { Text("Screen settings", style = MaterialTheme.typography.titleMedium) }
+        item {
+            SettingsSectionChip(
+                label = "POI settings",
+                onClick = { navController.navigate(WatchRoutes.POI_SETTINGS) },
+            )
+        }
+        item {
+            SettingsSectionChip(
+                label = "GPX settings",
+                onClick = { navController.navigate(WatchRoutes.GPX_SETTINGS) },
+            )
+        }
+        item {
+            SettingsSectionChip(
+                label = "Map settings",
+                onClick = { navController.navigate(WatchRoutes.MAP_SETTINGS) },
+            )
+        }
+        item {
+            DownloadSettingsSectionChip(
+                onClick = { navController.navigate(WatchRoutes.DOWNLOAD_SETTINGS) },
+            )
+        }
 
-            item { Text("Advanced settings", style = MaterialTheme.typography.titleMedium) }
-            item {
-                SettingsSectionChip(
-                    label = "Debugging",
-                    onClick = { navController.navigate(WatchRoutes.DEBUG_SETTINGS) },
-                )
-            }
-            item {
-                SettingsToggleChip(
-                    checked = backButtonExitsNavigation,
-                    onCheckedChanged = viewModel::setBackButtonExitsNavigation,
-                    label = "Exit back button",
-                    secondaryLabel = "For compatible watches",
-                )
-            }
-            item {
-                SettingsPickerChip(
-                    label = if (isClearingCache) "Clearing cache..." else "Clear cache",
-                    iconImageVector = null,
-                    onClick = {
-                        if (!isClearingCache) {
-                            showClearCacheDialog = true
-                        }
+        item { Text("Advanced settings", style = MaterialTheme.typography.titleMedium) }
+        item {
+            SettingsSectionChip(
+                label = "Debugging",
+                onClick = { navController.navigate(WatchRoutes.DEBUG_SETTINGS) },
+            )
+        }
+        item {
+            SettingsToggleChip(
+                checked = backButtonExitsNavigation,
+                onCheckedChanged = viewModel::setBackButtonExitsNavigation,
+                label = "Exit back button",
+                secondaryLabel = "For compatible watches",
+            )
+        }
+        item {
+            SettingsPickerChip(
+                label = if (isClearingCache) "Clearing cache..." else "Clear cache",
+                iconImageVector = null,
+                onClick = {
+                    if (!isClearingCache) {
+                        showClearCacheDialog = true
+                    }
+                },
+            )
+        }
+        item {
+            SettingsPickerChip(
+                label =
+                    if (isClearingPartialFiles) {
+                        "Clearing partial transfer..."
+                    } else {
+                        "Clear partial transfer"
                     },
-                )
-            }
-            item {
-                SettingsPickerChip(
-                    label =
-                        if (isClearingPartialFiles) {
-                            "Clearing partial transfer..."
-                        } else {
-                            "Clear partial transfer"
-                        },
-                    secondaryLabel = partialSummaryText,
-                    iconImageVector = null,
-                    onClick = {
-                        if (isClearingPartialFiles) return@SettingsPickerChip
-                        if (partialSummary.count <= 0) {
-                            Toast
-                                .makeText(
-                                    context,
-                                    "No partial transfer files",
-                                    Toast.LENGTH_SHORT,
-                                ).show()
-                        } else {
-                            showClearPartialTransfersDialog = true
-                        }
-                    },
-                )
-            }
-            item {
-                SettingsPickerChip(
-                    label = "Reset to Default",
-                    iconImageVector = null,
-                    onClick = { navController.navigate(WatchRoutes.RESET_DEFAULTS_CONFIRM) },
-                )
-            }
-            item {
-                SettingsSectionChip(
-                    label = "Credits & Legal",
-                    iconImageVector = Icons.Filled.Gavel,
-                    onClick = { navController.navigate(WatchRoutes.LICENSES) },
-                )
-            }
+                secondaryLabel = partialSummaryText,
+                iconImageVector = null,
+                onClick = {
+                    if (isClearingPartialFiles) return@SettingsPickerChip
+                    if (partialSummary.count <= 0) {
+                        Toast
+                            .makeText(
+                                context,
+                                "No partial transfer files",
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                    } else {
+                        showClearPartialTransfersDialog = true
+                    }
+                },
+            )
+        }
+        item {
+            SettingsPickerChip(
+                label = "Reset to Default",
+                iconImageVector = null,
+                onClick = { navController.navigate(WatchRoutes.RESET_DEFAULTS_CONFIRM) },
+            )
+        }
+        item {
+            SettingsSectionChip(
+                label = "Credits & Legal",
+                iconImageVector = Icons.Filled.Gavel,
+                onClick = { navController.navigate(WatchRoutes.LICENSES) },
+            )
         }
     }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/ThemeSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/ThemeSettingsScreen.kt
@@ -3,10 +3,7 @@
 package com.glancemap.glancemapwearos.presentation.features.settings
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.icons.Icons
@@ -24,7 +21,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.MaterialTheme
@@ -34,8 +30,6 @@ import com.glancemap.glancemapwearos.domain.model.maps.theme.ThemeListItem
 import com.glancemap.glancemapwearos.domain.model.maps.theme.mapsforge.MapsforgeThemeCatalog
 import com.glancemap.glancemapwearos.presentation.features.maps.MapViewModel
 import com.glancemap.glancemapwearos.presentation.features.maps.theme.ThemeViewModel
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.compose.layout.ScreenScaffold
 import java.util.Locale
 
 internal object ThemeOverlayGrouping {
@@ -140,7 +134,6 @@ private data class OsMapStyleUi(
     val variantOptions: List<Pair<String, String>>,
 )
 
-@OptIn(ExperimentalHorologistApi::class)
 @Composable
 fun ThemeSettingsScreen(
     themeViewModel: ThemeViewModel,
@@ -151,7 +144,6 @@ fun ThemeSettingsScreen(
 ) {
     val listTokens = rememberSettingsListTokens()
     val themeItems by themeViewModel.themeItems.collectAsState()
-    val listState = rememberSettingsScalingLazyListState(topPadding = listTokens.topPadding)
     val expandedGroups = remember { mutableStateMapOf<String, Boolean>() }
     var showThemePicker by remember { mutableStateOf(false) }
     var showStylePicker by remember { mutableStateOf(false) }
@@ -222,167 +214,151 @@ fun ThemeSettingsScreen(
             buildOverlayRows(overlayGroups, expandedGroups)
         }
 
-    ScreenScaffold(scrollState = listState) {
-        ScalingLazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            state = listState,
-            contentPadding =
-                PaddingValues(
-                    start = listTokens.horizontalPadding,
-                    end = listTokens.horizontalPadding,
-                    top = listTokens.topPadding,
-                    bottom = listTokens.bottomPadding,
-                ),
-            verticalArrangement = Arrangement.spacedBy(listTokens.itemSpacing),
-            anchorType = SettingsListAnchorType,
-            autoCentering = SettingsListAutoCentering,
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            item {
-                GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
-            }
+    WearSettingsListScreen(listTokens = listTokens, horizontalAlignment = Alignment.CenterHorizontally) {
+        item {
+            GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
+        }
 
-            item {
-                Button(onClick = { themeViewModel.resetToDefaults() }) {
-                    Text(
-                        text = "Reset defaults",
-                        color = MaterialTheme.colorScheme.onBackground,
-                    )
-                }
-            }
-
-            item {
-                SettingsToggleChip(
-                    checked = nightModeToggle?.enabled == true,
-                    onCheckedChanged = { enabled ->
-                        themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_NIGHT_MODE_ID, enabled)
-                    },
-                    label = "Night mode",
-                    secondaryLabel = if (nightModeToggle?.enabled == true) "On" else "Off",
+        item {
+            Button(onClick = { themeViewModel.resetToDefaults() }) {
+                Text(
+                    text = "Reset defaults",
+                    color = MaterialTheme.colorScheme.onBackground,
                 )
             }
+        }
 
-            if (nightModeToggle?.enabled == true) {
+        item {
+            SettingsToggleChip(
+                checked = nightModeToggle?.enabled == true,
+                onCheckedChanged = { enabled ->
+                    themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_NIGHT_MODE_ID, enabled)
+                },
+                label = "Night mode",
+                secondaryLabel = if (nightModeToggle?.enabled == true) "On" else "Off",
+            )
+        }
+
+        if (nightModeToggle?.enabled == true) {
+            item {
+                Text(
+                    text =
+                        "Night mode uses Mapsforge Dark. Your normal theme and overlay choices " +
+                            "are saved and return when it is off.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center,
+                )
+            }
+        } else if (themeOptions.isNotEmpty()) {
+            item {
+                Text(
+                    text = "Theme",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center,
+                )
+            }
+            item {
+                SettingsPickerChip(
+                    label = "Map theme",
+                    secondaryLabel = selectedTheme?.name?.ifBlank { selectedTheme.id } ?: "-",
+                    iconImageVector = Icons.Filled.UnfoldMore,
+                    onClick = { showThemePicker = true },
+                )
+            }
+        }
+
+        if (nightModeToggle?.enabled != true && styleSelectionAvailable) {
+            if (osMapStyleUi != null) {
                 item {
-                    Text(
-                        text =
-                            "Night mode uses Mapsforge Dark. Your normal theme and overlay choices " +
-                                "are saved and return when it is off.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onBackground,
-                        modifier = Modifier.fillMaxWidth(),
-                        textAlign = TextAlign.Center,
+                    SettingsPickerChip(
+                        label = "Mode",
+                        secondaryLabel = osMapStyleUi.selectedModeLabel,
+                        iconImageVector = Icons.Filled.UnfoldMore,
+                        onClick = { showOsMapModePicker = true },
                     )
                 }
-            } else if (themeOptions.isNotEmpty()) {
                 item {
-                    Text(
-                        text = "Theme",
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.onBackground,
-                        modifier = Modifier.fillMaxWidth(),
-                        textAlign = TextAlign.Center,
+                    Box(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .height(1.dp)
+                                .background(MaterialTheme.colorScheme.onBackground.copy(alpha = 0.22f)),
                     )
                 }
                 item {
                     SettingsPickerChip(
-                        label = "Map theme",
-                        secondaryLabel = selectedTheme?.name?.ifBlank { selectedTheme.id } ?: "-",
+                        label = "Map style",
+                        secondaryLabel = osMapStyleUi.selectedVariantLabel,
                         iconImageVector = Icons.Filled.UnfoldMore,
-                        onClick = { showThemePicker = true },
+                        onClick = { showOsMapVariantPicker = true },
                     )
                 }
-            }
-
-            if (nightModeToggle?.enabled != true && styleSelectionAvailable) {
-                if (osMapStyleUi != null) {
-                    item {
-                        SettingsPickerChip(
-                            label = "Mode",
-                            secondaryLabel = osMapStyleUi.selectedModeLabel,
-                            iconImageVector = Icons.Filled.UnfoldMore,
-                            onClick = { showOsMapModePicker = true },
-                        )
-                    }
-                    item {
-                        Box(
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .height(1.dp)
-                                    .background(MaterialTheme.colorScheme.onBackground.copy(alpha = 0.22f)),
-                        )
-                    }
-                    item {
-                        SettingsPickerChip(
-                            label = "Map style",
-                            secondaryLabel = osMapStyleUi.selectedVariantLabel,
-                            iconImageVector = Icons.Filled.UnfoldMore,
-                            onClick = { showOsMapVariantPicker = true },
-                        )
-                    }
-                } else {
-                    item {
-                        SettingsPickerChip(
-                            label = "Style",
-                            secondaryLabel = selectedStyle?.name?.ifBlank { selectedStyle.id } ?: "-",
-                            iconImageVector = Icons.Filled.UnfoldMore,
-                            onClick = { showStylePicker = true },
-                        )
-                    }
-                }
-            }
-
-            if (nightModeToggle?.enabled != true && themeOptions.isNotEmpty()) {
+            } else {
                 item {
-                    Text(
-                        text = "Themes can misread terrain or paths. Verify with local conditions and other sources.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.error,
-                        modifier = Modifier.fillMaxWidth(),
-                        textAlign = TextAlign.Center,
+                    SettingsPickerChip(
+                        label = "Style",
+                        secondaryLabel = selectedStyle?.name?.ifBlank { selectedStyle.id } ?: "-",
+                        iconImageVector = Icons.Filled.UnfoldMore,
+                        onClick = { showStylePicker = true },
                     )
                 }
             }
+        }
 
-            if (nightModeToggle?.enabled != true && bundledThemeSelected && overlayOptions.isNotEmpty()) {
-                item {
-                    Text(
-                        text = "Overlays (tap group to open)",
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.onBackground,
-                        modifier = Modifier.fillMaxWidth(),
-                        textAlign = TextAlign.Center,
-                    )
-                }
-                items(overlayRows) { row ->
-                    when (row) {
-                        is OverlayRow.Group -> {
-                            val enabledCount = row.group.overlays.count { it.enabled }
-                            val totalCount = row.group.overlays.size
-                            SettingsPickerChip(
-                                label = if (row.expanded) "▾ ${row.group.title}" else "▸ ${row.group.title}",
-                                secondaryLabel = "$enabledCount/$totalCount",
-                                iconImageVector = null,
-                                onClick = {
-                                    expandedGroups[row.group.id] = !row.expanded
-                                },
-                            )
-                        }
+        if (nightModeToggle?.enabled != true && themeOptions.isNotEmpty()) {
+            item {
+                Text(
+                    text = "Themes can misread terrain or paths. Verify with local conditions and other sources.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
 
-                        is OverlayRow.Item -> {
-                            SettingsToggleChip(
-                                modifier = Modifier.fillMaxWidth(),
-                                enabled = canToggleOverlays,
-                                checked = row.overlay.enabled,
-                                onCheckedChanged = { _ ->
-                                    if (canToggleOverlays) {
-                                        themeViewModel.toggleOverlay(row.overlay.layerId)
-                                    }
-                                },
-                                label = row.overlay.name.ifBlank { row.overlay.layerId },
-                            )
-                        }
+        if (nightModeToggle?.enabled != true && bundledThemeSelected && overlayOptions.isNotEmpty()) {
+            item {
+                Text(
+                    text = "Overlays (tap group to open)",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center,
+                )
+            }
+            items(overlayRows) { row ->
+                when (row) {
+                    is OverlayRow.Group -> {
+                        val enabledCount = row.group.overlays.count { it.enabled }
+                        val totalCount = row.group.overlays.size
+                        SettingsPickerChip(
+                            label = if (row.expanded) "▾ ${row.group.title}" else "▸ ${row.group.title}",
+                            secondaryLabel = "$enabledCount/$totalCount",
+                            iconImageVector = null,
+                            onClick = {
+                                expandedGroups[row.group.id] = !row.expanded
+                            },
+                        )
+                    }
+
+                    is OverlayRow.Item -> {
+                        SettingsToggleChip(
+                            modifier = Modifier.fillMaxWidth(),
+                            enabled = canToggleOverlays,
+                            checked = row.overlay.enabled,
+                            onCheckedChanged = { _ ->
+                                if (canToggleOverlays) {
+                                    themeViewModel.toggleOverlay(row.overlay.layerId)
+                                }
+                            },
+                            label = row.overlay.name.ifBlank { row.overlay.layerId },
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/WearSettingsListScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/WearSettingsListScreen.kt
@@ -1,0 +1,43 @@
+@file:Suppress("FunctionName")
+
+package com.glancemap.glancemapwearos.presentation.features.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
+import androidx.wear.compose.foundation.lazy.ScalingLazyListScope
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.compose.layout.ScreenScaffold
+
+@OptIn(ExperimentalHorologistApi::class)
+@Composable
+internal fun WearSettingsListScreen(
+    listTokens: SettingsListTokens = rememberSettingsListTokens(),
+    horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
+    content: ScalingLazyListScope.() -> Unit,
+) {
+    val listState = rememberSettingsScalingLazyListState(topPadding = listTokens.topPadding)
+
+    ScreenScaffold(scrollState = listState) {
+        ScalingLazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            state = listState,
+            contentPadding =
+                PaddingValues(
+                    start = listTokens.horizontalPadding,
+                    end = listTokens.horizontalPadding,
+                    top = listTokens.topPadding,
+                    bottom = listTokens.bottomPadding,
+                ),
+            verticalArrangement = Arrangement.spacedBy(listTokens.itemSpacing),
+            anchorType = SettingsListAnchorType,
+            autoCentering = SettingsListAutoCentering,
+            horizontalAlignment = horizontalAlignment,
+            content = content,
+        )
+    }
+}

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/DeleteConfirmationDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/DeleteConfirmationDialog.kt
@@ -1,27 +1,8 @@
 package com.glancemap.glancemapwearos.presentation.ui
 
-import androidx.compose.foundation.focusable
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.input.rotary.onPreRotaryScrollEvent
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material3.AlertDialog
-import androidx.wear.compose.material3.Button
-import androidx.wear.compose.material3.ButtonDefaults
-import androidx.wear.compose.material3.MaterialTheme
-import androidx.wear.compose.material3.Text
-import kotlin.math.abs
 
 @Composable
 fun DeleteConfirmationDialog(
@@ -37,86 +18,16 @@ fun DeleteConfirmationDialog(
 ) {
     if (!visible) return
 
-    val adaptive = rememberWearAdaptiveSpec()
-    val scrollState = rememberScrollState()
-    val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(visible) {
-        if (visible) {
-            focusRequester.requestFocus()
-        }
-    }
-
-    AlertDialog(
+    WearActionDialog(
         visible = visible,
+        title = title,
+        message = message,
+        confirmText = confirmText,
+        onConfirm = onConfirm,
         onDismissRequest = onDismiss,
-        title = {
-            Text(
-                text = title,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth(),
-                style = MaterialTheme.typography.titleMedium,
-            )
-        },
-        text = {
-            Column(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = adaptive.dialogHorizontalPadding),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    WearDialogScrollableColumn(
-                        maxHeight = adaptive.dialogBodyMaxHeight,
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(top = messageTopPadding, bottom = messageBottomPadding),
-                        contentModifier =
-                            Modifier
-                                .onPreRotaryScrollEvent { event ->
-                                    val consumed = scrollState.dispatchRawDelta(event.verticalScrollPixels)
-                                    abs(consumed) > 0.5f
-                                }.focusRequester(focusRequester)
-                                .focusable(),
-                        scrollState = scrollState,
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        Text(
-                            text = message,
-                            textAlign = TextAlign.Center,
-                            style = MaterialTheme.typography.bodySmall,
-                        )
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            Button(
-                onClick = onConfirm,
-                colors =
-                    ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.errorContainer,
-                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
-                    ),
-            ) {
-                Text(confirmText)
-            }
-        },
-        dismissButton = {
-            Button(
-                onClick = onDismiss,
-                colors =
-                    ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                    ),
-            ) {
-                Text(dismissText)
-            }
-        },
+        dismissText = dismissText,
+        confirmRole = WearActionButtonRole.Destructive,
+        messageTopPadding = messageTopPadding,
+        messageBottomPadding = messageBottomPadding,
     )
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/RenameValueDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/RenameValueDialog.kt
@@ -11,7 +11,6 @@ package com.glancemap.glancemapwearos.presentation.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -34,6 +33,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -62,27 +62,13 @@ fun RenameValueDialog(
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
     val scrollState = rememberScrollState()
+    val textFieldVerticalPadding = 10.dp
     val maxDialogHeight =
         (
             adaptive.heightDp.dp -
                 adaptive.dialogVerticalPadding * 2 -
                 18.dp
         ).coerceAtLeast(132.dp)
-    val fullScreenTopPadding =
-        adaptive.dialogVerticalPadding +
-            adaptive.headerTopSafeInset +
-            if (adaptive.isRound) 14.dp else 0.dp
-    val fullScreenBottomPadding =
-        adaptive.dialogVerticalPadding +
-            if (adaptive.isRound) 42.dp else 12.dp
-    val fullScreenControlWidthFraction =
-        if (fullScreen && adaptive.isRound) {
-            0.86f
-        } else {
-            1f
-        }
-    val textFieldVerticalPadding = if (fullScreen) 8.dp else 10.dp
-    val buttonMinHeight = if (fullScreen) 44.dp else 48.dp
 
     LaunchedEffect(visible, isSaving) {
         if (visible && !isSaving && autoFocusInput) {
@@ -91,23 +77,34 @@ fun RenameValueDialog(
         }
     }
 
+    if (fullScreen) {
+        WearFormDialog(
+            visible = visible,
+            title = title,
+            onDismiss = onDismiss,
+        ) { formTokens ->
+            RenameValueFormContent(
+                draftValue = draftValue,
+                onDraftValueChange = { draftValue = it },
+                isSaving = isSaving,
+                error = error,
+                focusRequester = focusRequester,
+                textFieldVerticalPadding = formTokens.textFieldVerticalPadding,
+                controlModifier = formTokens.controlModifier,
+                buttonMinHeight = formTokens.buttonMinHeight,
+                onDismiss = onDismiss,
+                onConfirm = onConfirm,
+            )
+        }
+        return
+    }
+
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
-        val dialogModifier =
-            if (fullScreen) {
-                Modifier
-                    .fillMaxSize()
-                    .background(Color.Black)
-                    .verticalScroll(scrollState)
-                    .padding(
-                        horizontal = adaptive.dialogHorizontalPadding,
-                    ).padding(
-                        top = fullScreenTopPadding,
-                        bottom = fullScreenBottomPadding,
-                    )
-            } else {
+        Column(
+            modifier =
                 Modifier
                     .wearDialogWidth(
                         roundFraction = dialogWidthFraction,
@@ -119,18 +116,9 @@ fun RenameValueDialog(
                         horizontal = adaptive.dialogHorizontalPadding,
                         vertical = adaptive.dialogVerticalPadding,
                     ).heightIn(max = maxDialogHeight)
-                    .verticalScroll(scrollState)
-            }
-
-        Column(
-            modifier = dialogModifier,
+                    .verticalScroll(scrollState),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement =
-                if (fullScreen) {
-                    Arrangement.spacedBy(8.dp, Alignment.Top)
-                } else {
-                    Arrangement.spacedBy(6.dp)
-                },
+            verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             Text(
                 text = title,
@@ -150,7 +138,7 @@ fun RenameValueDialog(
                 cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
                 modifier =
                     Modifier
-                        .fillMaxWidth(fullScreenControlWidthFraction)
+                        .fillMaxWidth()
                         .focusRequester(focusRequester)
                         .background(
                             Color(0xFF1F1F1F),
@@ -183,8 +171,8 @@ fun RenameValueDialog(
                 onClick = { onConfirm(draftValue) },
                 modifier =
                     Modifier
-                        .fillMaxWidth(fullScreenControlWidthFraction)
-                        .heightIn(min = buttonMinHeight),
+                        .fillMaxWidth()
+                        .heightIn(min = 48.dp),
                 enabled = !isSaving,
             ) {
                 Text(if (isSaving) "Saving..." else "Save")
@@ -194,8 +182,8 @@ fun RenameValueDialog(
                 onClick = onDismiss,
                 modifier =
                     Modifier
-                        .fillMaxWidth(fullScreenControlWidthFraction)
-                        .heightIn(min = buttonMinHeight),
+                        .fillMaxWidth()
+                        .heightIn(min = 48.dp),
                 enabled = !isSaving,
                 colors =
                     ButtonDefaults.buttonColors(
@@ -206,5 +194,85 @@ fun RenameValueDialog(
                 Text("Cancel")
             }
         }
+    }
+}
+
+@Composable
+private fun RenameValueFormContent(
+    draftValue: String,
+    onDraftValueChange: (String) -> Unit,
+    isSaving: Boolean,
+    error: String?,
+    focusRequester: FocusRequester,
+    textFieldVerticalPadding: Dp,
+    controlModifier: Modifier,
+    buttonMinHeight: Dp,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    BasicTextField(
+        value = draftValue,
+        onValueChange = { onDraftValueChange(it.take(64)) },
+        singleLine = true,
+        textStyle =
+            TextStyle(
+                color = Color.White,
+                textAlign = TextAlign.Center,
+            ),
+        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+        modifier =
+            controlModifier
+                .focusRequester(focusRequester)
+                .background(
+                    Color(0xFF1F1F1F),
+                    RoundedCornerShape(12.dp),
+                ).padding(horizontal = 12.dp, vertical = textFieldVerticalPadding),
+        decorationBox = { innerTextField ->
+            if (draftValue.isBlank()) {
+                Text(
+                    text = "Enter name",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.White.copy(alpha = 0.45f),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            innerTextField()
+        },
+    )
+
+    error?.takeIf { it.isNotBlank() }?.let { message ->
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.error,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+
+    Button(
+        onClick = { onConfirm(draftValue) },
+        modifier =
+            controlModifier
+                .heightIn(min = buttonMinHeight),
+        enabled = !isSaving,
+    ) {
+        Text(if (isSaving) "Saving..." else "Save")
+    }
+
+    Button(
+        onClick = onDismiss,
+        modifier =
+            controlModifier
+                .heightIn(min = buttonMinHeight),
+        enabled = !isSaving,
+        colors =
+            ButtonDefaults.buttonColors(
+                containerColor = Color.White.copy(alpha = 0.12f),
+                contentColor = Color.White,
+            ),
+    ) {
+        Text("Cancel")
     }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearActionDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearActionDialog.kt
@@ -139,10 +139,17 @@ private fun WearActionSurface(
 ) {
     val adaptive = rememberWearAdaptiveSpec()
     val scrollState = rememberScrollState()
+    val highFontTopInset =
+        if (adaptive.isRound && adaptive.fontScale >= 1.25f) {
+            8.dp
+        } else {
+            0.dp
+        }
     val topPadding =
         adaptive.dialogVerticalPadding +
             adaptive.headerTopSafeInset +
-            if (adaptive.isRound) 18.dp else 0.dp
+            (if (adaptive.isRound) 18.dp else 0.dp) +
+            highFontTopInset
     val bottomPadding =
         adaptive.dialogVerticalPadding +
             if (adaptive.isRound) 42.dp else 12.dp
@@ -164,23 +171,25 @@ private fun WearActionSurface(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top),
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleSmall,
-                textAlign = TextAlign.Center,
-            )
-            content()
-            buttons.forEach { button ->
-                Button(
-                    onClick = button.onClick,
-                    enabled = button.enabled,
-                    colors = actionButtonColors(button.role),
-                    modifier =
-                        Modifier
-                            .fillMaxWidth(controlWidthFraction)
-                            .heightIn(min = 44.dp),
-                ) {
-                    Text(button.text)
+            cappedFontScale(maxFontScale = 1.12f) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    textAlign = TextAlign.Center,
+                )
+                content()
+                buttons.forEach { button ->
+                    Button(
+                        onClick = button.onClick,
+                        enabled = button.enabled,
+                        colors = actionButtonColors(button.role),
+                        modifier =
+                            Modifier
+                                .fillMaxWidth(controlWidthFraction)
+                                .heightIn(min = 44.dp),
+                    ) {
+                        Text(button.text)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearActionDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearActionDialog.kt
@@ -1,0 +1,205 @@
+@file:Suppress("FunctionName", "LongParameterList", "MatchingDeclarationName")
+
+package com.glancemap.glancemapwearos.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+
+enum class WearActionButtonRole {
+    Primary,
+    Secondary,
+    Destructive,
+}
+
+data class WearActionDialogButton(
+    val text: String,
+    val onClick: () -> Unit,
+    val enabled: Boolean = true,
+    val role: WearActionButtonRole = WearActionButtonRole.Primary,
+)
+
+@Composable
+fun WearActionDialog(
+    visible: Boolean,
+    title: String,
+    message: String,
+    confirmText: String,
+    onConfirm: () -> Unit,
+    onDismissRequest: () -> Unit,
+    dismissText: String? = null,
+    onDismiss: () -> Unit = onDismissRequest,
+    confirmEnabled: Boolean = true,
+    dismissEnabled: Boolean = true,
+    confirmRole: WearActionButtonRole = WearActionButtonRole.Primary,
+    messageTopPadding: Dp = 0.dp,
+    messageBottomPadding: Dp = 0.dp,
+) {
+    WearActionDialog(
+        visible = visible,
+        title = title,
+        onDismissRequest = onDismissRequest,
+        buttons =
+            buildList {
+                add(
+                    WearActionDialogButton(
+                        text = confirmText,
+                        onClick = onConfirm,
+                        enabled = confirmEnabled,
+                        role = confirmRole,
+                    ),
+                )
+                if (dismissText != null) {
+                    add(
+                        WearActionDialogButton(
+                            text = dismissText,
+                            onClick = onDismiss,
+                            enabled = dismissEnabled,
+                            role = WearActionButtonRole.Secondary,
+                        ),
+                    )
+                }
+            },
+    ) {
+        Text(
+            text = message,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(top = messageTopPadding, bottom = messageBottomPadding),
+        )
+    }
+}
+
+@Composable
+fun WearActionDialog(
+    visible: Boolean,
+    title: String,
+    onDismissRequest: () -> Unit,
+    buttons: List<WearActionDialogButton>,
+    backgroundColor: Color = Color.Black,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    if (!visible) return
+
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        WearActionSurface(
+            title = title,
+            buttons = buttons,
+            backgroundColor = backgroundColor,
+            content = content,
+        )
+    }
+}
+
+@Composable
+fun WearActionScreen(
+    title: String,
+    buttons: List<WearActionDialogButton>,
+    backgroundColor: Color = Color.Black,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    WearActionSurface(
+        title = title,
+        buttons = buttons,
+        backgroundColor = backgroundColor,
+        content = content,
+    )
+}
+
+@Composable
+private fun WearActionSurface(
+    title: String,
+    buttons: List<WearActionDialogButton>,
+    backgroundColor: Color,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val adaptive = rememberWearAdaptiveSpec()
+    val scrollState = rememberScrollState()
+    val topPadding =
+        adaptive.dialogVerticalPadding +
+            adaptive.headerTopSafeInset +
+            if (adaptive.isRound) 18.dp else 0.dp
+    val bottomPadding =
+        adaptive.dialogVerticalPadding +
+            if (adaptive.isRound) 42.dp else 12.dp
+    val controlWidthFraction = if (adaptive.isRound) 0.86f else 1f
+
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(backgroundColor),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .verticalScroll(scrollState)
+                    .padding(horizontal = adaptive.dialogHorizontalPadding)
+                    .padding(top = topPadding, bottom = bottomPadding),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                textAlign = TextAlign.Center,
+            )
+            content()
+            buttons.forEach { button ->
+                Button(
+                    onClick = button.onClick,
+                    enabled = button.enabled,
+                    colors = actionButtonColors(button.role),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth(controlWidthFraction)
+                            .heightIn(min = 44.dp),
+                ) {
+                    Text(button.text)
+                }
+            }
+        }
+        WearScreenEdgeScrollIndicator(scrollState = scrollState)
+    }
+}
+
+@Composable
+private fun actionButtonColors(role: WearActionButtonRole) =
+    when (role) {
+        WearActionButtonRole.Primary -> ButtonDefaults.buttonColors()
+        WearActionButtonRole.Secondary ->
+            ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        WearActionButtonRole.Destructive ->
+            ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.errorContainer,
+                contentColor = MaterialTheme.colorScheme.onErrorContainer,
+            )
+    }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearFormDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearFormDialog.kt
@@ -1,0 +1,90 @@
+@file:Suppress("FunctionName", "MatchingDeclarationName")
+
+package com.glancemap.glancemapwearos.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+
+data class WearFormDialogTokens(
+    val controlModifier: Modifier,
+    val buttonMinHeight: Dp,
+    val textFieldVerticalPadding: Dp,
+)
+
+@Composable
+fun WearFormDialog(
+    visible: Boolean,
+    title: String,
+    onDismiss: () -> Unit,
+    backgroundColor: Color = Color.Black,
+    content: @Composable ColumnScope.(WearFormDialogTokens) -> Unit,
+) {
+    if (!visible) return
+
+    val adaptive = rememberWearAdaptiveSpec()
+    val scrollState = rememberScrollState()
+    val topPadding =
+        adaptive.dialogVerticalPadding +
+            adaptive.headerTopSafeInset +
+            if (adaptive.isRound) 18.dp else 0.dp
+    val bottomPadding =
+        adaptive.dialogVerticalPadding +
+            if (adaptive.isRound) 42.dp else 12.dp
+    val controlWidthFraction = if (adaptive.isRound) 0.86f else 1f
+    val tokens =
+        WearFormDialogTokens(
+            controlModifier = Modifier.fillMaxWidth(controlWidthFraction),
+            buttonMinHeight = 44.dp,
+            textFieldVerticalPadding = 10.dp,
+        )
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(backgroundColor),
+        ) {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .verticalScroll(scrollState)
+                        .padding(horizontal = adaptive.dialogHorizontalPadding)
+                        .padding(top = topPadding, bottom = bottomPadding),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top),
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    textAlign = TextAlign.Center,
+                )
+                content(tokens)
+            }
+            WearScreenEdgeScrollIndicator(scrollState = scrollState)
+        }
+    }
+}

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearFormDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearFormDialog.kt
@@ -42,10 +42,17 @@ fun WearFormDialog(
 
     val adaptive = rememberWearAdaptiveSpec()
     val scrollState = rememberScrollState()
+    val highFontTopInset =
+        if (adaptive.isRound && adaptive.fontScale >= 1.25f) {
+            8.dp
+        } else {
+            0.dp
+        }
     val topPadding =
         adaptive.dialogVerticalPadding +
             adaptive.headerTopSafeInset +
-            if (adaptive.isRound) 18.dp else 0.dp
+            (if (adaptive.isRound) 18.dp else 0.dp) +
+            highFontTopInset
     val bottomPadding =
         adaptive.dialogVerticalPadding +
             if (adaptive.isRound) 42.dp else 12.dp
@@ -77,12 +84,14 @@ fun WearFormDialog(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top),
             ) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleSmall,
-                    textAlign = TextAlign.Center,
-                )
-                content(tokens)
+                cappedFontScale(maxFontScale = 1.12f) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleSmall,
+                        textAlign = TextAlign.Center,
+                    )
+                    content(tokens)
+                }
             }
             WearScreenEdgeScrollIndicator(scrollState = scrollState)
         }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearInfoDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearInfoDialog.kt
@@ -1,0 +1,150 @@
+@file:Suppress("FunctionName", "LongMethod")
+
+package com.glancemap.glancemapwearos.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.rotary.onPreRotaryScrollEvent
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import kotlin.math.abs
+
+private const val INFO_DIALOG_DRAG_DISMISS_PX = 55f
+
+@Composable
+fun WearInfoDialog(
+    visible: Boolean,
+    title: String,
+    onDismiss: () -> Unit,
+    dismissible: Boolean = true,
+    content: LazyListScope.() -> Unit,
+) {
+    if (!visible) return
+
+    val adaptive = rememberWearAdaptiveSpec()
+    val listState = rememberLazyListState()
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(visible, title) {
+        focusRequester.requestFocus()
+    }
+
+    Dialog(
+        onDismissRequest = {
+            if (dismissible) {
+                onDismiss()
+            }
+        },
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.82f)),
+        ) {
+            LazyColumn(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .onPreRotaryScrollEvent { event ->
+                            val consumed = listState.dispatchRawDelta(event.verticalScrollPixels)
+                            abs(consumed) > 0.5f
+                        }.focusRequester(focusRequester)
+                        .focusable(),
+                state = listState,
+                contentPadding =
+                    PaddingValues(
+                        start = adaptive.dialogHorizontalPadding,
+                        top = adaptive.dialogVerticalPadding + adaptive.headerTopSafeInset + 18.dp,
+                        end = adaptive.dialogHorizontalPadding + 10.dp,
+                        bottom = adaptive.dialogVerticalPadding + if (adaptive.isRound) 42.dp else 18.dp,
+                    ),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                userScrollEnabled = true,
+            ) {
+                item {
+                    InfoDialogDragHandle(
+                        dismissible = dismissible,
+                        onDismiss = onDismiss,
+                    )
+                }
+                item {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleLarge,
+                        textAlign = TextAlign.Center,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 6.dp),
+                    )
+                }
+                content()
+            }
+            WearLazyListScreenEdgeScrollIndicator(listState = listState)
+        }
+    }
+}
+
+@Composable
+private fun InfoDialogDragHandle(
+    dismissible: Boolean,
+    onDismiss: () -> Unit,
+) {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(12.dp)
+                .pointerInput(dismissible) {
+                    if (!dismissible) return@pointerInput
+                    var totalDrag = 0f
+                    detectVerticalDragGestures(
+                        onDragEnd = { totalDrag = 0f },
+                        onDragCancel = { totalDrag = 0f },
+                    ) { _, dragAmount ->
+                        totalDrag += dragAmount
+                        if (totalDrag > INFO_DIALOG_DRAG_DISMISS_PX) {
+                            onDismiss()
+                            totalDrag = 0f
+                        }
+                    }
+                },
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .width(26.dp)
+                    .height(3.dp)
+                    .background(Color.White.copy(alpha = 0.42f), RoundedCornerShape(50)),
+        )
+    }
+}

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearToolPanelDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearToolPanelDialog.kt
@@ -1,0 +1,140 @@
+@file:Suppress("FunctionName", "MatchingDeclarationName")
+
+package com.glancemap.glancemapwearos.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+
+private const val TOOL_PANEL_DRAG_DISMISS_PX = 55f
+
+@Composable
+fun WearToolPanelDialog(
+    visible: Boolean,
+    title: String,
+    onDismiss: () -> Unit,
+    backgroundColor: Color = Color.Black.copy(alpha = 0.86f),
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    if (!visible) return
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        WearToolPanelSurface(
+            title = title,
+            onDismiss = onDismiss,
+            backgroundColor = backgroundColor,
+            content = content,
+        )
+    }
+}
+
+@Composable
+private fun WearToolPanelSurface(
+    title: String,
+    onDismiss: () -> Unit,
+    backgroundColor: Color,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val adaptive = rememberWearAdaptiveSpec()
+    val scrollState = rememberScrollState()
+    val highFontTopInset =
+        if (adaptive.isRound && adaptive.fontScale >= 1.25f) {
+            8.dp
+        } else {
+            0.dp
+        }
+    val topPadding =
+        adaptive.dialogVerticalPadding +
+            adaptive.headerTopSafeInset +
+            (if (adaptive.isRound) 10.dp else 0.dp) +
+            highFontTopInset
+    val bottomPadding =
+        adaptive.dialogVerticalPadding +
+            if (adaptive.isRound) 34.dp else 12.dp
+
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(backgroundColor),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .verticalScroll(scrollState)
+                    .padding(horizontal = adaptive.dialogHorizontalPadding)
+                    .padding(top = topPadding, bottom = bottomPadding),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top),
+        ) {
+            ToolPanelDragHandle(onDismiss = onDismiss)
+
+            cappedFontScale(maxFontScale = 1.12f) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    textAlign = TextAlign.Center,
+                )
+                content()
+            }
+        }
+        WearScreenEdgeScrollIndicator(scrollState = scrollState)
+    }
+}
+
+@Composable
+private fun ToolPanelDragHandle(onDismiss: () -> Unit) {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .pointerInput(Unit) {
+                    var totalDrag = 0f
+                    detectVerticalDragGestures(
+                        onDragEnd = { totalDrag = 0f },
+                        onDragCancel = { totalDrag = 0f },
+                    ) { _, dragAmount ->
+                        totalDrag += dragAmount
+                        if (totalDrag > TOOL_PANEL_DRAG_DISMISS_PX) {
+                            onDismiss()
+                            totalDrag = 0f
+                        }
+                    }
+                },
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .width(26.dp)
+                    .height(3.dp)
+                    .background(Color.White.copy(alpha = 0.42f), RoundedCornerShape(50)),
+        )
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,8 +35,8 @@ android.r8.strictFullModeForKeepRules=false
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
 glanceMapVersionName=1.1.2
-glanceMapWearVersionCode=1019
-glanceMapPhoneVersionCode=2017
+glanceMapWearVersionCode=1020
+glanceMapPhoneVersionCode=2018
 
 # Elevate theme build-time sync (download -> generated assets -> packaged in APK)
 elevateThemeVersion=5.6


### PR DESCRIPTION
## Summary
- move GPX Tools to a full-screen scroll-owned tool panel so the controls can use more of the watch face
- stack the GPX Tools Create/Modify selector at large font on round displays
- add safer top padding and capped scaling to the shared form dialog used by rename/search-style popups

## Verification
- ./gradlew :app:ktlintFormat --no-daemon --console=plain
- ./gradlew :app:compileDebugKotlin :app:detekt :app:ktlintCheck --no-daemon --console=plain