### PR TITLE
[codex] Improve Wear dialog safety for Play compliance

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxScreen.kt
@@ -265,6 +265,7 @@ fun GpxScreen(
             initialValue = fileToRename?.displayTitle.orEmpty(),
             isSaving = renameInProgress,
             error = renameError,
+            fullScreen = true,
             onDismiss = {
                 if (!renameInProgress) {
                     showRenameDialog = false

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
@@ -21,12 +21,9 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.lazy.items as foundationItems
-import androidx.compose.foundation.lazy.itemsIndexed as foundationItemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.CallSplit
 import androidx.compose.material.icons.filled.Check
@@ -83,6 +80,8 @@ import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
 import kotlinx.coroutines.delay
 import java.util.Locale
+import androidx.compose.foundation.lazy.items as foundationItems
+import androidx.compose.foundation.lazy.itemsIndexed as foundationItemsIndexed
 
 private val MAP_DATA_BADGE_SIZE = 26.dp
 private val MAP_DATA_ICON_SIZE = 15.dp

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.lazy.items as foundationItems
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.CallSplit
 import androidx.compose.material.icons.filled.Check
@@ -55,12 +56,9 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.wear.compose.foundation.lazy.items
-import androidx.wear.compose.material3.AlertDialog
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.Icon
-import androidx.wear.compose.material3.IconButton
-import androidx.wear.compose.material3.IconButtonDefaults
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.SwitchButton
 import androidx.wear.compose.material3.Text
@@ -73,8 +71,7 @@ import com.glancemap.glancemapwearos.presentation.ui.CompactIconHitTargetButton
 import com.glancemap.glancemapwearos.presentation.ui.DeleteConfirmationDialog
 import com.glancemap.glancemapwearos.presentation.ui.RenameValueDialog
 import com.glancemap.glancemapwearos.presentation.ui.WearActionDialog
-import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollBottomSpacer
-import com.glancemap.glancemapwearos.presentation.ui.WearDialogScrollableColumn
+import com.glancemap.glancemapwearos.presentation.ui.WearDataDialog
 import com.glancemap.glancemapwearos.presentation.ui.WearInfoDialog
 import com.glancemap.glancemapwearos.presentation.ui.WearScreenSize
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
@@ -326,6 +323,7 @@ fun MapsScreen(
             initialValue = mapToRename?.name?.substringBeforeLast(".map") ?: "",
             isSaving = renameInProgress,
             error = renameError,
+            fullScreen = true,
             onDismiss = {
                 if (!renameInProgress) {
                     showRenameDialog = false
@@ -415,152 +413,141 @@ fun MapsScreen(
             onDismiss = { showDeleteAllRoutingDialog = false },
         )
 
-        AlertDialog(
+        WearDataDialog(
             visible = showRoutingDataDialog,
-            onDismissRequest = { showRoutingDataDialog = false },
-            edgeButton = {
+            title = "Routing data",
+            onDismiss = { showRoutingDataDialog = false },
+            bottomAction =
                 if (routingPackFiles.isNotEmpty()) {
-                    CompactIconHitTargetButton(
-                        onClick = { showDeleteAllRoutingDialog = true },
-                        modifier = Modifier.offset(y = (-16).dp),
-                        visualSize = 32.dp,
-                        visualOffsetY = (-2).dp,
-                        containerColor = MaterialTheme.colorScheme.errorContainer,
-                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Delete,
-                            contentDescription = "Delete all routing packs",
-                            modifier = Modifier.size(15.dp),
-                        )
-                    }
-                }
-            },
-            title = { Text("Routing data") },
-            text = {
-                WearDialogScrollableColumn(
-                    maxHeight = adaptive.helpDialogMaxHeight,
-                    modifier =
-                        Modifier
-                            .fillMaxWidth(),
-                    scrollable = false,
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Text(
-                        text = routingPackSummary(routingPackFiles),
-                        style = MaterialTheme.typography.bodySmall,
-                        textAlign = TextAlign.Center,
-                    )
-                    if (routingPackFiles.isEmpty()) {
-                        Text(
-                            text = "No routing packs installed on the watch.",
-                            style = MaterialTheme.typography.bodySmall,
-                            textAlign = TextAlign.Center,
-                        )
-                    } else {
-                        routingPackFiles.forEach { pack ->
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            ) {
-                                Column(
-                                    modifier = Modifier.weight(1f),
-                                    horizontalAlignment = Alignment.Start,
-                                ) {
-                                    Text(
-                                        text = pack.name,
-                                        style = MaterialTheme.typography.labelMedium,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                    )
-                                    Text(
-                                        text = formatRoutingStorageSize(pack.sizeBytes),
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = Color.White.copy(alpha = 0.68f),
-                                    )
-                                }
-                                IconButton(
-                                    onClick = { routingPackToDelete = pack },
-                                    modifier = Modifier.size(26.dp),
-                                    colors =
-                                        IconButtonDefaults.iconButtonColors(
-                                            containerColor = MaterialTheme.colorScheme.errorContainer,
-                                            contentColor = MaterialTheme.colorScheme.onErrorContainer,
-                                        ),
-                                ) {
-                                    Icon(
-                                        imageVector = Icons.Default.Delete,
-                                        contentDescription = "Delete routing pack",
-                                        modifier = Modifier.size(14.dp),
-                                    )
-                                }
-                            }
+                    {
+                        CompactIconHitTargetButton(
+                            onClick = { showDeleteAllRoutingDialog = true },
+                            visualSize = 32.dp,
+                            visualOffsetY = (-2).dp,
+                            containerColor = MaterialTheme.colorScheme.errorContainer,
+                            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Delete,
+                                contentDescription = "Delete all routing packs",
+                                modifier = Modifier.size(15.dp),
+                            )
                         }
                     }
-                    WearDialogScrollBottomSpacer()
-                }
-            },
-        )
-
-        AlertDialog(
-            visible = showDemDataDialog,
-            onDismissRequest = { showDemDataDialog = false },
-            title = { Text("Elevation data") },
-            content = {
+                } else {
+                    null
+                },
+        ) {
+            item {
+                Text(
+                    text = routingPackSummary(routingPackFiles),
+                    style = MaterialTheme.typography.bodySmall,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            if (routingPackFiles.isEmpty()) {
                 item {
                     Text(
-                        text = "Used for hill shading, slope and altitude.",
+                        text = "No routing packs installed on the watch.",
                         style = MaterialTheme.typography.bodySmall,
                         textAlign = TextAlign.Center,
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }
+            } else {
+                foundationItems(routingPackFiles) { pack ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            horizontalAlignment = Alignment.Start,
+                        ) {
+                            Text(
+                                text = pack.name,
+                                style = MaterialTheme.typography.labelMedium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Text(
+                                text = formatRoutingStorageSize(pack.sizeBytes),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.White.copy(alpha = 0.68f),
+                            )
+                        }
+                        CompactIconHitTargetButton(
+                            onClick = { routingPackToDelete = pack },
+                            visualSize = 26.dp,
+                            containerColor = MaterialTheme.colorScheme.errorContainer,
+                            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Delete,
+                                contentDescription = "Delete routing pack",
+                                modifier = Modifier.size(14.dp),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        WearDataDialog(
+            visible = showDemDataDialog,
+            title = "Elevation data",
+            onDismiss = { showDemDataDialog = false },
+        ) {
+            item {
+                Text(
+                    text = "Used for hill shading, slope and altitude.",
+                    style = MaterialTheme.typography.bodySmall,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            item {
+                Text(
+                    text = "Choose quality for new elevation downloads.",
+                    style = MaterialTheme.typography.labelMedium,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            foundationItems(DemSource.entries) { source ->
+                DemQualityChoiceRow(
+                    source = source,
+                    selected = selectedDemSource == source,
+                    onSelect = { themeViewModel.setDemSource(source) },
+                )
+            }
+            foundationItems(DemSource.entries) { source ->
+                val files = demTileFiles.filter { it.source == source }
+                DemStorageSummaryRow(
+                    source = source,
+                    files = files,
+                    onDeleteAll = { demSourceToDeleteAll = source },
+                )
+            }
+            if (mapFiles.isNotEmpty()) {
                 item {
                     Text(
-                        text = "Choose quality for new elevation downloads.",
+                        text = "Map coverage",
                         style = MaterialTheme.typography.labelMedium,
                         textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(top = 2.dp),
                     )
                 }
-                items(DemSource.entries) { source ->
-                    DemQualityChoiceRow(
-                        source = source,
-                        selected = selectedDemSource == source,
-                        onSelect = { themeViewModel.setDemSource(source) },
-                    )
+                foundationItems(mapFiles) { mapFile ->
+                    DemMapCoverageRow(mapFile = mapFile)
                 }
-                items(DemSource.entries) { source ->
-                    val files = demTileFiles.filter { it.source == source }
-                    DemStorageSummaryRow(
-                        source = source,
-                        files = files,
-                        onDeleteAll = { demSourceToDeleteAll = source },
-                    )
-                }
-                if (mapFiles.isNotEmpty()) {
-                    item {
-                        Text(
-                            text = "Map coverage",
-                            style = MaterialTheme.typography.labelMedium,
-                            textAlign = TextAlign.Center,
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .padding(top = 2.dp),
-                        )
-                    }
-                    items(mapFiles) { mapFile ->
-                        DemMapCoverageRow(mapFile = mapFile)
-                    }
-                }
-                item {
-                    WearDialogScrollBottomSpacer()
-                }
-            },
-        )
+            }
+        }
 
         WearInfoDialog(
             visible = showHelpDialog,
@@ -1198,14 +1185,11 @@ private fun DemStorageSummaryRow(
             )
         }
         if (files.isNotEmpty()) {
-            IconButton(
+            CompactIconHitTargetButton(
                 onClick = onDeleteAll,
-                modifier = Modifier.size(24.dp),
-                colors =
-                    IconButtonDefaults.iconButtonColors(
-                        containerColor = MaterialTheme.colorScheme.errorContainer,
-                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
-                    ),
+                visualSize = 24.dp,
+                containerColor = MaterialTheme.colorScheme.errorContainer,
+                contentColor = MaterialTheme.colorScheme.onErrorContainer,
             ) {
                 Icon(
                     imageVector = Icons.Default.Delete,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.items as foundationItems
+import androidx.compose.foundation.lazy.itemsIndexed as foundationItemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.CallSplit
 import androidx.compose.material.icons.filled.Check
@@ -516,11 +517,12 @@ fun MapsScreen(
                     modifier = Modifier.fillMaxWidth(),
                 )
             }
-            foundationItems(DemSource.entries) { source ->
+            foundationItemsIndexed(DemSource.entries) { index, source ->
                 DemQualityChoiceRow(
                     source = source,
                     selected = selectedDemSource == source,
                     onSelect = { themeViewModel.setDemSource(source) },
+                    modifier = Modifier.padding(top = if (index == 0) 0.dp else 6.dp),
                 )
             }
             foundationItems(DemSource.entries) { source ->
@@ -1106,10 +1108,11 @@ private fun DemQualityChoiceRow(
     source: DemSource,
     selected: Boolean,
     onSelect: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Button(
         onClick = onSelect,
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         colors =
             if (selected) {
                 ButtonDefaults.buttonColors(

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/CompassRecalibrationDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/CompassRecalibrationDialog.kt
@@ -407,7 +407,11 @@ fun CompassRecalibrationDialog(
                     text = "Recalibrate Compass",
                     fontSize = tokens.titleFontSize,
                     fontWeight = FontWeight.Bold,
-                    modifier = Modifier.padding(top = tokens.titleTopPadding),
+                    textAlign = TextAlign.Center,
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(top = tokens.titleTopPadding),
                 )
 
                 Text(

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/CompassRecalibrationDialogSupport.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/CompassRecalibrationDialogSupport.kt
@@ -97,7 +97,7 @@ internal fun rememberCompassRecalibrationDialogTokens(): CompassRecalibrationDia
             WearWindowClass.COMPACT ->
                 CompassRecalibrationDialogTokens(
                     viewportVerticalInset = if (adaptive.isRound) 10.dp else 0.dp,
-                    titleTopPadding = if (adaptive.isRound) 6.dp else 0.dp,
+                    titleTopPadding = if (adaptive.isRound) 12.dp else 0.dp,
                     dialogWidthFraction = if (adaptive.isRound) 0.88f else 0.94f,
                     dialogContentSpacing = 4.dp,
                     dialogHorizontalPadding = 8.dp,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearActionDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearActionDialog.kt
@@ -154,6 +154,19 @@ private fun WearActionSurface(
         adaptive.dialogVerticalPadding +
             if (adaptive.isRound) 42.dp else 12.dp
     val controlWidthFraction = if (adaptive.isRound) 0.86f else 1f
+    val textWidthFraction =
+        when {
+            !adaptive.isRound -> 1f
+            adaptive.fontScale >= 1.45f -> 0.72f
+            adaptive.fontScale >= 1.25f -> 0.78f
+            else -> 0.86f
+        }
+    val actionFontScaleCap =
+        if (adaptive.isRound && adaptive.fontScale >= 1.25f) {
+            1.0f
+        } else {
+            1.12f
+        }
 
     Box(
         modifier =
@@ -171,13 +184,20 @@ private fun WearActionSurface(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top),
         ) {
-            cappedFontScale(maxFontScale = 1.12f) {
+            cappedFontScale(maxFontScale = actionFontScaleCap) {
                 Text(
                     text = title,
                     style = MaterialTheme.typography.titleSmall,
                     textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(textWidthFraction),
                 )
-                content()
+                Column(
+                    modifier = Modifier.fillMaxWidth(textWidthFraction),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    content()
+                }
                 buttons.forEach { button ->
                     Button(
                         onClick = button.onClick,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearActionDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearActionDialog.kt
@@ -137,36 +137,8 @@ private fun WearActionSurface(
     backgroundColor: Color,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    val adaptive = rememberWearAdaptiveSpec()
     val scrollState = rememberScrollState()
-    val highFontTopInset =
-        if (adaptive.isRound && adaptive.fontScale >= 1.25f) {
-            8.dp
-        } else {
-            0.dp
-        }
-    val topPadding =
-        adaptive.dialogVerticalPadding +
-            adaptive.headerTopSafeInset +
-            (if (adaptive.isRound) 18.dp else 0.dp) +
-            highFontTopInset
-    val bottomPadding =
-        adaptive.dialogVerticalPadding +
-            if (adaptive.isRound) 42.dp else 12.dp
-    val controlWidthFraction = if (adaptive.isRound) 0.86f else 1f
-    val textWidthFraction =
-        when {
-            !adaptive.isRound -> 1f
-            adaptive.fontScale >= 1.45f -> 0.72f
-            adaptive.fontScale >= 1.25f -> 0.78f
-            else -> 0.86f
-        }
-    val actionFontScaleCap =
-        if (adaptive.isRound && adaptive.fontScale >= 1.25f) {
-            1.0f
-        } else {
-            1.12f
-        }
+    val metrics = rememberWearActionLayoutMetrics()
 
     Box(
         modifier =
@@ -179,41 +151,93 @@ private fun WearActionSurface(
                 Modifier
                     .fillMaxSize()
                     .verticalScroll(scrollState)
-                    .padding(horizontal = adaptive.dialogHorizontalPadding)
-                    .padding(top = topPadding, bottom = bottomPadding),
+                    .padding(horizontal = metrics.horizontalPadding)
+                    .padding(top = metrics.topPadding, bottom = metrics.bottomPadding),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top),
         ) {
-            cappedFontScale(maxFontScale = actionFontScaleCap) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleSmall,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth(textWidthFraction),
-                )
-                Column(
-                    modifier = Modifier.fillMaxWidth(textWidthFraction),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    content()
-                }
-                buttons.forEach { button ->
-                    Button(
-                        onClick = button.onClick,
-                        enabled = button.enabled,
-                        colors = actionButtonColors(button.role),
-                        modifier =
-                            Modifier
-                                .fillMaxWidth(controlWidthFraction)
-                                .heightIn(min = 44.dp),
-                    ) {
-                        Text(button.text)
-                    }
-                }
-            }
+            WearActionContent(title = title, buttons = buttons, metrics = metrics, content = content)
         }
         WearScreenEdgeScrollIndicator(scrollState = scrollState)
+    }
+}
+
+private data class WearActionLayoutMetrics(
+    val horizontalPadding: Dp,
+    val topPadding: Dp,
+    val bottomPadding: Dp,
+    val controlWidthFraction: Float,
+    val textWidthFraction: Float,
+    val actionFontScaleCap: Float,
+)
+
+@Composable
+private fun rememberWearActionLayoutMetrics(): WearActionLayoutMetrics {
+    val adaptive = rememberWearAdaptiveSpec()
+    val highFontTopInset = if (adaptive.isRound && adaptive.fontScale >= 1.25f) 8.dp else 0.dp
+    val textWidthFraction =
+        when {
+            !adaptive.isRound -> 1f
+            adaptive.fontScale >= 1.45f -> 0.72f
+            adaptive.fontScale >= 1.25f -> 0.78f
+            else -> 0.86f
+        }
+    return WearActionLayoutMetrics(
+        horizontalPadding = adaptive.dialogHorizontalPadding,
+        topPadding =
+            adaptive.dialogVerticalPadding +
+                adaptive.headerTopSafeInset +
+                (if (adaptive.isRound) 18.dp else 0.dp) +
+                highFontTopInset,
+        bottomPadding = adaptive.dialogVerticalPadding + if (adaptive.isRound) 42.dp else 12.dp,
+        controlWidthFraction = if (adaptive.isRound) 0.86f else 1f,
+        textWidthFraction = textWidthFraction,
+        actionFontScaleCap = if (adaptive.isRound && adaptive.fontScale >= 1.25f) 1.0f else 1.12f,
+    )
+}
+
+@Composable
+private fun ColumnScope.WearActionContent(
+    title: String,
+    buttons: List<WearActionDialogButton>,
+    metrics: WearActionLayoutMetrics,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    cappedFontScale(maxFontScale = metrics.actionFontScaleCap) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleSmall,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(metrics.textWidthFraction),
+        )
+        Column(
+            modifier = Modifier.fillMaxWidth(metrics.textWidthFraction),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            content()
+        }
+        buttons.forEach { button ->
+            WearActionButton(button = button, widthFraction = metrics.controlWidthFraction)
+        }
+    }
+}
+
+@Composable
+private fun WearActionButton(
+    button: WearActionDialogButton,
+    widthFraction: Float,
+) {
+    Button(
+        onClick = button.onClick,
+        enabled = button.enabled,
+        colors = actionButtonColors(button.role),
+        modifier =
+            Modifier
+                .fillMaxWidth(widthFraction)
+                .heightIn(min = 44.dp),
+    ) {
+        Text(button.text)
     }
 }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearDataDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearDataDialog.kt
@@ -1,0 +1,163 @@
+@file:Suppress("FunctionName")
+
+package com.glancemap.glancemapwearos.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.rotary.onPreRotaryScrollEvent
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import kotlinx.coroutines.launch
+import kotlin.math.abs
+
+private const val DATA_DIALOG_DRAG_DISMISS_PX = 55f
+
+@Composable
+fun WearDataDialog(
+    visible: Boolean,
+    title: String,
+    onDismiss: () -> Unit,
+    bottomAction: (@Composable BoxScope.() -> Unit)? = null,
+    content: LazyListScope.() -> Unit,
+) {
+    if (!visible) return
+
+    val adaptive = rememberWearAdaptiveSpec()
+    val listState = rememberLazyListState()
+    val focusRequester = remember { FocusRequester() }
+    val coroutineScope = rememberCoroutineScope()
+    LaunchedEffect(visible, title) {
+        focusRequester.requestFocus()
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.82f)),
+        ) {
+            LazyColumn(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .onPreRotaryScrollEvent { event ->
+                            coroutineScope.launch {
+                                listState.scrollBy(event.verticalScrollPixels)
+                            }
+                            abs(event.verticalScrollPixels) > 0.5f
+                        }.focusRequester(focusRequester)
+                        .focusable(),
+                state = listState,
+                contentPadding =
+                    PaddingValues(
+                        start = adaptive.dialogHorizontalPadding,
+                        top = adaptive.dialogVerticalPadding + adaptive.headerTopSafeInset + 18.dp,
+                        end = adaptive.dialogHorizontalPadding + 10.dp,
+                        bottom =
+                            adaptive.dialogVerticalPadding +
+                                if (bottomAction != null) {
+                                    76.dp
+                                } else if (adaptive.isRound) {
+                                    42.dp
+                                } else {
+                                    18.dp
+                                },
+                    ),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                item {
+                    DataDialogDragHandle(onDismiss = onDismiss)
+                }
+                item {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleLarge,
+                        textAlign = TextAlign.Center,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 6.dp),
+                    )
+                }
+                content()
+            }
+
+            WearLazyListScreenEdgeScrollIndicator(listState = listState)
+
+            if (bottomAction != null) {
+                Box(
+                    modifier =
+                        Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(bottom = adaptive.dialogVerticalPadding + 14.dp),
+                    contentAlignment = Alignment.Center,
+                    content = bottomAction,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DataDialogDragHandle(onDismiss: () -> Unit) {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(12.dp)
+                .pointerInput(Unit) {
+                    var totalDrag = 0f
+                    detectVerticalDragGestures(
+                        onDragEnd = { totalDrag = 0f },
+                        onDragCancel = { totalDrag = 0f },
+                    ) { _, dragAmount ->
+                        totalDrag += dragAmount
+                        if (totalDrag > DATA_DIALOG_DRAG_DISMISS_PX) {
+                            onDismiss()
+                            totalDrag = 0f
+                        }
+                    }
+                },
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .width(26.dp)
+                    .height(3.dp)
+                    .background(Color.White.copy(alpha = 0.42f), RoundedCornerShape(50)),
+        )
+    }
+}

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearDataDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearDataDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -30,6 +31,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.rotary.onPreRotaryScrollEvent
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -62,72 +64,133 @@ fun WearDataDialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.82f)),
-        ) {
-            LazyColumn(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .onPreRotaryScrollEvent { event ->
-                            coroutineScope.launch {
-                                listState.scrollBy(event.verticalScrollPixels)
-                            }
-                            abs(event.verticalScrollPixels) > 0.5f
-                        }.focusRequester(focusRequester)
-                        .focusable(),
-                state = listState,
-                contentPadding =
-                    PaddingValues(
-                        start = adaptive.dialogHorizontalPadding,
-                        top = adaptive.dialogVerticalPadding + adaptive.headerTopSafeInset + 18.dp,
-                        end = adaptive.dialogHorizontalPadding + 10.dp,
-                        bottom =
-                            adaptive.dialogVerticalPadding +
-                                if (bottomAction != null) {
-                                    76.dp
-                                } else if (adaptive.isRound) {
-                                    42.dp
-                                } else {
-                                    18.dp
-                                },
-                    ),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                item {
-                    DataDialogDragHandle(onDismiss = onDismiss)
-                }
-                item {
-                    Text(
-                        text = title,
-                        style = MaterialTheme.typography.titleLarge,
-                        textAlign = TextAlign.Center,
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 6.dp),
-                    )
-                }
-                content()
-            }
+        WearDataDialogSurface(
+            title = title,
+            onDismiss = onDismiss,
+            dialogState =
+                DataDialogRuntime(
+                    listState = listState,
+                    focusRequester = focusRequester,
+                    contentPadding = dataDialogPadding(adaptive, bottomAction != null),
+                    bottomActionPadding = adaptive.dialogVerticalPadding + 14.dp,
+                    onRotaryScroll = { delta ->
+                        coroutineScope.launch { listState.scrollBy(delta) }
+                    },
+                ),
+            bottomAction = bottomAction,
+            content = content,
+        )
+    }
+}
 
-            WearLazyListScreenEdgeScrollIndicator(listState = listState)
+private data class DataDialogRuntime(
+    val listState: LazyListState,
+    val focusRequester: FocusRequester,
+    val contentPadding: PaddingValues,
+    val bottomActionPadding: Dp,
+    val onRotaryScroll: (Float) -> Unit,
+)
 
-            if (bottomAction != null) {
-                Box(
-                    modifier =
-                        Modifier
-                            .align(Alignment.BottomCenter)
-                            .padding(bottom = adaptive.dialogVerticalPadding + 14.dp),
-                    contentAlignment = Alignment.Center,
-                    content = bottomAction,
-                )
-            }
+@Composable
+private fun WearDataDialogSurface(
+    title: String,
+    onDismiss: () -> Unit,
+    dialogState: DataDialogRuntime,
+    bottomAction: (@Composable BoxScope.() -> Unit)?,
+    content: LazyListScope.() -> Unit,
+) {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.82f)),
+    ) {
+        DataDialogList(
+            title = title,
+            onDismiss = onDismiss,
+            dialogState = dialogState,
+            content = content,
+        )
+        WearLazyListScreenEdgeScrollIndicator(listState = dialogState.listState)
+        if (bottomAction != null) {
+            DataDialogBottomAction(bottomPadding = dialogState.bottomActionPadding, content = bottomAction)
         }
     }
+}
+
+private fun dataDialogPadding(
+    adaptive: WearAdaptiveSpec,
+    hasBottomAction: Boolean,
+): PaddingValues =
+    PaddingValues(
+        start = adaptive.dialogHorizontalPadding,
+        top = adaptive.dialogVerticalPadding + adaptive.headerTopSafeInset + 18.dp,
+        end = adaptive.dialogHorizontalPadding + 10.dp,
+        bottom =
+            adaptive.dialogVerticalPadding +
+                when {
+                    hasBottomAction -> 76.dp
+                    adaptive.isRound -> 42.dp
+                    else -> 18.dp
+                },
+    )
+
+@Composable
+private fun DataDialogList(
+    title: String,
+    onDismiss: () -> Unit,
+    dialogState: DataDialogRuntime,
+    content: LazyListScope.() -> Unit,
+) {
+    LazyColumn(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .onPreRotaryScrollEvent { event ->
+                    dialogState.onRotaryScroll(event.verticalScrollPixels)
+                    abs(event.verticalScrollPixels) > 0.5f
+                }.focusRequester(dialogState.focusRequester)
+                .focusable(),
+        state = dialogState.listState,
+        contentPadding = dialogState.contentPadding,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        item {
+            DataDialogDragHandle(onDismiss = onDismiss)
+        }
+        item {
+            DataDialogTitle(title = title)
+        }
+        content()
+    }
+}
+
+@Composable
+private fun DataDialogTitle(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleLarge,
+        textAlign = TextAlign.Center,
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 6.dp),
+    )
+}
+
+@Composable
+private fun BoxScope.DataDialogBottomAction(
+    bottomPadding: Dp,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    Box(
+        modifier =
+            Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = bottomPadding),
+        contentAlignment = Alignment.Center,
+        content = content,
+    )
 }
 
 @Composable

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,8 +35,8 @@ android.r8.strictFullModeForKeepRules=false
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
 glanceMapVersionName=1.1.2
-glanceMapWearVersionCode=1020
-glanceMapPhoneVersionCode=2018
+glanceMapWearVersionCode=1021
+glanceMapPhoneVersionCode=2019
 
 # Elevate theme build-time sync (download -> generated assets -> packaged in APK)
 elevateThemeVersion=5.6


### PR DESCRIPTION
## Summary
- bump Wear and companion version codes
- add safer Wear dialog templates for action/data dialogs
- move routing/elevation data and GPX/Maps rename flows onto safer full-screen dialog patterns
- improve compass recalibration title spacing and elevation quality option spacing

## Why
This continues the Play Store Wear quality pass, especially max-font and small-round compliance where text, controls, and scrollbars must not be cropped.

## Validation
- `./gradlew :app:compileDebugKotlin --no-daemon --console=plain`