### PR TITLE
[codex] Improve high-font Wear dialogs

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/MainActivity.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/MainActivity.kt
@@ -160,7 +160,8 @@ class MainActivity : ComponentActivity() {
 
                 AppScaffold(
                     timeText = {
-                        if (showTimeInNavigate && isNavigateScreen && !isAmbient && !suppressNavigateTime) {
+                        val canShowNavigateTime = showTimeInNavigate && isNavigateScreen && !isAmbient
+                        if (canShowNavigateTime && !suppressNavigateTime) {
                             cappedFontScale(maxFontScale = 1f) {
                                 val context = LocalContext.current
                                 TimeText(

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/MainActivity.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/MainActivity.kt
@@ -314,6 +314,11 @@ class MainActivity : ComponentActivity() {
                             ) {
                                 DownloadSettingsScreen(
                                     viewModel = appContainer.downloadViewModel,
+                                    onOpenGeneralSettings = {
+                                        navController.navigate(WatchRoutes.SETTINGS) {
+                                            popUpTo(WatchRoutes.SETTINGS) { inclusive = false }
+                                        }
+                                    },
                                 )
                             }
                         }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/MainActivity.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/MainActivity.kt
@@ -133,11 +133,17 @@ class MainActivity : ComponentActivity() {
                 val backStackEntry by navController.currentBackStackEntryAsState()
                 val route = backStackEntry?.destination?.route
                 val routeLabel = route ?: WatchRoutes.NAVIGATE
+                var suppressNavigateTime by remember { mutableStateOf(false) }
                 LaunchedEffect(routeLabel) {
                     activeRoute = routeLabel
                     logNavigationTelemetry(event = "route_visible", route = routeLabel)
                 }
                 val isNavigateScreen = routeLabel == WatchRoutes.NAVIGATE
+                LaunchedEffect(isNavigateScreen) {
+                    if (!isNavigateScreen) {
+                        suppressNavigateTime = false
+                    }
+                }
                 val navigateViaSwipeLeft: () -> Unit = {
                     val popped = navController.popBackStack(WatchRoutes.NAVIGATE, inclusive = false)
                     if (!popped) {
@@ -154,7 +160,7 @@ class MainActivity : ComponentActivity() {
 
                 AppScaffold(
                     timeText = {
-                        if (showTimeInNavigate && isNavigateScreen && !isAmbient) {
+                        if (showTimeInNavigate && isNavigateScreen && !isAmbient && !suppressNavigateTime) {
                             cappedFontScale(maxFontScale = 1f) {
                                 val context = LocalContext.current
                                 TimeText(
@@ -205,6 +211,7 @@ class MainActivity : ComponentActivity() {
                                 isAmbient = isAmbient,
                                 isDeviceInteractive = isDeviceInteractive,
                                 ambientTickMs = ambientTickMs,
+                                onNavigateTimeSuppressedChange = { suppressNavigateTime = it },
                                 onMenuClick = {
                                     logNavigationTelemetry(
                                         event = "menu_click",

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/download/DownloadSettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.wear.compose.material3.SplitSwitchButton
 import androidx.wear.compose.material3.SwitchButtonDefaults
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.core.maps.DemSource
+import com.glancemap.glancemapwearos.presentation.features.settings.GeneralSettingsShortcutChip
 import com.glancemap.glancemapwearos.presentation.features.settings.OptionPickerDialog
 import com.glancemap.glancemapwearos.presentation.features.settings.SettingsToggleChip
 import com.glancemap.glancemapwearos.presentation.features.settings.WearSettingsListScreen
@@ -30,7 +31,10 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @OptIn(ExperimentalHorologistApi::class)
 @Composable
-fun DownloadSettingsScreen(viewModel: DownloadViewModel) {
+fun DownloadSettingsScreen(
+    viewModel: DownloadViewModel,
+    onOpenGeneralSettings: () -> Unit,
+) {
     val uiState by viewModel.uiState.collectAsState()
     val listTokens =
         rememberSettingsListTokens(
@@ -50,6 +54,9 @@ fun DownloadSettingsScreen(viewModel: DownloadViewModel) {
     )
 
     WearSettingsListScreen(listTokens = listTokens, horizontalAlignment = Alignment.CenterHorizontally) {
+        item {
+            GeneralSettingsShortcutChip(onClick = onOpenGeneralSettings)
+        }
         item {
             SettingsToggleChip(
                 checked = uiState.selection.includeMap,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxHelpBottomSheet.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxHelpBottomSheet.kt
@@ -75,6 +75,7 @@ fun GpxHelpBottomSheet(
     }
 }
 
+@Suppress("FunctionNaming")
 @Composable
 private fun GpxHelpText(text: String) {
     cappedFontScale(maxFontScale = 1.08f) {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxHelpBottomSheet.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxHelpBottomSheet.kt
@@ -10,12 +10,14 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.Text
 import com.glancemap.glancemapwearos.R
 import com.glancemap.glancemapwearos.presentation.ui.WearInfoDialog
+import com.glancemap.glancemapwearos.presentation.ui.cappedFontScale
 
 @Composable
 fun GpxHelpBottomSheet(
@@ -30,51 +32,56 @@ fun GpxHelpBottomSheet(
         onDismiss = onDismiss,
     ) {
         item {
-            Text(
-                "Toggle tracks to show or hide them on the map.",
-                modifier = Modifier.fillMaxWidth(),
-            )
+            GpxHelpText("Toggle tracks on the map.")
         }
         item {
-            Text(
-                "Long press a track to view elevation.",
-                modifier = Modifier.fillMaxWidth(),
-            )
+            GpxHelpText("Long press for elevation.")
         }
         item {
-            Text(
-                text =
-                    buildAnnotatedString {
-                        append("Use the ")
-                        appendInlineContent("sendToPhone", "[send]")
-                        append(" button to select one or more GPX, then send them to your phone.")
-                    },
-                modifier = Modifier.fillMaxWidth(),
-                inlineContent =
-                    mapOf(
-                        "sendToPhone" to
-                            InlineTextContent(
-                                placeholder =
-                                    Placeholder(
-                                        width = 16.sp,
-                                        height = 16.sp,
-                                        placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
-                                    ),
-                            ) {
-                                Icon(
-                                    painter = painterResource(R.drawable.ic_mobile_arrow_right),
-                                    contentDescription = null,
-                                    modifier = Modifier.size(16.dp),
-                                )
-                            },
-                    ),
-            )
+            cappedFontScale(maxFontScale = 1.08f) {
+                Text(
+                    text =
+                        buildAnnotatedString {
+                            append("Use ")
+                            appendInlineContent("sendToPhone", "[send]")
+                            append(" to send GPX to phone.")
+                        },
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                    inlineContent =
+                        mapOf(
+                            "sendToPhone" to
+                                InlineTextContent(
+                                    placeholder =
+                                        Placeholder(
+                                            width = 16.sp,
+                                            height = 16.sp,
+                                            placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
+                                        ),
+                                ) {
+                                    Icon(
+                                        painter = painterResource(R.drawable.ic_mobile_arrow_right),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(16.dp),
+                                    )
+                                },
+                        ),
+                )
+            }
         }
         item {
-            Text(
-                "Use edit or delete mode to rename or remove tracks.",
-                modifier = Modifier.fillMaxWidth(),
-            )
+            GpxHelpText("Edit or delete tracks with mode buttons.")
         }
+    }
+}
+
+@Composable
+private fun GpxHelpText(text: String) {
+    cappedFontScale(maxFontScale = 1.08f) {
+        Text(
+            text,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(),
+        )
     }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
@@ -72,6 +72,7 @@ import com.glancemap.glancemapwearos.presentation.ui.WearActionDialog
 import com.glancemap.glancemapwearos.presentation.ui.WearDataDialog
 import com.glancemap.glancemapwearos.presentation.ui.WearInfoDialog
 import com.glancemap.glancemapwearos.presentation.ui.WearScreenSize
+import com.glancemap.glancemapwearos.presentation.ui.cappedFontScale
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearAdaptiveSpec
 import com.glancemap.glancemapwearos.presentation.ui.rememberWearScreenSize
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
@@ -501,20 +502,26 @@ fun MapsScreen(
             onDismiss = { showDemDataDialog = false },
         ) {
             item {
-                Text(
-                    text = "Used for hill shading, slope and altitude.",
-                    style = MaterialTheme.typography.bodySmall,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-            item {
-                Text(
-                    text = "Choose quality for new elevation downloads.",
-                    style = MaterialTheme.typography.labelMedium,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                cappedFontScale(maxFontScale = 1.08f) {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(3.dp),
+                    ) {
+                        Text(
+                            text = "For shading, slope and altitude.",
+                            style = MaterialTheme.typography.bodySmall,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        Text(
+                            text = "Quality for new downloads.",
+                            style = MaterialTheme.typography.labelMedium,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
             }
             foundationItemsIndexed(DemSource.entries) { index, source ->
                 DemQualityChoiceRow(

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
@@ -19,8 +19,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
@@ -496,15 +498,26 @@ fun MapsScreen(
             }
         }
 
+        val demDataHighFont = adaptive.fontScale > 1f
         WearDataDialog(
             visible = showDemDataDialog,
             title = "Elevation data",
             onDismiss = { showDemDataDialog = false },
+            viewportPadding =
+                if (demDataHighFont) {
+                    PaddingValues(top = 24.dp, bottom = 72.dp)
+                } else {
+                    PaddingValues(0.dp)
+                },
         ) {
+            val demDialogHorizontalPadding = if (demDataHighFont) 22.dp else 0.dp
             item {
                 cappedFontScale(maxFontScale = 1.08f) {
                     Column(
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = demDialogHorizontalPadding),
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.spacedBy(3.dp),
                     ) {
@@ -524,35 +537,57 @@ fun MapsScreen(
                 }
             }
             foundationItemsIndexed(DemSource.entries) { index, source ->
-                DemQualityChoiceRow(
-                    source = source,
-                    selected = selectedDemSource == source,
-                    onSelect = { themeViewModel.setDemSource(source) },
-                    modifier = Modifier.padding(top = if (index == 0) 0.dp else 6.dp),
-                )
+                DemDialogDenseContent(highFont = demDataHighFont) {
+                    DemQualityChoiceRow(
+                        source = source,
+                        selected = selectedDemSource == source,
+                        onSelect = { themeViewModel.setDemSource(source) },
+                        modifier =
+                            Modifier.padding(
+                                horizontal = demDialogHorizontalPadding,
+                                vertical = 0.dp,
+                            ).padding(top = if (index == 0) 0.dp else 6.dp),
+                    )
+                }
             }
             foundationItems(DemSource.entries) { source ->
                 val files = demTileFiles.filter { it.source == source }
-                DemStorageSummaryRow(
-                    source = source,
-                    files = files,
-                    onDeleteAll = { demSourceToDeleteAll = source },
-                )
+                DemDialogDenseContent(highFont = demDataHighFont) {
+                    DemStorageSummaryRow(
+                        source = source,
+                        files = files,
+                        onDeleteAll = { demSourceToDeleteAll = source },
+                        modifier = Modifier.padding(horizontal = demDialogHorizontalPadding),
+                    )
+                }
             }
             if (mapFiles.isNotEmpty()) {
                 item {
-                    Text(
-                        text = "Map coverage",
-                        style = MaterialTheme.typography.labelMedium,
-                        textAlign = TextAlign.Center,
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(top = 2.dp),
-                    )
+                    DemDialogDenseContent(highFont = demDataHighFont) {
+                        Text(
+                            text = "Map coverage",
+                            style = MaterialTheme.typography.labelMedium,
+                            textAlign = TextAlign.Center,
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = demDialogHorizontalPadding)
+                                    .padding(top = 2.dp),
+                        )
+                    }
                 }
                 foundationItems(mapFiles) { mapFile ->
-                    DemMapCoverageRow(mapFile = mapFile)
+                    DemDialogDenseContent(highFont = demDataHighFont) {
+                        DemMapCoverageRow(
+                            mapFile = mapFile,
+                            modifier = Modifier.padding(horizontal = demDialogHorizontalPadding),
+                        )
+                    }
+                }
+            }
+            if (demDataHighFont) {
+                item {
+                    Spacer(modifier = Modifier.height(48.dp))
                 }
             }
         }
@@ -1172,9 +1207,10 @@ private fun DemStorageSummaryRow(
     source: DemSource,
     files: List<DemTileFileState>,
     onDeleteAll: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
@@ -1211,9 +1247,12 @@ private fun DemStorageSummaryRow(
 }
 
 @Composable
-private fun DemMapCoverageRow(mapFile: MapFileState) {
+private fun DemMapCoverageRow(
+    mapFile: MapFileState,
+    modifier: Modifier = Modifier,
+) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
@@ -1231,6 +1270,18 @@ private fun DemMapCoverageRow(mapFile: MapFileState) {
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
+    }
+}
+
+@Composable
+private fun DemDialogDenseContent(
+    highFont: Boolean,
+    content: @Composable () -> Unit,
+) {
+    if (highFont) {
+        cappedFontScale(maxFontScale = 1.08f, content = content)
+    } else {
+        content()
     }
 }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
@@ -89,7 +89,7 @@ import androidx.compose.foundation.lazy.itemsIndexed as foundationItemsIndexed
 private val MAP_DATA_BADGE_SIZE = 26.dp
 private val MAP_DATA_ICON_SIZE = 15.dp
 private val MAP_ROUTING_BADGE_SLOT_WIDTH = 22.dp
-private val MAP_DEM_BADGE_SLOT_WIDTH = 18.dp
+private val MAP_DEM_BADGE_SLOT_WIDTH = 22.dp
 
 @Composable
 fun MapsScreen(
@@ -815,6 +815,12 @@ fun MapsScreen(
                 demDownloadState.isDownloading || visibleDemStatusMessage.isNotBlank()
 
             if (showDemStatusBlock) {
+                val demStatusWidthFraction =
+                    when {
+                        !adaptive.isRound -> 1f
+                        adaptive.fontScale > 1f -> 0.76f
+                        else -> 0.86f
+                    }
                 Column(
                     modifier =
                         Modifier
@@ -840,8 +846,10 @@ fun MapsScreen(
                             text = visibleDemStatusMessage,
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.onBackground,
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier.fillMaxWidth(demStatusWidthFraction),
                             textAlign = TextAlign.Center,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
                         )
                     }
                 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsScreen.kt
@@ -538,15 +538,18 @@ fun MapsScreen(
             }
             foundationItemsIndexed(DemSource.entries) { index, source ->
                 DemDialogDenseContent(highFont = demDataHighFont) {
+                    val rowModifier =
+                        Modifier.padding(
+                            start = demDialogHorizontalPadding,
+                            top = if (index == 0) 0.dp else 6.dp,
+                            end = demDialogHorizontalPadding,
+                            bottom = 0.dp,
+                        )
                     DemQualityChoiceRow(
                         source = source,
                         selected = selectedDemSource == source,
                         onSelect = { themeViewModel.setDemSource(source) },
-                        modifier =
-                            Modifier.padding(
-                                horizontal = demDialogHorizontalPadding,
-                                vertical = 0.dp,
-                            ).padding(top = if (index == 0) 0.dp else 6.dp),
+                        modifier = rowModifier,
                     )
                 }
             }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateContent.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateContent.kt
@@ -1227,6 +1227,7 @@ internal fun NavigateContent(
                     busyMessage = crosshairSelectionBusyMessage,
                     titleOverride = crosshairSelectionTitle ?: "+ POI",
                     instructionOverride = crosshairSelectionInstruction ?: "Move map, then check.",
+                    popupTopOffset = 4.dp,
                     showCapturedPoints = false,
                     onPickHere = {
                         onCrosshairSelectionPickHere(

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateContent.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateContent.kt
@@ -99,6 +99,7 @@ internal fun NavigateContent(
     mapHolder: MapHolder?,
     onMapHolderChange: (MapHolder?) -> Unit,
     onMapViewReadyForRendering: () -> Unit,
+    onNavigateTimeSuppressedChange: (Boolean) -> Unit,
     mapAppearanceApplyInProgress: Boolean,
     slopeOverlayToggleEnabled: Boolean,
     slopeOverlayEnabled: Boolean,
@@ -186,6 +187,7 @@ internal fun NavigateContent(
     val context = LocalContext.current
     val screenSize = rememberWearScreenSize()
     val adaptive = rememberWearAdaptiveSpec()
+    val latestOnNavigateTimeSuppressedChange = rememberUpdatedState(onNavigateTimeSuppressedChange)
 
     DisposableEffect(mapView, onMapViewReadyForRendering) {
         if (mapView == null) return@DisposableEffect onDispose {}
@@ -656,6 +658,19 @@ internal fun NavigateContent(
     var showScaleBar by remember { mutableStateOf(false) }
     var liveElevationLabel by remember(mapHolder, isMetric) { mutableStateOf<String?>(null) }
     var liveDistanceLabel by remember(isMetric) { mutableStateOf<String?>(null) }
+    val routeToolModeActive = routeToolSession != null || crosshairSelectionActive || reshapePreviewInspectMode
+    val shouldSuppressNavigateTime =
+        adaptive.fontScale > 1f && (showScaleBar || routeToolModeActive)
+
+    LaunchedEffect(shouldSuppressNavigateTime) {
+        latestOnNavigateTimeSuppressedChange.value(shouldSuppressNavigateTime)
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            latestOnNavigateTimeSuppressedChange.value(false)
+        }
+    }
 
     LaunchedEffect(mapView, isMetric) {
         scaleIndicator =
@@ -1119,7 +1134,7 @@ internal fun NavigateContent(
                 sideButtonSize = sideButtonSize,
                 sideButtonIconSize = sideButtonIconSize,
                 shortcutTrayExpanded = shortcutTrayExpanded,
-                routeToolModeActive = routeToolSession != null || crosshairSelectionActive || reshapePreviewInspectMode,
+                routeToolModeActive = routeToolModeActive,
                 onShortcutTrayToggle = onShortcutTrayToggle,
                 onShortcutTrayDismiss = onShortcutTrayDismiss,
                 onGpxToolsClick = onOpenGpxTools,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.kt
@@ -75,6 +75,7 @@ import org.mapsforge.core.model.LatLong
 import org.mapsforge.map.android.graphics.AndroidBitmap
 import kotlin.math.abs
 
+@Suppress("CyclomaticComplexMethod", "FunctionNaming", "LongMethod", "LongParameterList")
 @Composable
 fun NavigateScreen(
     mapViewModel: MapViewModel,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.kt
@@ -85,6 +85,7 @@ fun NavigateScreen(
     isAmbient: Boolean,
     isDeviceInteractive: Boolean,
     ambientTickMs: Long,
+    onNavigateTimeSuppressedChange: (Boolean) -> Unit = {},
     onMenuClick: () -> Unit,
     compassViewModel: CompassViewModel = viewModel(),
     navigateViewModel: NavigateViewModel =
@@ -1157,6 +1158,7 @@ fun NavigateScreen(
         mapHolder = mapHolder,
         onMapHolderChange = { /* no-op */ },
         onMapViewReadyForRendering = { mapViewModel.onMapViewReadyForRendering() },
+        onNavigateTimeSuppressedChange = onNavigateTimeSuppressedChange,
         mapAppearanceApplyInProgress = mapAppearanceApplyInProgress,
         slopeOverlayToggleEnabled = slopeOverlayToggleEnabled,
         slopeOverlayEnabled = slopeOverlayState.enabled,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteCrosshairOverlay.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteCrosshairOverlay.kt
@@ -39,6 +39,7 @@ import com.glancemap.glancemapwearos.presentation.formatting.UnitFormatter
 import com.glancemap.glancemapwearos.presentation.ui.CompactIconHitTargetButton
 import com.glancemap.glancemapwearos.presentation.ui.WearScreenSize
 
+@Suppress("CyclomaticComplexMethod", "FunctionNaming", "LongMethod", "LongParameterList")
 @Composable
 internal fun BoxScope.RouteCrosshairOverlay(
     session: RouteToolSession,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteCrosshairOverlay.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteCrosshairOverlay.kt
@@ -51,6 +51,7 @@ internal fun BoxScope.RouteCrosshairOverlay(
     busyMessage: String? = null,
     titleOverride: String? = null,
     instructionOverride: String? = null,
+    popupTopOffset: Dp = 0.dp,
     showCapturedPoints: Boolean = true,
     onPickHere: () -> Unit,
     onCancel: () -> Unit,
@@ -120,7 +121,9 @@ internal fun BoxScope.RouteCrosshairOverlay(
             WearScreenSize.MEDIUM -> 34.dp
             WearScreenSize.SMALL -> 30.dp
         }
-    val popupTopPadding = if (multiPointMode) popupSpec.topPadding + 2.dp else popupSpec.topPadding
+    val popupTopPadding =
+        (if (multiPointMode) popupSpec.topPadding + 2.dp else popupSpec.topPadding) +
+            popupTopOffset
     val effectiveActionsBottomPadding = if (multiPointMode) actionsBottomPadding + 2.dp else actionsBottomPadding
     val actionVisualOffsetY = if (multiPointMode) (-2).dp else 0.dp
     if (session.usesCrosshair) {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolsActionPanel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolsActionPanel.kt
@@ -66,7 +66,7 @@ internal fun RouteToolsActionPanel(
         visible = true,
         title = "GPX Tools",
         onDismiss = onDismiss,
-        backgroundColor = Color.Black.copy(alpha = 0.86f),
+        backgroundColor = Color.Black.copy(alpha = 0.90f),
     ) {
         if (!preflightMessage.isNullOrBlank() && !shouldUsePreflightPopup) {
             Box(

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearActionDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearActionDialog.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -26,6 +25,7 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.ScrollIndicator
 import androidx.wear.compose.material3.Text
 
 enum class WearActionButtonRole {
@@ -140,7 +140,6 @@ private fun WearActionSurface(
 ) {
     val scrollState = rememberScrollState()
     val metrics = rememberWearActionLayoutMetrics()
-    val adaptive = rememberWearAdaptiveSpec()
 
     Box(
         modifier =
@@ -160,12 +159,9 @@ private fun WearActionSurface(
         ) {
             WearActionContent(title = title, buttons = buttons, metrics = metrics, content = content)
         }
-        WearThinVerticalScrollIndicator(
-            scrollState = scrollState,
-            modifier =
-                Modifier
-                    .align(Alignment.CenterEnd)
-                    .offset(x = if (adaptive.isRound) (-12).dp else 0.dp),
+        ScrollIndicator(
+            state = scrollState,
+            modifier = Modifier.align(Alignment.CenterEnd),
         )
     }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearActionDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearActionDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -139,6 +140,7 @@ private fun WearActionSurface(
 ) {
     val scrollState = rememberScrollState()
     val metrics = rememberWearActionLayoutMetrics()
+    val adaptive = rememberWearAdaptiveSpec()
 
     Box(
         modifier =
@@ -158,7 +160,13 @@ private fun WearActionSurface(
         ) {
             WearActionContent(title = title, buttons = buttons, metrics = metrics, content = content)
         }
-        WearScreenEdgeScrollIndicator(scrollState = scrollState)
+        WearThinVerticalScrollIndicator(
+            scrollState = scrollState,
+            modifier =
+                Modifier
+                    .align(Alignment.CenterEnd)
+                    .offset(x = if (adaptive.isRound) (-12).dp else 0.dp),
+        )
     }
 }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearDataDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearDataDialog.kt
@@ -1,4 +1,4 @@
-@file:Suppress("FunctionName")
+@file:Suppress("FunctionName", "LongParameterList")
 
 package com.glancemap.glancemapwearos.presentation.ui
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearDataDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearDataDialog.kt
@@ -130,7 +130,7 @@ private fun dataDialogPadding(
             adaptive.dialogVerticalPadding +
                 when {
                     hasBottomAction -> 76.dp
-                    adaptive.isRound && adaptive.fontScale >= 1.25f -> 72.dp
+                    adaptive.isRound && adaptive.fontScale >= 1.25f -> 132.dp
                     adaptive.isRound -> 42.dp
                     else -> 18.dp
                 },

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearDataDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearDataDialog.kt
@@ -121,20 +121,29 @@ private fun WearDataDialogSurface(
 private fun dataDialogPadding(
     adaptive: WearAdaptiveSpec,
     hasBottomAction: Boolean,
-): PaddingValues =
-    PaddingValues(
-        start = adaptive.dialogHorizontalPadding,
+): PaddingValues {
+    val highFontRound = adaptive.isRound && adaptive.fontScale >= 1.25f
+    val horizontalPadding =
+        if (highFontRound) {
+            adaptive.dialogHorizontalPadding + 14.dp
+        } else {
+            adaptive.dialogHorizontalPadding
+        }
+
+    return PaddingValues(
+        start = horizontalPadding,
         top = adaptive.dialogVerticalPadding + adaptive.headerTopSafeInset + 18.dp,
-        end = adaptive.dialogHorizontalPadding + 10.dp,
+        end = horizontalPadding + 10.dp,
         bottom =
             adaptive.dialogVerticalPadding +
                 when {
                     hasBottomAction -> 76.dp
-                    adaptive.isRound && adaptive.fontScale >= 1.25f -> 132.dp
+                    highFontRound -> 180.dp
                     adaptive.isRound -> 42.dp
                     else -> 18.dp
                 },
     )
+}
 
 @Composable
 private fun DataDialogList(

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearDataDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearDataDialog.kt
@@ -130,6 +130,7 @@ private fun dataDialogPadding(
             adaptive.dialogVerticalPadding +
                 when {
                     hasBottomAction -> 76.dp
+                    adaptive.isRound && adaptive.fontScale >= 1.25f -> 72.dp
                     adaptive.isRound -> 42.dp
                     else -> 18.dp
                 },

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearDataDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearDataDialog.kt
@@ -47,6 +47,7 @@ fun WearDataDialog(
     visible: Boolean,
     title: String,
     onDismiss: () -> Unit,
+    viewportPadding: PaddingValues = PaddingValues(0.dp),
     bottomAction: (@Composable BoxScope.() -> Unit)? = null,
     content: LazyListScope.() -> Unit,
 ) {
@@ -71,6 +72,7 @@ fun WearDataDialog(
                 DataDialogRuntime(
                     listState = listState,
                     focusRequester = focusRequester,
+                    viewportPadding = viewportPadding,
                     contentPadding = dataDialogPadding(adaptive, bottomAction != null),
                     bottomActionPadding = adaptive.dialogVerticalPadding + 14.dp,
                     onRotaryScroll = { delta ->
@@ -86,6 +88,7 @@ fun WearDataDialog(
 private data class DataDialogRuntime(
     val listState: LazyListState,
     val focusRequester: FocusRequester,
+    val viewportPadding: PaddingValues,
     val contentPadding: PaddingValues,
     val bottomActionPadding: Dp,
     val onRotaryScroll: (Float) -> Unit,
@@ -103,7 +106,7 @@ private fun WearDataDialogSurface(
         modifier =
             Modifier
                 .fillMaxSize()
-                .background(Color.Black.copy(alpha = 0.82f)),
+                .background(Color.Black.copy(alpha = 0.90f)),
     ) {
         DataDialogList(
             title = title,
@@ -124,11 +127,12 @@ private fun dataDialogPadding(
 ): PaddingValues {
     val highFontRound = adaptive.isRound && adaptive.fontScale >= 1.25f
     val horizontalPadding =
-        if (highFontRound) {
-            adaptive.dialogHorizontalPadding + 14.dp
-        } else {
-            adaptive.dialogHorizontalPadding
-        }
+        adaptive.dialogHorizontalPadding +
+            when {
+                highFontRound -> 18.dp
+                adaptive.isRound -> 8.dp
+                else -> 4.dp
+            }
 
     return PaddingValues(
         start = horizontalPadding,
@@ -138,7 +142,7 @@ private fun dataDialogPadding(
             adaptive.dialogVerticalPadding +
                 when {
                     hasBottomAction -> 76.dp
-                    highFontRound -> 180.dp
+                    highFontRound -> 260.dp
                     adaptive.isRound -> 42.dp
                     else -> 18.dp
                 },
@@ -156,6 +160,7 @@ private fun DataDialogList(
         modifier =
             Modifier
                 .fillMaxSize()
+                .padding(dialogState.viewportPadding)
                 .onPreRotaryScrollEvent { event ->
                     dialogState.onRotaryScroll(event.verticalScrollPixels)
                     abs(event.verticalScrollPixels) > 0.5f

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearFormDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearFormDialog.kt
@@ -1,4 +1,4 @@
-@file:Suppress("FunctionName", "MatchingDeclarationName")
+@file:Suppress("FunctionName", "LongMethod", "MatchingDeclarationName")
 
 package com.glancemap.glancemapwearos.presentation.ui
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearFormDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearFormDialog.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.ScrollIndicator
 import androidx.wear.compose.material3.Text
 
 data class WearFormDialogTokens(
@@ -93,7 +94,10 @@ fun WearFormDialog(
                     content(tokens)
                 }
             }
-            WearScreenEdgeScrollIndicator(scrollState = scrollState)
+            ScrollIndicator(
+                state = scrollState,
+                modifier = Modifier.align(Alignment.CenterEnd),
+            )
         }
     }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearScrollIndicators.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearScrollIndicators.kt
@@ -127,6 +127,24 @@ fun WearVerticalScrollIndicator(
 }
 
 @Composable
+fun WearThinVerticalScrollIndicator(
+    scrollState: ScrollState,
+    modifier: Modifier = Modifier,
+) {
+    if (scrollState.maxValue <= MIN_VISIBLE_SCROLL_RANGE_PX) return
+
+    WearScrollIndicatorTrack(
+        modifier = modifier,
+        progress = scrollState.value.toFloat() / scrollState.maxValue.toFloat(),
+        thumbFraction = 0.18f,
+        trackWidth = 1.dp,
+        thumbWidth = 4.dp,
+        minThumbHeight = 22.dp,
+        maxThumbHeight = 42.dp,
+    )
+}
+
+@Composable
 fun BoxScope.WearScreenEdgeScrollIndicator(
     scrollState: ScrollState,
     modifier: Modifier = Modifier,
@@ -278,6 +296,10 @@ private fun WearScrollIndicatorTrack(
     progress: Float,
     thumbFraction: Float,
     modifier: Modifier = Modifier,
+    trackWidth: Dp = 2.dp,
+    thumbWidth: Dp = 6.dp,
+    minThumbHeight: Dp = 24.dp,
+    maxThumbHeight: Dp = 46.dp,
 ) {
     val adaptive = rememberWearAdaptiveSpec()
     val topSafeInset =
@@ -306,9 +328,9 @@ private fun WearScrollIndicatorTrack(
             modifier
                 .fillMaxHeight()
                 .padding(top = topSafeInset, bottom = bottomSafeInset)
-                .width(6.dp),
+                .width(thumbWidth),
     ) {
-        val thumbHeight = (maxHeight * thumbFraction).coerceIn(24.dp, 46.dp)
+        val thumbHeight = (maxHeight * thumbFraction).coerceIn(minThumbHeight, maxThumbHeight)
         val travel = (maxHeight - thumbHeight).coerceAtLeast(0.dp)
         val thumbOffset = travel * progress.coerceIn(0f, 1f)
 
@@ -317,7 +339,7 @@ private fun WearScrollIndicatorTrack(
                 Modifier
                     .align(Alignment.Center)
                     .fillMaxHeight()
-                    .width(2.dp)
+                    .width(trackWidth)
                     .background(Color.White.copy(alpha = 0.16f), RoundedCornerShape(50)),
         )
         Box(
@@ -325,7 +347,7 @@ private fun WearScrollIndicatorTrack(
                 Modifier
                     .align(Alignment.TopCenter)
                     .offset(y = thumbOffset)
-                    .width(6.dp)
+                    .width(thumbWidth)
                     .height(thumbHeight)
                     .background(Color.White.copy(alpha = 0.72f), RoundedCornerShape(50)),
         )

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearToolPanelDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearToolPanelDialog.kt
@@ -76,7 +76,7 @@ private fun WearToolPanelSurface(
     val bottomPadding =
         adaptive.dialogVerticalPadding +
             when {
-                adaptive.isRound && adaptive.fontScale >= 1.25f -> 56.dp
+                adaptive.isRound && adaptive.fontScale >= 1.25f -> 72.dp
                 adaptive.isRound -> 42.dp
                 else -> 12.dp
             }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearToolPanelDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearToolPanelDialog.kt
@@ -1,4 +1,4 @@
-@file:Suppress("FunctionName", "MatchingDeclarationName")
+@file:Suppress("FunctionName", "LongMethod", "MatchingDeclarationName")
 
 package com.glancemap.glancemapwearos.presentation.ui
 
@@ -83,7 +83,7 @@ private fun WearToolPanelSurface(
             (if (adaptive.isRound) 10.dp else 0.dp) +
             highFontTopInset
     val bottomPadding =
-            adaptive.dialogVerticalPadding +
+        adaptive.dialogVerticalPadding +
             when {
                 highFontRound -> 120.dp
                 adaptive.isRound -> 42.dp
@@ -121,7 +121,7 @@ private fun WearToolPanelSurface(
             state = scrollState,
             modifier =
                 Modifier
-                    .align(Alignment.CenterEnd)
+                    .align(Alignment.CenterEnd),
         )
     }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearToolPanelDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearToolPanelDialog.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -27,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.ScrollIndicator
 import androidx.wear.compose.material3.Text
 
 private const val TOOL_PANEL_DRAG_DISMISS_PX = 55f
@@ -36,7 +36,7 @@ fun WearToolPanelDialog(
     visible: Boolean,
     title: String,
     onDismiss: () -> Unit,
-    backgroundColor: Color = Color.Black.copy(alpha = 0.86f),
+    backgroundColor: Color = Color.Black.copy(alpha = 0.90f),
     content: @Composable ColumnScope.() -> Unit,
 ) {
     if (!visible) return
@@ -63,21 +63,29 @@ private fun WearToolPanelSurface(
 ) {
     val adaptive = rememberWearAdaptiveSpec()
     val scrollState = rememberScrollState()
+    val highFontRound = adaptive.isRound && adaptive.fontScale >= 1.25f
     val highFontTopInset =
-        if (adaptive.isRound && adaptive.fontScale >= 1.25f) {
+        if (highFontRound) {
             8.dp
         } else {
             0.dp
         }
+    val horizontalPadding =
+        adaptive.dialogHorizontalPadding +
+            when {
+                highFontRound -> 18.dp
+                adaptive.isRound -> 8.dp
+                else -> 4.dp
+            }
     val topPadding =
         adaptive.dialogVerticalPadding +
             adaptive.headerTopSafeInset +
             (if (adaptive.isRound) 10.dp else 0.dp) +
             highFontTopInset
     val bottomPadding =
-        adaptive.dialogVerticalPadding +
+            adaptive.dialogVerticalPadding +
             when {
-                adaptive.isRound && adaptive.fontScale >= 1.25f -> 96.dp
+                highFontRound -> 120.dp
                 adaptive.isRound -> 42.dp
                 else -> 12.dp
             }
@@ -93,7 +101,7 @@ private fun WearToolPanelSurface(
                 Modifier
                     .fillMaxSize()
                     .verticalScroll(scrollState)
-                    .padding(horizontal = adaptive.dialogHorizontalPadding)
+                    .padding(horizontal = horizontalPadding)
                     .padding(top = topPadding, bottom = bottomPadding),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top),
@@ -109,12 +117,11 @@ private fun WearToolPanelSurface(
                 content()
             }
         }
-        WearThinVerticalScrollIndicator(
-            scrollState = scrollState,
+        ScrollIndicator(
+            state = scrollState,
             modifier =
                 Modifier
                     .align(Alignment.CenterEnd)
-                    .offset(x = if (adaptive.isRound) (-12).dp else 0.dp),
         )
     }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearToolPanelDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearToolPanelDialog.kt
@@ -75,7 +75,11 @@ private fun WearToolPanelSurface(
             highFontTopInset
     val bottomPadding =
         adaptive.dialogVerticalPadding +
-            if (adaptive.isRound) 34.dp else 12.dp
+            when {
+                adaptive.isRound && adaptive.fontScale >= 1.25f -> 56.dp
+                adaptive.isRound -> 42.dp
+                else -> 12.dp
+            }
 
     Box(
         modifier =

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearToolPanelDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearToolPanelDialog.kt
@@ -76,7 +76,7 @@ private fun WearToolPanelSurface(
     val bottomPadding =
         adaptive.dialogVerticalPadding +
             when {
-                adaptive.isRound && adaptive.fontScale >= 1.25f -> 72.dp
+                adaptive.isRound && adaptive.fontScale >= 1.25f -> 96.dp
                 adaptive.isRound -> 42.dp
                 else -> 12.dp
             }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearToolPanelDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearToolPanelDialog.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -108,9 +109,12 @@ private fun WearToolPanelSurface(
                 content()
             }
         }
-        WearVerticalScrollIndicator(
+        WearThinVerticalScrollIndicator(
             scrollState = scrollState,
-            modifier = Modifier.align(Alignment.CenterEnd),
+            modifier =
+                Modifier
+                    .align(Alignment.CenterEnd)
+                    .offset(x = if (adaptive.isRound) (-12).dp else 0.dp),
         )
     }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearToolPanelDialog.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/ui/WearToolPanelDialog.kt
@@ -108,7 +108,10 @@ private fun WearToolPanelSurface(
                 content()
             }
         }
-        WearScreenEdgeScrollIndicator(scrollState = scrollState)
+        WearVerticalScrollIndicator(
+            scrollState = scrollState,
+            modifier = Modifier.align(Alignment.CenterEnd),
+        )
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,8 +35,8 @@ android.r8.strictFullModeForKeepRules=false
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
 glanceMapVersionName=1.1.2
-glanceMapWearVersionCode=1021
-glanceMapPhoneVersionCode=2019
+glanceMapWearVersionCode=1022
+glanceMapPhoneVersionCode=2020
 
 # Elevate theme build-time sync (download -> generated assets -> packaged in APK)
 elevateThemeVersion=5.6


### PR DESCRIPTION
## Summary
- Hide the map time when increased font users are zooming or creating/modifying POI/GPX routes.
- Move dialog/form/tool scrollbars to Wear Material-style indicators and raise overlay opacity for map data/tool dialogs.
- Improve Elevation data popup spacing, DEM status message wrapping, and map row DEM/routing affordance spacing.

## Validation
- `./gradlew :app:compileDebugKotlin --no-daemon --console=plain`

## Notes
- Gradle wrapper files remain dirty locally but were intentionally not committed.