### PR TITLE
[codex] Improve companion live tracking flow

### DIFF
--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/ArkluzLiveTrackingClient.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/ArkluzLiveTrackingClient.kt
@@ -8,6 +8,7 @@ import com.glancemap.glancemapcompanionapp.BuildConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
@@ -56,8 +57,27 @@ internal data class ArkluzLocationUpdate(
     val stuckAlarmMinutes: String,
     val start: Boolean,
     val stop: Boolean,
+    val pause: Boolean = false,
+    val resume: Boolean = false,
+    val dateId: String? = null,
 ) {
-    fun asStoredGpsPoint(): ArkluzLocationUpdate = copy(start = false, stop = false)
+    fun asStoredGpsPoint(): ArkluzLocationUpdate =
+        copy(
+            start = false,
+            stop = false,
+            pause = false,
+            resume = false,
+            dateId = null,
+        )
+}
+
+internal data class ArkluzRecordedGpxDownload(
+    val cacheFile: File,
+    val suggestedFileName: String,
+) {
+    fun delete() {
+        cacheFile.delete()
+    }
 }
 
 enum class ArkluzTrackingEndpoint(
@@ -65,7 +85,6 @@ enum class ArkluzTrackingEndpoint(
     val url: String,
 ) {
     PRODUCTION("Production", "https://arkluz.com/trk"),
-    DEVELOPMENT("Development", "https://arkluz.com/dev/trk"),
     ;
 
     companion object {
@@ -199,8 +218,8 @@ internal class ArkluzLiveTrackingClient(
     suspend fun downloadRecordedGpx(
         settings: LiveTrackingSettings,
         userOnly: Boolean,
-        outputUri: Uri,
-    ): ArkluzServerResult =
+        fallbackFileName: String,
+    ): ArkluzRecordedGpxDownload =
         withContext(Dispatchers.IO) {
             val urlBuilder =
                 settings.trackingUrl
@@ -224,8 +243,24 @@ internal class ArkluzLiveTrackingClient(
                         .url(urlBuilder.build())
                         .get()
                         .build(),
-                outputUri = outputUri,
+                fallbackFileName = fallbackFileName,
             )
+        }
+
+    suspend fun saveRecordedGpx(
+        download: ArkluzRecordedGpxDownload,
+        outputUri: Uri,
+    ): ArkluzServerResult =
+        withContext(Dispatchers.IO) {
+            try {
+                appContext.contentResolver.openOutputStream(outputUri, "wt").use { output ->
+                    requireNotNull(output) { "Unable to open destination file" }
+                    download.cacheFile.inputStream().use { input -> input.copyTo(output) }
+                }
+                ArkluzServerResult("Recorded GPX downloaded")
+            } finally {
+                download.delete()
+            }
         }
 
     suspend fun saveSettings(settings: LiveTrackingSettings): ArkluzServerResult =
@@ -269,11 +304,15 @@ internal class ArkluzLiveTrackingClient(
         stop: Boolean,
     ): ArkluzServerResult = sendLocationUpdate(buildLocationUpdate(settings, location, start, stop))
 
+    @Suppress("LongParameterList")
     fun buildLocationUpdate(
         settings: LiveTrackingSettings,
         location: Location,
         start: Boolean,
         stop: Boolean,
+        pause: Boolean = false,
+        resume: Boolean = false,
+        dateId: String? = null,
     ): ArkluzLocationUpdate =
         ArkluzLocationUpdate(
             trackingUrl = settings.trackingUrl.trim().ifBlank { ArkluzTrackingEndpoint.defaultUrl },
@@ -293,52 +332,17 @@ internal class ArkluzLiveTrackingClient(
             stuckAlarmMinutes = settings.stuckAlarmMinutes.trim(),
             start = start,
             stop = stop,
+            pause = pause,
+            resume = resume,
+            dateId = dateId,
         )
 
     suspend fun sendLocationUpdate(update: ArkluzLocationUpdate): ArkluzServerResult =
         withContext(Dispatchers.IO) {
-            val urlBuilder =
-                update.trackingUrl
-                    .trim()
-                    .ifBlank { ArkluzTrackingEndpoint.defaultUrl }
-                    .toHttpUrl()
-                    .newBuilder()
-                    .addQueryParameter("lat", update.latitude.toString())
-                    .addQueryParameter("lon", update.longitude.toString())
-                    .addQueryParameter("acc", update.accuracyMeters.toString())
-                    .addQueryParameter("time", update.epochSeconds.toString())
-                    .addQueryParameter("battery", update.batteryPercent.toString())
-                    .addQueryParameter("gsm_signal", update.gsmSignalPercent.toString())
-                    .addQueryParameter("group", update.group)
-                    .addQueryParameter("pass", update.participantPassword)
-                    .addQueryParameter("user", update.userName)
-
-            update.altitudeMeters?.let { altitude ->
-                urlBuilder.addQueryParameter("alt", altitude.toString())
-            }
-            update.speedMetersPerSecond?.let { speed ->
-                urlBuilder.addQueryParameter("speed", speed.toString())
-            }
-            update.notificationEmails.takeIf { it.isNotBlank() }?.let { emails ->
-                urlBuilder.addQueryParameter("email", emails)
-            }
-            update.alertEmails.takeIf { it.isNotBlank() }?.let { emails ->
-                urlBuilder.addQueryParameter("alert", emails)
-            }
-            update.stuckAlarmMinutes.takeIf { it.isNotBlank() }?.let { alarm ->
-                urlBuilder.addQueryParameter("alarm", alarm)
-            }
-            if (update.start) {
-                urlBuilder.addEncodedQueryParameter("start", null)
-            }
-            if (update.stop) {
-                urlBuilder.addEncodedQueryParameter("stop", null)
-            }
-
             execute(
                 Request
                     .Builder()
-                    .url(urlBuilder.build())
+                    .url(buildArkluzLocationUrl(update))
                     .get()
                     .build(),
             )
@@ -360,10 +364,11 @@ internal class ArkluzLiveTrackingClient(
         }
     }
 
+    @Suppress("NestedBlockDepth", "ThrowsCount", "TooGenericExceptionCaught")
     private fun executeGpxDownload(
         request: Request,
-        outputUri: Uri,
-    ): ArkluzServerResult {
+        fallbackFileName: String,
+    ): ArkluzRecordedGpxDownload {
         httpClient.newCall(request).execute().use { response ->
             val body = response.body
             val contentType = body.contentType()?.toString().orEmpty()
@@ -378,11 +383,22 @@ internal class ArkluzLiveTrackingClient(
                 throw IllegalStateException(serverMessage.ifBlank { "Server did not return a GPX file" })
             }
 
-            appContext.contentResolver.openOutputStream(outputUri, "wt").use { output ->
-                requireNotNull(output) { "Unable to open destination file" }
-                body.byteStream().use { input -> input.copyTo(output) }
+            val suggestedFileName =
+                contentDispositionFileName(response.header("Content-Disposition"))
+                    ?: fallbackFileName
+            val cacheFile = File.createTempFile("arkluz-recorded-", ".gpx", appContext.cacheDir)
+            try {
+                cacheFile.outputStream().use { output ->
+                    body.byteStream().use { input -> input.copyTo(output) }
+                }
+            } catch (error: Throwable) {
+                cacheFile.delete()
+                throw error
             }
-            return ArkluzServerResult("Recorded GPX downloaded")
+            return ArkluzRecordedGpxDownload(
+                cacheFile = cacheFile,
+                suggestedFileName = suggestedFileName,
+            )
         }
     }
 
@@ -412,6 +428,36 @@ internal class ArkluzLiveTrackingClient(
 }
 
 private fun todayForArkluz(): String = java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.US).format(java.util.Date())
+
+internal fun buildArkluzLocationUrl(update: ArkluzLocationUpdate): HttpUrl {
+    val urlBuilder =
+        update.trackingUrl
+            .trim()
+            .ifBlank { ArkluzTrackingEndpoint.defaultUrl }
+            .toHttpUrl()
+            .newBuilder()
+            .addQueryParameter("lat", update.latitude.toString())
+            .addQueryParameter("lon", update.longitude.toString())
+            .addQueryParameter("acc", update.accuracyMeters.toString())
+            .addQueryParameter("time", update.epochSeconds.toString())
+            .addQueryParameter("battery", update.batteryPercent.toString())
+            .addQueryParameter("gsm_signal", update.gsmSignalPercent.toString())
+            .addQueryParameter("group", update.group)
+            .addQueryParameter("pass", update.participantPassword)
+            .addQueryParameter("user", update.userName)
+
+    update.altitudeMeters?.let { urlBuilder.addQueryParameter("alt", it.toString()) }
+    update.speedMetersPerSecond?.let { urlBuilder.addQueryParameter("speed", it.toString()) }
+    update.notificationEmails.takeIf(String::isNotBlank)?.let { urlBuilder.addQueryParameter("email", it) }
+    update.alertEmails.takeIf(String::isNotBlank)?.let { urlBuilder.addQueryParameter("alert", it) }
+    update.stuckAlarmMinutes.takeIf(String::isNotBlank)?.let { urlBuilder.addQueryParameter("alarm", it) }
+    if (update.start) urlBuilder.addEncodedQueryParameter("start", null)
+    if (update.stop) urlBuilder.addEncodedQueryParameter("stop", null)
+    if (update.pause) urlBuilder.addEncodedQueryParameter("pause", null)
+    if (update.resume) urlBuilder.addEncodedQueryParameter("resume", null)
+    update.dateId?.takeIf(String::isNotBlank)?.let { urlBuilder.addQueryParameter("date_id", it) }
+    return urlBuilder.build()
+}
 
 internal class ArkluzHttpException(
     val code: Int,
@@ -444,9 +490,15 @@ private fun arkluzUtcTimestamp(): String =
 
 data class ArkluzServerResult(
     val message: String,
-    val viewerPassword: String? = null,
+    val responseValue: String? = null,
     val groupAvailable: Boolean = false,
-)
+) {
+    val viewerPassword: String?
+        get() = responseValue
+
+    val dateId: String?
+        get() = responseValue
+}
 
 private fun String.toReadableServerMessage(): String =
     replace(Regex("<br\\s*/?>", RegexOption.IGNORE_CASE), "\n")
@@ -480,14 +532,14 @@ private fun String.toUserFacingServerMessage(): String =
 
 private fun String.toArkluzServerResult(): ArkluzServerResult {
     val lines = lines().map { it.trim() }.filter { it.isNotBlank() }
-    val viewerPassword =
+    val responseValue =
         lines
             .drop(1)
             .firstOrNull()
             ?.takeIf { lines.firstOrNull()?.equals("OK", ignoreCase = true) == true }
     return ArkluzServerResult(
         message = toUserFacingServerMessage(),
-        viewerPassword = viewerPassword,
+        responseValue = responseValue,
         groupAvailable = equals("group available", ignoreCase = true),
     )
 }

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/ArkluzLiveTrackingClient.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/ArkluzLiveTrackingClient.kt
@@ -7,8 +7,8 @@ import android.os.BatteryManager
 import com.glancemap.glancemapcompanionapp.BuildConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingControlQueue.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingControlQueue.kt
@@ -4,10 +4,9 @@ import android.content.Context
 import org.json.JSONArray
 import org.json.JSONObject
 
-internal object LiveTrackingPositionQueue {
-    private const val PREFS_NAME = "arkluz_live_tracking_position_queue"
+internal object LiveTrackingControlQueue {
+    private const val PREFS_NAME = "arkluz_live_tracking_control_queue"
     private const val KEY_QUEUE = "queue"
-    private const val MAX_QUEUE_SIZE = 500
     private val lock = Any()
 
     fun enqueue(
@@ -15,23 +14,26 @@ internal object LiveTrackingPositionQueue {
         update: ArkluzLocationUpdate,
     ): Int =
         synchronized(lock) {
-            val updates = loadLocked(context) + update.asStoredGpsPoint()
-            val cappedUpdates = updates.takeLast(MAX_QUEUE_SIZE)
-            saveLocked(context, cappedUpdates)
-            cappedUpdates.size
+            val updates = loadLocked(context) + update
+            saveLocked(context, updates)
+            updates.size
         }
 
     fun load(context: Context): List<ArkluzLocationUpdate> =
         synchronized(lock) {
-            loadLocked(context).sortedBy { it.epochSeconds }
+            loadLocked(context)
         }
 
-    fun replaceAll(
-        context: Context,
-        updates: List<ArkluzLocationUpdate>,
-    ) {
+    fun removeFirst(context: Context) {
         synchronized(lock) {
-            saveLocked(context, updates.sortedBy { it.epochSeconds }.takeLast(MAX_QUEUE_SIZE))
+            val remaining = loadLocked(context).drop(1)
+            saveLocked(context, remaining)
+        }
+    }
+
+    fun clear(context: Context) {
+        synchronized(lock) {
+            saveLocked(context, emptyList())
         }
     }
 
@@ -44,7 +46,7 @@ internal object LiveTrackingPositionQueue {
         val jsonArray = runCatching { JSONArray(raw) }.getOrElse { JSONArray() }
         return buildList {
             for (index in 0 until jsonArray.length()) {
-                jsonArray.optJSONObject(index)?.toLocationUpdateOrNull()?.let(::add)
+                jsonArray.optJSONObject(index)?.toControlUpdateOrNull()?.let(::add)
             }
         }
     }
@@ -54,9 +56,7 @@ internal object LiveTrackingPositionQueue {
         updates: List<ArkluzLocationUpdate>,
     ) {
         val jsonArray = JSONArray()
-        updates.forEach { update ->
-            jsonArray.put(update.toJson())
-        }
+        updates.forEach { jsonArray.put(it.toJson()) }
         context
             .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .edit()
@@ -81,13 +81,11 @@ internal object LiveTrackingPositionQueue {
             .put("notificationEmails", notificationEmails)
             .put("alertEmails", alertEmails)
             .put("stuckAlarmMinutes", stuckAlarmMinutes)
-            .put("start", start)
-            .put("stop", stop)
             .put("pause", pause)
             .put("resume", resume)
             .put("dateId", dateId)
 
-    private fun JSONObject.toLocationUpdateOrNull(): ArkluzLocationUpdate? =
+    private fun JSONObject.toControlUpdateOrNull(): ArkluzLocationUpdate? =
         runCatching {
             ArkluzLocationUpdate(
                 trackingUrl = getString("trackingUrl"),
@@ -105,8 +103,8 @@ internal object LiveTrackingPositionQueue {
                 notificationEmails = optString("notificationEmails"),
                 alertEmails = optString("alertEmails"),
                 stuckAlarmMinutes = optString("stuckAlarmMinutes"),
-                start = optBoolean("start"),
-                stop = optBoolean("stop"),
+                start = false,
+                stop = false,
                 pause = optBoolean("pause"),
                 resume = optBoolean("resume"),
                 dateId = optString("dateId").takeIf(String::isNotBlank),
@@ -114,9 +112,5 @@ internal object LiveTrackingPositionQueue {
         }.getOrNull()
 
     private fun JSONObject.nullableDouble(key: String): Double? =
-        if (isNull(key)) {
-            null
-        } else {
-            optDouble(key)
-        }
+        if (isNull(key)) null else optDouble(key)
 }

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingControlQueue.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingControlQueue.kt
@@ -111,6 +111,5 @@ internal object LiveTrackingControlQueue {
             )
         }.getOrNull()
 
-    private fun JSONObject.nullableDouble(key: String): Double? =
-        if (isNull(key)) null else optDouble(key)
+    private fun JSONObject.nullableDouble(key: String): Double? = if (isNull(key)) null else optDouble(key)
 }

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingHelpers.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingHelpers.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.provider.ContactsContract
 import android.util.Patterns
 import androidx.core.content.ContextCompat
+import java.io.ByteArrayOutputStream
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -41,14 +42,24 @@ internal fun validateStartSettings(
     participantPassword: String,
     followerPassword: String,
     userName: String,
+    stuckAlarmMinutes: String,
 ): String? =
     when {
         group.isBlank() -> "Private group is required."
         participantPassword.isBlank() -> "Participant password is required."
         followerPassword.isBlank() -> "Create / Join in settings first."
         userName.isBlank() -> "Participant name is required."
+        else -> validateNoMovementAlertMinutes(stuckAlarmMinutes)
+    }
+
+internal fun validateNoMovementAlertMinutes(minutes: String): String? {
+    val value = minutes.trim().toIntOrNull()
+    return when {
+        value == -1 -> null
+        value == null || value < 10 -> "No-movement alert must be at least 10 minutes, or disabled."
         else -> null
     }
+}
 
 internal fun validateRecordedTrackDownloadSettings(
     group: String,
@@ -127,6 +138,66 @@ internal fun recordedTrackDownloadFilename(
             .ifBlank { target.name.lowercase() }
     return "$day-$safeName.gpx"
 }
+
+@Suppress("ReturnCount")
+internal fun contentDispositionFileName(header: String?): String? {
+    if (header.isNullOrBlank()) return null
+    val extendedValue =
+        Regex("""(?i)(?:^|;)\s*filename\*\s*=\s*("[^"]*"|[^;]*)""")
+            .find(header)
+            ?.groupValues
+            ?.get(1)
+            ?.trim()
+            ?.removeSurrounding("\"")
+    val extendedFileName =
+        extendedValue
+            ?.split('\'', limit = 3)
+            ?.takeIf { it.size == 3 && it[0].equals("UTF-8", ignoreCase = true) }
+            ?.get(2)
+            ?.decodeRfc5987Utf8()
+            ?.safeDownloadFileName()
+    if (!extendedFileName.isNullOrBlank()) return extendedFileName
+
+    return Regex("""(?i)(?:^|;)\s*filename\s*=\s*("(?:\\.|[^"])*"|[^;]*)""")
+        .find(header)
+        ?.groupValues
+        ?.get(1)
+        ?.trim()
+        ?.removeSurrounding("\"")
+        ?.replace("\\\"", "\"")
+        ?.replace("\\\\", "\\")
+        ?.safeDownloadFileName()
+        ?.takeIf { it.isNotBlank() }
+}
+
+private fun String.decodeRfc5987Utf8(): String? =
+    runCatching {
+        val bytes = ByteArrayOutputStream(length)
+        var index = 0
+        while (index < length) {
+            if (this[index] == '%' && index + 2 < length) {
+                val value = substring(index + 1, index + 3).toIntOrNull(16)
+                if (value != null) {
+                    bytes.write(value)
+                    index += 3
+                    continue
+                }
+            }
+            this[index]
+                .toString()
+                .toByteArray(Charsets.UTF_8)
+                .forEach { byte -> bytes.write(byte.toInt()) }
+            index += 1
+        }
+        bytes.toByteArray().toString(Charsets.UTF_8)
+    }.getOrNull()
+
+private fun String.safeDownloadFileName(): String =
+    substringAfterLast('/')
+        .substringAfterLast('\\')
+        .replace("\r", "")
+        .replace("\n", "")
+        .trim()
 
 internal fun editableSettingsSnapshot(
     group: String,

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingMainContent.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingMainContent.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Route
 import androidx.compose.material.icons.filled.Settings
@@ -69,6 +70,8 @@ internal fun ColumnScope.MainTrackingContent(
     validationMessage: String?,
     sendStatusMessage: String?,
     onStart: () -> Unit,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
     onStop: () -> Unit,
     userName: String,
     groupTrackUrl: String,
@@ -148,17 +151,34 @@ internal fun ColumnScope.MainTrackingContent(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Button(
-                    onClick = onStart,
-                    enabled = !sessionState.isTracking && !isStartingSession,
+                    onClick =
+                        when {
+                            sessionState.isPaused -> onResume
+                            sessionState.isTracking -> onPause
+                            else -> onStart
+                        },
+                    enabled = !isStartingSession,
                     modifier = Modifier.weight(1f),
                 ) {
                     Icon(
-                        imageVector = Icons.Filled.PlayArrow,
+                        imageVector =
+                            if (sessionState.isTracking && !sessionState.isPaused) {
+                                Icons.Filled.Pause
+                            } else {
+                                Icons.Filled.PlayArrow
+                            },
                         contentDescription = null,
                         modifier = Modifier.size(18.dp),
                     )
                     Spacer(modifier = Modifier.size(6.dp))
-                    Text(if (isStartingSession) "Starting" else "Start")
+                    Text(
+                        when {
+                            isStartingSession -> "Starting"
+                            sessionState.isPaused -> "Resume"
+                            sessionState.isTracking -> "Pause"
+                            else -> "Start"
+                        },
+                    )
                 }
                 OutlinedButton(
                     onClick = onStop,
@@ -179,6 +199,13 @@ internal fun ColumnScope.MainTrackingContent(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            if (sessionState.status.contains("Arkluz notification pending")) {
+                Text(
+                    text = "Arkluz has not been notified yet. No-movement alerts may still be triggered.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
             validationMessage?.let { message ->
                 Text(
                     text = message,

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingScreen.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -122,7 +123,7 @@ fun LiveTrackingScreen(
     var isDeletingTracks by remember { mutableStateOf(false) }
     var recordedTrackDownloadStatusMessage by remember { mutableStateOf<String?>(null) }
     var isDownloadingRecordedTrack by remember { mutableStateOf(false) }
-    var pendingRecordedTrackDownloadTarget by remember { mutableStateOf<RecordedTrackDownloadTarget?>(null) }
+    var pendingRecordedTrackDownload by remember { mutableStateOf<ArkluzRecordedGpxDownload?>(null) }
     var planSent by remember { mutableStateOf(false) }
     var emailPickerTarget by remember { mutableStateOf<EmailPickerTarget?>(null) }
     var showUseLastTransferGpxDialog by remember { mutableStateOf(false) }
@@ -189,32 +190,20 @@ fun LiveTrackingScreen(
         rememberLauncherForActivityResult(
             contract = ActivityResultContracts.CreateDocument("application/gpx+xml"),
         ) { uri ->
-            val target = pendingRecordedTrackDownloadTarget
-            pendingRecordedTrackDownloadTarget = null
-            if (uri == null || target == null) return@rememberLauncherForActivityResult
+            val download = pendingRecordedTrackDownload
+            pendingRecordedTrackDownload = null
+            if (uri == null || download == null) {
+                download?.delete()
+                isDownloadingRecordedTrack = false
+                if (download != null) recordedTrackDownloadStatusMessage = "Download cancelled"
+                return@rememberLauncherForActivityResult
+            }
 
-            isDownloadingRecordedTrack = true
-            recordedTrackDownloadStatusMessage = "Downloading recorded GPX"
-            val downloadSettings =
-                LiveTrackingSettings(
-                    trackingUrl = trackingEndpoint.url,
-                    updateIntervalSeconds = updateIntervalSeconds,
-                    group = group,
-                    participantPassword = participantPassword,
-                    followerPassword = followerPassword,
-                    userName = userName,
-                    notificationEmails = "",
-                    alertEmails = "",
-                    stuckAlarmMinutes = stuckAlarmMinutes,
-                    comments = "",
-                    gpxUri = null,
-                    gpxName = "",
-                )
+            recordedTrackDownloadStatusMessage = "Saving recorded GPX"
             coroutineScope.launch {
                 runCatching {
-                    ArkluzLiveTrackingClient(context).downloadRecordedGpx(
-                        settings = downloadSettings,
-                        userOnly = target == RecordedTrackDownloadTarget.USER,
+                    ArkluzLiveTrackingClient(context).saveRecordedGpx(
+                        download = download,
                         outputUri = uri,
                     )
                 }.onSuccess { result ->
@@ -226,6 +215,56 @@ fun LiveTrackingScreen(
                 isDownloadingRecordedTrack = false
             }
         }
+
+    fun downloadRecordedTrack(target: RecordedTrackDownloadTarget) {
+        isDownloadingRecordedTrack = true
+        recordedTrackDownloadStatusMessage = "Downloading recorded GPX"
+        val downloadSettings =
+            LiveTrackingSettings(
+                trackingUrl = trackingEndpoint.url,
+                updateIntervalSeconds = updateIntervalSeconds,
+                group = group,
+                participantPassword = participantPassword,
+                followerPassword = followerPassword,
+                userName = userName,
+                notificationEmails = "",
+                alertEmails = "",
+                stuckAlarmMinutes = stuckAlarmMinutes,
+                comments = "",
+                gpxUri = null,
+                gpxName = "",
+            )
+        coroutineScope.launch {
+            runCatching {
+                ArkluzLiveTrackingClient(context).downloadRecordedGpx(
+                    settings = downloadSettings,
+                    userOnly = target == RecordedTrackDownloadTarget.USER,
+                    fallbackFileName =
+                        recordedTrackDownloadFilename(
+                            group = group,
+                            userName = userName,
+                            target = target,
+                        ),
+                )
+            }.onSuccess { download ->
+                pendingRecordedTrackDownload?.delete()
+                pendingRecordedTrackDownload = download
+                recordedTrackDownloadStatusMessage = "Choose where to save the recorded GPX"
+                recordedTrackSavePicker.launch(download.suggestedFileName)
+            }.onFailure { error ->
+                recordedTrackDownloadStatusMessage =
+                    "Download failed: ${error.toArkluzFailureDetail()}"
+                isDownloadingRecordedTrack = false
+            }
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            pendingRecordedTrackDownload?.delete()
+        }
+    }
+
     val contactEmailPicker =
         rememberLauncherForActivityResult(
             contract = ActivityResultContracts.StartActivityForResult(),
@@ -423,6 +462,17 @@ fun LiveTrackingScreen(
             saveSettingsStatusMessage = null
         }
 
+        fun restoreGroupProfileOrOpenInitialSettings(groupName: String) {
+            val profile = LiveTrackingPreferences.loadGroupSettings(context, groupName)
+            if (profile == null) {
+                settingsSnapshot = currentSettingsSnapshot()
+                saveSettingsStatusMessage = null
+                page = LiveTrackingPage.SETTINGS
+            } else {
+                applySettingsSnapshot(profile)
+            }
+        }
+
         fun saveSettings(exitAfterSave: Boolean = false) {
             saveSettingsStatusMessage =
                 validateStartSettings(
@@ -430,6 +480,7 @@ fun LiveTrackingScreen(
                     participantPassword = participantPassword,
                     followerPassword = followerPassword,
                     userName = userName,
+                    stuckAlarmMinutes = stuckAlarmMinutes,
                 )
                     ?: validatePendingEmailInputs(
                         notificationEmailInput = notificationEmailInput,
@@ -501,6 +552,7 @@ fun LiveTrackingScreen(
                     participantPassword = participantPassword,
                     followerPassword = followerPassword,
                     userName = userName,
+                    stuckAlarmMinutes = stuckAlarmMinutes,
                 )
                     ?: validatePendingEmailInputs(
                         notificationEmailInput = notificationEmailInput,
@@ -646,6 +698,8 @@ fun LiveTrackingScreen(
                         validationMessage = validationMessage,
                         sendStatusMessage = sendStatusMessage,
                         onStart = { startLiveTracking(requestMissingPermissions = true) },
+                        onPause = { LiveTrackingService.pause(context) },
+                        onResume = { LiveTrackingService.resume(context) },
                         onStop = { LiveTrackingService.stop(context) },
                         userName = userName,
                         groupTrackUrl = groupTrackUrl,
@@ -683,14 +737,7 @@ fun LiveTrackingScreen(
                                     userOnly = true,
                                 )
                             if (recordedTrackDownloadStatusMessage == null) {
-                                pendingRecordedTrackDownloadTarget = RecordedTrackDownloadTarget.USER
-                                recordedTrackSavePicker.launch(
-                                    recordedTrackDownloadFilename(
-                                        group = group,
-                                        userName = userName,
-                                        target = RecordedTrackDownloadTarget.USER,
-                                    ),
-                                )
+                                downloadRecordedTrack(RecordedTrackDownloadTarget.USER)
                             }
                         },
                         scrollState = scrollState,
@@ -752,13 +799,7 @@ fun LiveTrackingScreen(
                                             createGroupPasswordConfirmation = ""
                                             showCreateGroupDialog = true
                                         } else {
-                                            LiveTrackingPreferences.loadGroupSettings(context, cleanGroup)?.let { profile ->
-                                                userName = profile.userName
-                                                notificationEmailAddresses = profile.notificationEmailAddresses
-                                                alertEmailAddresses = profile.alertEmailAddresses
-                                                stuckAlarmMinutes = profile.stuckAlarmMinutes
-                                                updateIntervalSeconds = profile.updateIntervalSeconds
-                                            }
+                                            restoreGroupProfileOrOpenInitialSettings(cleanGroup)
                                             loginJoinStatusMessage = "Connected to $cleanGroup"
                                             headerMessage = null
                                         }
@@ -801,14 +842,9 @@ fun LiveTrackingScreen(
                                         createGroupPasswordConfirmation = ""
                                         "Created + connected"
                                     }.onSuccess { status ->
-                                        LiveTrackingPreferences.loadGroupSettings(context, group.trim())?.let { profile ->
-                                            userName = profile.userName
-                                            notificationEmailAddresses = profile.notificationEmailAddresses
-                                            alertEmailAddresses = profile.alertEmailAddresses
-                                            stuckAlarmMinutes = profile.stuckAlarmMinutes
-                                            updateIntervalSeconds = profile.updateIntervalSeconds
-                                        }
-                                        loginJoinStatusMessage = "$status to ${group.trim()}"
+                                        val cleanGroup = group.trim()
+                                        restoreGroupProfileOrOpenInitialSettings(cleanGroup)
+                                        loginJoinStatusMessage = "$status to $cleanGroup"
                                         headerMessage = null
                                     }.onFailure { error ->
                                         loginJoinStatusMessage =

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingService.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingService.kt
@@ -282,10 +282,11 @@ class LiveTrackingService : Service() {
     @Suppress("ReturnCount")
     private fun pauseTracking() {
         val activeSettings = settings ?: return
-        val location = lastLocation ?: run {
-            LiveTrackingSessionStore.setError("Wait for the first GPS position before pausing")
-            return
-        }
+        val location =
+            lastLocation ?: run {
+                LiveTrackingSessionStore.setError("Wait for the first GPS position before pausing")
+                return
+            }
         if (isPaused || isStopping || !sentStart) return
         runCatching { locationClient.removeLocationUpdates(locationCallback) }
         isPaused = true

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingService.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingService.kt
@@ -45,6 +45,7 @@ class LiveTrackingService : Service() {
     private var settings: LiveTrackingSettings? = null
     private var lastLocation: Location? = null
     private var sentStart = false
+    private var dateId: String? = null
     private var isPaused = false
     private var isStopping = false
     private val sendMutex = Mutex()
@@ -97,8 +98,10 @@ class LiveTrackingService : Service() {
                 } else {
                     settings = parsedSettings
                     sentStart = false
+                    dateId = null
                     isPaused = false
                     isStopping = false
+                    LiveTrackingControlQueue.clear(this)
                     LiveTrackingSessionStore.setStarting()
                     startForegroundNotification("Starting live tracking")
                     startTracking(parsedSettings)
@@ -164,6 +167,7 @@ class LiveTrackingService : Service() {
         sendLocation(location = location, start = !sentStart, stop = false)
     }
 
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     private suspend fun sendLocation(
         location: Location,
         start: Boolean,
@@ -180,9 +184,13 @@ class LiveTrackingService : Service() {
             )
         sendMutex.withLock {
             runCatching {
+                flushPendingSessionControlsLocked()
                 arkluzClient.sendLocationUpdate(update)
             }.onSuccess { result ->
-                if (start) sentStart = true
+                if (start) {
+                    sentStart = true
+                    result.dateId?.let { dateId = it }
+                }
                 val serverMessage = result.message.takeUnless { it == "Server accepted request" }
                 val status =
                     serverMessage ?: when {
@@ -212,11 +220,20 @@ class LiveTrackingService : Service() {
                         updateNotification("Stored GPS points still waiting")
                     }
             }.onFailure { error ->
+                val controlsPending = LiveTrackingControlQueue.load(this@LiveTrackingService).isNotEmpty()
                 if (!stop && error.isRetryableArkluzFailure()) {
                     val queueSize = LiveTrackingPositionQueue.enqueue(this@LiveTrackingService, update)
-                    val message = "GPS stored for retry ($queueSize waiting): ${error.toLiveTrackingErrorText()}"
-                    LiveTrackingSessionStore.setError(message)
-                    updateNotification("GPS stored for retry ($queueSize waiting)")
+                    if (controlsPending) {
+                        LiveTrackingSessionStore.setActive(
+                            status = "GPS stored for retry ($queueSize waiting)",
+                            serverSyncPending = true,
+                        )
+                        updateNotification("Tracking active; Arkluz notification pending")
+                    } else {
+                        val message = "GPS stored for retry ($queueSize waiting): ${error.toLiveTrackingErrorText()}"
+                        LiveTrackingSessionStore.setError(message)
+                        updateNotification("GPS stored for retry ($queueSize waiting)")
+                    }
                 } else {
                     LiveTrackingSessionStore.setError(error.message ?: "Unable to send position")
                     updateNotification("Unable to send position")
@@ -262,16 +279,36 @@ class LiveTrackingService : Service() {
         locationClient.requestLocationUpdates(request, locationCallback, mainLooper)
     }
 
+    @Suppress("ReturnCount")
     private fun pauseTracking() {
-        if (settings == null || isPaused || isStopping) return
+        val activeSettings = settings ?: return
+        val location = lastLocation ?: run {
+            LiveTrackingSessionStore.setError("Wait for the first GPS position before pausing")
+            return
+        }
+        if (isPaused || isStopping || !sentStart) return
         runCatching { locationClient.removeLocationUpdates(locationCallback) }
         isPaused = true
-        LiveTrackingSessionStore.setStatus("Paused")
-        updateNotification("Live tracking paused")
+        LiveTrackingControlQueue.enqueue(
+            this,
+            buildSessionControl(
+                settings = activeSettings,
+                location = location,
+                pause = true,
+            ),
+        )
+        LiveTrackingSessionStore.setPaused(serverSyncPending = true)
+        updateNotification("Paused on phone; notifying Arkluz")
+        serviceScope.launch {
+            runCatching { flushPendingSessionControls() }
+            updateControlSyncStatus()
+            retryPendingControlsWhilePaused()
+        }
     }
 
     private fun resumeTracking() {
-        if (settings == null) return
+        val activeSettings = settings ?: return
+        val location = lastLocation ?: return
         if (!isPaused || isStopping) return
         if (!hasLocationPermission()) {
             LiveTrackingSessionStore.setStopped("Location permission is required")
@@ -280,11 +317,91 @@ class LiveTrackingService : Service() {
             return
         }
         isPaused = false
-        LiveTrackingSessionStore.setStatus("Waiting for GPS fix")
-        updateNotification("Waiting for GPS fix")
+        LiveTrackingControlQueue.enqueue(
+            this,
+            buildSessionControl(
+                settings = activeSettings,
+                location = location,
+                resume = true,
+            ),
+        )
+        LiveTrackingSessionStore.setActive(
+            status = "Waiting for GPS fix",
+            serverSyncPending = true,
+        )
+        updateNotification("Tracking resumed; notifying Arkluz")
         startLocationUpdates()
         serviceScope.launch {
-            sendLastKnownLocationIfAvailable()
+            runCatching { flushPendingSessionControls() }
+            updateControlSyncStatus()
+        }
+    }
+
+    private fun buildSessionControl(
+        settings: LiveTrackingSettings,
+        location: Location,
+        pause: Boolean = false,
+        resume: Boolean = false,
+    ): ArkluzLocationUpdate =
+        arkluzClient.buildLocationUpdate(
+            settings = settings,
+            location = location,
+            start = false,
+            stop = false,
+            pause = pause,
+            resume = resume,
+            dateId = dateId,
+        )
+
+    private suspend fun flushPendingSessionControls() {
+        sendMutex.withLock {
+            flushPendingSessionControlsLocked()
+        }
+    }
+
+    private suspend fun flushPendingSessionControlsLocked(): Int {
+        var sentCount = 0
+        while (true) {
+            val update = LiveTrackingControlQueue.load(this).firstOrNull() ?: break
+            arkluzClient.sendLocationUpdate(update)
+            LiveTrackingControlQueue.removeFirst(this)
+            sentCount += 1
+        }
+        return sentCount
+    }
+
+    private suspend fun retryPendingControlsWhilePaused() {
+        while (isPaused && !isStopping && LiveTrackingControlQueue.load(this).isNotEmpty()) {
+            delay(CONTROL_RETRY_DELAY_MS)
+            if (!isPaused || isStopping) return
+            runCatching { flushPendingSessionControls() }
+            updateControlSyncStatus()
+        }
+    }
+
+    private fun updateControlSyncStatus() {
+        val serverSyncPending = LiveTrackingControlQueue.load(this).isNotEmpty()
+        if (isPaused) {
+            LiveTrackingSessionStore.setPaused(serverSyncPending)
+            updateNotification(
+                if (serverSyncPending) {
+                    "Paused on phone; Arkluz notification pending"
+                } else {
+                    "Live tracking paused"
+                },
+            )
+        } else {
+            LiveTrackingSessionStore.setActive(
+                status = "Tracking active",
+                serverSyncPending = serverSyncPending,
+            )
+            updateNotification(
+                if (serverSyncPending) {
+                    "Tracking active; Arkluz notification pending"
+                } else {
+                    "Live tracking active"
+                },
+            )
         }
     }
 
@@ -348,11 +465,13 @@ class LiveTrackingService : Service() {
                 stop = true,
             )
         sendMutex.withLock {
+            flushPendingSessionControlsLocked()
             arkluzClient.sendLocationUpdate(update)
         }
     }
 
     private fun finishStopped(status: String) {
+        LiveTrackingControlQueue.clear(this)
         LiveTrackingSessionStore.setStopped(status)
         ServiceCompat.stopForeground(this@LiveTrackingService, ServiceCompat.STOP_FOREGROUND_REMOVE)
         stopSelf()
@@ -401,7 +520,7 @@ class LiveTrackingService : Service() {
                     .setAction(if (isPaused) ACTION_RESUME else ACTION_PAUSE),
                 PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
             )
-        val pauseResumeLabel = if (isPaused) "Start" else "Pause"
+        val pauseResumeLabel = if (isPaused) "Resume" else "Pause"
         val builder =
             NotificationCompat
                 .Builder(this, CHANNEL_ID)
@@ -447,6 +566,7 @@ class LiveTrackingService : Service() {
         private const val MIN_UPDATE_INTERVAL_SECONDS = 15
         private const val MAX_UPDATE_INTERVAL_SECONDS = 600
         private const val STOP_RETRY_DELAY_MS = 30_000L
+        private const val CONTROL_RETRY_DELAY_MS = 30_000L
         private const val ACTION_STOP = "com.glancemap.glancemapcompanionapp.livetracking.STOP"
         private const val ACTION_PAUSE = "com.glancemap.glancemapcompanionapp.livetracking.PAUSE"
         private const val ACTION_RESUME = "com.glancemap.glancemapcompanionapp.livetracking.RESUME"
@@ -488,6 +608,18 @@ class LiveTrackingService : Service() {
         fun stop(context: Context) {
             context.startService(
                 Intent(context, LiveTrackingService::class.java).setAction(ACTION_STOP),
+            )
+        }
+
+        fun pause(context: Context) {
+            context.startService(
+                Intent(context, LiveTrackingService::class.java).setAction(ACTION_PAUSE),
+            )
+        }
+
+        fun resume(context: Context) {
+            context.startService(
+                Intent(context, LiveTrackingService::class.java).setAction(ACTION_RESUME),
             )
         }
 

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingSessionStore.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingSessionStore.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.asStateFlow
 
 data class LiveTrackingUiState(
     val isTracking: Boolean = false,
+    val isPaused: Boolean = false,
     val status: String = "Not started",
     val lastSuccessfulUpdateEpochMs: Long? = null,
     val lastError: String? = null,
@@ -18,6 +19,7 @@ object LiveTrackingSessionStore {
         _state.value =
             _state.value.copy(
                 isTracking = true,
+                isPaused = false,
                 status = "Starting",
                 lastError = null,
             )
@@ -42,6 +44,39 @@ object LiveTrackingSessionStore {
             )
     }
 
+    fun setPaused(serverSyncPending: Boolean = false) {
+        _state.value =
+            _state.value.copy(
+                isTracking = true,
+                isPaused = true,
+                status =
+                    if (serverSyncPending) {
+                        "Paused on phone — Arkluz notification pending"
+                    } else {
+                        "Paused"
+                    },
+                lastError = null,
+            )
+    }
+
+    fun setActive(
+        status: String,
+        serverSyncPending: Boolean = false,
+    ) {
+        _state.value =
+            _state.value.copy(
+                isTracking = true,
+                isPaused = false,
+                status =
+                    if (serverSyncPending) {
+                        "Tracking resumed — Arkluz notification pending"
+                    } else {
+                        status
+                    },
+                lastError = null,
+            )
+    }
+
     fun setError(message: String) {
         _state.value =
             _state.value.copy(
@@ -54,6 +89,7 @@ object LiveTrackingSessionStore {
         _state.value =
             _state.value.copy(
                 isTracking = false,
+                isPaused = false,
                 status = status,
                 lastError = null,
             )
@@ -66,6 +102,7 @@ object LiveTrackingSessionStore {
         _state.value =
             _state.value.copy(
                 isTracking = false,
+                isPaused = false,
                 status = status,
                 lastError = message,
             )
@@ -75,6 +112,7 @@ object LiveTrackingSessionStore {
         _state.value =
             _state.value.copy(
                 isTracking = false,
+                isPaused = false,
                 status = status,
             )
     }

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingSettingsContent.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingSettingsContent.kt
@@ -228,11 +228,13 @@ internal fun PasswordField(
 }
 
 @Composable
+@Suppress("FunctionNaming", "LongMethod")
 private fun NoMovementAlertInput(
     minutes: String,
     onMinutesChange: (String) -> Unit,
 ) {
     val isDisabled = minutes == "-1"
+    val validationMessage = validateNoMovementAlertMinutes(minutes)
 
     Column(
         verticalArrangement = Arrangement.spacedBy(6.dp),
@@ -245,7 +247,7 @@ private fun NoMovementAlertInput(
             Checkbox(
                 checked = isDisabled,
                 onCheckedChange = { disabled ->
-                    onMinutesChange(if (disabled) "-1" else "")
+                    onMinutesChange(if (disabled) "-1" else "15")
                 },
             )
             Text(
@@ -272,9 +274,18 @@ private fun NoMovementAlertInput(
                 value = if (isDisabled) "" else minutes,
                 onValueChange = onMinutesChange,
                 enabled = !isDisabled,
-                placeholder = { Text("default") },
+                placeholder = { Text("15") },
                 singleLine = true,
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                isError = !isDisabled && validationMessage != null,
+                supportingText =
+                    if (!isDisabled) {
+                        {
+                            Text(validationMessage ?: "Minimum 10 minutes")
+                        }
+                    } else {
+                        null
+                    },
                 modifier = Modifier.weight(1f),
             )
             Text(

--- a/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/livetracking/ArkluzSessionControlUrlTest.kt
+++ b/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/livetracking/ArkluzSessionControlUrlTest.kt
@@ -1,0 +1,55 @@
+package com.glancemap.glancemapcompanionapp.livetracking
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ArkluzSessionControlUrlTest {
+    @Test
+    fun pauseIncludesPauseAndDateIdWithoutStartingNewActivity() {
+        val url = buildArkluzLocationUrl(update(pause = true, dateId = "20260622-42"))
+
+        assertTrue("pause" in url.queryParameterNames)
+        assertFalse("start" in url.queryParameterNames)
+        assertFalse("resume" in url.queryParameterNames)
+        assertEquals("20260622-42", url.queryParameter("date_id"))
+    }
+
+    @Test
+    fun resumeIncludesResumeAndDateIdWithoutStartingNewActivity() {
+        val url = buildArkluzLocationUrl(update(resume = true, dateId = "20260622-42"))
+
+        assertTrue("resume" in url.queryParameterNames)
+        assertFalse("start" in url.queryParameterNames)
+        assertFalse("pause" in url.queryParameterNames)
+        assertEquals("20260622-42", url.queryParameter("date_id"))
+    }
+
+    private fun update(
+        pause: Boolean = false,
+        resume: Boolean = false,
+        dateId: String? = null,
+    ) = ArkluzLocationUpdate(
+        trackingUrl = "https://arkluz.com/trk",
+        latitude = 45.0,
+        longitude = 6.0,
+        altitudeMeters = null,
+        speedMetersPerSecond = null,
+        accuracyMeters = 5f,
+        epochSeconds = 1_750_000_000,
+        batteryPercent = 80,
+        gsmSignalPercent = -1,
+        group = "Alpes",
+        participantPassword = "secret",
+        userName = "André",
+        notificationEmails = "",
+        alertEmails = "",
+        stuckAlarmMinutes = "15",
+        start = false,
+        stop = false,
+        pause = pause,
+        resume = resume,
+        dateId = dateId,
+    )
+}

--- a/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/livetracking/ContentDispositionFileNameTest.kt
+++ b/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/livetracking/ContentDispositionFileNameTest.kt
@@ -1,0 +1,46 @@
+package com.glancemap.glancemapcompanionapp.livetracking
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ContentDispositionFileNameTest {
+    @Test
+    fun prefersAndDecodesUtf8ExtendedFilename() {
+        val header =
+            "attachment; filename=\"fallback.gpx\"; " +
+                "filename*=UTF-8''2026-06-22-Andr%C3%A9-%C3%89t%C3%A9.gpx"
+
+        assertEquals(
+            "2026-06-22-André-Été.gpx",
+            contentDispositionFileName(header),
+        )
+    }
+
+    @Test
+    fun preservesPlusCharactersInExtendedFilename() {
+        val header = "attachment; filename*=UTF-8''A+B%20C.gpx"
+
+        assertEquals("A+B C.gpx", contentDispositionFileName(header))
+    }
+
+    @Test
+    fun fallsBackToLegacyFilename() {
+        val header = "attachment; filename=\"recorded-track.gpx\""
+
+        assertEquals("recorded-track.gpx", contentDispositionFileName(header))
+    }
+
+    @Test
+    fun stripsPathComponentsFromServerFilename() {
+        val header = "attachment; filename*=UTF-8''..%2Fprivate%2Ftrack.gpx"
+
+        assertEquals("track.gpx", contentDispositionFileName(header))
+    }
+
+    @Test
+    fun returnsNullWithoutFilename() {
+        assertNull(contentDispositionFileName("attachment"))
+        assertNull(contentDispositionFileName(null))
+    }
+}

--- a/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/livetracking/NoMovementAlertValidationTest.kt
+++ b/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/livetracking/NoMovementAlertValidationTest.kt
@@ -1,0 +1,24 @@
+package com.glancemap.glancemapcompanionapp.livetracking
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NoMovementAlertValidationTest {
+    @Test
+    fun acceptsDisabledAndValuesAtLeastTenMinutes() {
+        assertNull(validateNoMovementAlertMinutes("-1"))
+        assertNull(validateNoMovementAlertMinutes("10"))
+        assertNull(validateNoMovementAlertMinutes("60"))
+    }
+
+    @Test
+    fun rejectsBlankInvalidAndTooSmallValues() {
+        val expected = "No-movement alert must be at least 10 minutes, or disabled."
+
+        assertEquals(expected, validateNoMovementAlertMinutes(""))
+        assertEquals(expected, validateNoMovementAlertMinutes("invalid"))
+        assertEquals(expected, validateNoMovementAlertMinutes("9"))
+        assertEquals(expected, validateNoMovementAlertMinutes("-2"))
+    }
+}


### PR DESCRIPTION
## Summary

This PR updates the companion app live tracking flow based on the latest Arkluz backend guidance.

Changes included:
- Switch Arkluz tracking to the production `/trk` endpoint.
- Keep the upload-before-start flow and preserve a small delay before starting, reducing duplicate start emails.
- Enforce the server-side no-movement alert minimum in the GUI: disabled is `-1`, enabled values must be at least 10 minutes, with 15 minutes shown as the clear default.
- Parse UTF-8 `filename*=` from GPX download `Content-Disposition` headers so accented user/group names are preserved.
- Add pause/resume support using `&pause` / `&resume`, with local-first behavior so the phone stops GPS immediately even offline and retries server notification later.
- Open Settings directly after the first successful login/create flow.

## Notes

SMS support and the authentication/key discussion are intentionally not implemented in this PR. We’ll handle those later once the product behavior is clearer.

## Validation

- `./gradlew :glancemapcompanionapp:testDebugUnitTest --tests 'com.glancemap.glancemapcompanionapp.livetracking.*' :glancemapcompanionapp:compileDebugKotlin --no-daemon --console=plain`
- `./gradlew :glancemapcompanionapp:detekt --no-daemon --console=plain`
- `git diff --check`