### PR TITLE
Fix stale POI route location preflight

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/AppContainer.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/AppContainer.kt
@@ -98,6 +98,7 @@ class DefaultAppContainer(
             gpxExportRepository = gpxExportRepository,
             syncManager = syncManager,
             settingsRepository = settingsRepository,
+            poiRepository = poiRepository,
             routePlanner = routePlanner,
             elevationProvider = RecordingElevationProvider(applicationContext),
         )

--- a/app/src/main/java/com/glancemap/glancemapwearos/AppContainer.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/AppContainer.kt
@@ -14,6 +14,7 @@ import com.glancemap.glancemapwearos.presentation.features.download.OamBundleDow
 import com.glancemap.glancemapwearos.presentation.features.download.OamDownloadNetworkMonitor
 import com.glancemap.glancemapwearos.presentation.features.download.OamDownloadNotificationController
 import com.glancemap.glancemapwearos.presentation.features.download.OamDownloadServiceClient
+import com.glancemap.glancemapwearos.presentation.features.gpx.GpxRouteServices
 import com.glancemap.glancemapwearos.presentation.features.gpx.GpxViewModel
 import com.glancemap.glancemapwearos.presentation.features.maps.MapViewModel
 import com.glancemap.glancemapwearos.presentation.features.maps.theme.ThemeViewModel
@@ -99,8 +100,11 @@ class DefaultAppContainer(
             syncManager = syncManager,
             settingsRepository = settingsRepository,
             poiRepository = poiRepository,
-            routePlanner = routePlanner,
-            elevationProvider = RecordingElevationProvider(applicationContext),
+            routeServices =
+                GpxRouteServices(
+                    planner = routePlanner,
+                    elevationProvider = RecordingElevationProvider(applicationContext),
+                ),
         )
     }
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/core/service/diagnostics/DiagnosticsExporter.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/core/service/diagnostics/DiagnosticsExporter.kt
@@ -1516,9 +1516,18 @@ object DiagnosticsExporter {
                     if (telemetryInsights.recordingGapEndpointDistanceSampleCount <= 0) {
                         "samples:0"
                     } else {
+                        val averageMeters =
+                            TelemetryFormatters.decimalOrNa(
+                                telemetryInsights.recordingGapEndpointDistanceAvgMeters,
+                                1,
+                            )
+                        val maximumMeters =
+                            TelemetryFormatters.decimalOrNa(
+                                telemetryInsights.recordingGapEndpointDistanceMaxMeters,
+                                1,
+                            )
                         "samples:${telemetryInsights.recordingGapEndpointDistanceSampleCount}," +
-                            "avg:${TelemetryFormatters.decimalOrNa(telemetryInsights.recordingGapEndpointDistanceAvgMeters, 1)}," +
-                            "max:${TelemetryFormatters.decimalOrNa(telemetryInsights.recordingGapEndpointDistanceMaxMeters, 1)}"
+                            "avg:$averageMeters,max:$maximumMeters"
                     },
             )
             writer.appendLine("recordingMaxGapMs=${telemetryInsights.recordingMaxGapMs?.toString() ?: "na"}")

--- a/app/src/main/java/com/glancemap/glancemapwearos/core/service/diagnostics/DiagnosticsExporter.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/core/service/diagnostics/DiagnosticsExporter.kt
@@ -371,6 +371,9 @@ object DiagnosticsExporter {
         var turnByTurnTurnAlertOffRouteCount: Int = 0
         var turnByTurnTurnAlertMissedWindowCount: Int = 0
         var recordingTrackFilter: RecordingTrackFilterInsights = RecordingTrackFilterInsights()
+        var recordingGapEndpointDistanceSampleCount: Int = 0
+        var recordingGapEndpointDistanceAvgMeters: Float? = null
+        var recordingGapEndpointDistanceMaxMeters: Float? = null
     }
 
     internal data class CompassTelemetryInsights(
@@ -1507,6 +1510,17 @@ object DiagnosticsExporter {
             )
             writer.appendLine("recordingGapCount=${telemetryInsights.recordingGapCount?.toString() ?: "na"}")
             writer.appendLine("recordingGapEventCount=${telemetryInsights.recordingGapEventCount}")
+            writer.appendLine("recordingGapDefinition=accepted_point_time_gap_not_confirmed_movement_loss")
+            writer.appendLine(
+                "recordingGapEndpointDistanceM=" +
+                    if (telemetryInsights.recordingGapEndpointDistanceSampleCount <= 0) {
+                        "samples:0"
+                    } else {
+                        "samples:${telemetryInsights.recordingGapEndpointDistanceSampleCount}," +
+                            "avg:${TelemetryFormatters.decimalOrNa(telemetryInsights.recordingGapEndpointDistanceAvgMeters, 1)}," +
+                            "max:${TelemetryFormatters.decimalOrNa(telemetryInsights.recordingGapEndpointDistanceMaxMeters, 1)}"
+                    },
+            )
             writer.appendLine("recordingMaxGapMs=${telemetryInsights.recordingMaxGapMs?.toString() ?: "na"}")
             writer.appendLine(
                 "recordingLastPointAgeMs=${telemetryInsights.recordingLastPointAgeMs?.toString() ?: "na"}",

--- a/app/src/main/java/com/glancemap/glancemapwearos/core/service/diagnostics/DiagnosticsExporter.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/core/service/diagnostics/DiagnosticsExporter.kt
@@ -876,6 +876,20 @@ object DiagnosticsExporter {
                     formatMarkerMotionMetricSummary(markerMotionSummary.nextFixPredictionResidualM, digits = 1),
             )
             writer.appendLine(
+                "markerMotionVisibleNextFixResidualM=" +
+                    formatMarkerMotionMetricSummary(
+                        markerMotionSummary.visibleNextFixPredictionResidualM,
+                        digits = 1,
+                    ),
+            )
+            writer.appendLine(
+                "markerMotionScreenOffNextFixResidualM=" +
+                    formatMarkerMotionMetricSummary(
+                        markerMotionSummary.screenOffNextFixPredictionResidualM,
+                        digits = 1,
+                    ),
+            )
+            writer.appendLine(
                 "markerMotionRenderStepPx=" +
                     formatMarkerMotionMetricSummary(markerMotionSummary.renderDisplacementPx, digits = 2),
             )
@@ -1951,6 +1965,20 @@ object DiagnosticsExporter {
             writer.appendLine(
                 "nextFixPredictionResidualM=" +
                     formatMarkerMotionMetricSummary(markerMotionSummary.nextFixPredictionResidualM, digits = 1),
+            )
+            writer.appendLine(
+                "visibleNextFixPredictionResidualM=" +
+                    formatMarkerMotionMetricSummary(
+                        markerMotionSummary.visibleNextFixPredictionResidualM,
+                        digits = 1,
+                    ),
+            )
+            writer.appendLine(
+                "screenOffNextFixPredictionResidualM=" +
+                    formatMarkerMotionMetricSummary(
+                        markerMotionSummary.screenOffNextFixPredictionResidualM,
+                        digits = 1,
+                    ),
             )
             writer.appendLine("correctionComponentSamples=${markerMotionSummary.correctionComponentSamples}")
             writer.appendLine(

--- a/app/src/main/java/com/glancemap/glancemapwearos/core/service/diagnostics/export/DiagnosticsExporterTelemetry.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/core/service/diagnostics/export/DiagnosticsExporterTelemetry.kt
@@ -205,6 +205,9 @@ internal fun deriveTelemetryInsights(
     var recordingPointCaptureRatePercent: Int? = null
     var recordingGapCount: Int? = null
     var recordingGapEventCount = 0
+    var recordingGapEndpointDistanceSampleCount = 0
+    var recordingGapEndpointDistanceSumMeters = 0.0
+    var recordingGapEndpointDistanceMaxMeters = 0f
     var recordingMaxGapMs: Long? = null
     var recordingLastPointAgeMs: Long? = null
     var recordingForcedAcceptCount: Int? = null
@@ -539,7 +542,15 @@ internal fun deriveTelemetryInsights(
                 "pause" -> recordingPauseCount += 1
                 "resume" -> recordingResumeCount += 1
                 "point" -> recordingPointSampleCount += 1
-                "gap" -> recordingGapEventCount += 1
+                "gap" -> {
+                    recordingGapEventCount += 1
+                    parseFloatToken(line, "gapEndpointDistanceM=")?.takeIf { it >= 0f }?.let { distance ->
+                        recordingGapEndpointDistanceSampleCount += 1
+                        recordingGapEndpointDistanceSumMeters += distance
+                        recordingGapEndpointDistanceMaxMeters =
+                            maxOf(recordingGapEndpointDistanceMaxMeters, distance)
+                    }
+                }
                 "gap_recovery_accept" -> {
                     parseIntToken(line, "gapRecoveryAcceptCount=")?.let { count ->
                         recordingGapRecoveryAcceptCount = maxOf(recordingGapRecoveryAcceptCount ?: count, count)
@@ -1329,6 +1340,15 @@ internal fun deriveTelemetryInsights(
         insights.turnByTurnTurnAlertFilteredCount = turnByTurnTurnAlertFilteredCount
         insights.turnByTurnTurnAlertOffRouteCount = turnByTurnTurnAlertOffRouteCount
         insights.turnByTurnTurnAlertMissedWindowCount = turnByTurnTurnAlertMissedWindowCount
+        insights.recordingGapEndpointDistanceSampleCount = recordingGapEndpointDistanceSampleCount
+        insights.recordingGapEndpointDistanceAvgMeters =
+            if (recordingGapEndpointDistanceSampleCount > 0) {
+                (recordingGapEndpointDistanceSumMeters / recordingGapEndpointDistanceSampleCount).toFloat()
+            } else {
+                null
+            }
+        insights.recordingGapEndpointDistanceMaxMeters =
+            recordingGapEndpointDistanceMaxMeters.takeIf { recordingGapEndpointDistanceSampleCount > 0 }
         insights.recordingTrackFilter =
             RecordingTrackFilterInsights(
                 smoothingMode = recordingTrackSmoothingMode,

--- a/app/src/main/java/com/glancemap/glancemapwearos/data/repository/PoiFileStorage.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/data/repository/PoiFileStorage.kt
@@ -1,0 +1,52 @@
+package com.glancemap.glancemapwearos.data.repository
+
+import com.glancemap.glancemapwearos.data.repository.internal.AtomicStreamWriter
+import java.io.File
+import java.io.InputStream
+import java.util.Locale
+
+/** Owns atomic POI file writes, independent of POI database reads and metadata. */
+internal class PoiFileStorage(
+    private val poiDir: File,
+) {
+    fun list(): List<File> =
+        if (!poiDir.exists()) {
+            emptyList()
+        } else {
+            poiDir
+                .listFiles { _, name -> name.endsWith(".poi", ignoreCase = true) }
+                ?.sortedBy { it.name.lowercase(Locale.ROOT) }
+                ?: emptyList()
+        }
+
+    suspend fun saveAtomic(
+        fileName: String,
+        inputStream: InputStream,
+        onProgress: (bytesCopied: Long) -> Unit,
+        expectedSize: Long?,
+        resumeOffset: Long,
+    ): String? {
+        val expectedBytes = expectedSize?.takeIf { it > 0L }
+        val options =
+            AtomicStreamWriter.Options(
+                bufferSize = 1024 * 1024,
+                progressStepBytes = 2L * 1024 * 1024,
+                fsync = true,
+                failIfExists = false,
+                expectedSize = expectedBytes,
+                requireExactSize = (expectedBytes != null),
+                resumeOffset = resumeOffset.coerceAtLeast(0L),
+                keepPartialOnCancel = true,
+                keepPartialOnFailure = true,
+                computeSha256 = true,
+            )
+        return AtomicStreamWriter
+            .writeAtomic(
+                dir = poiDir,
+                fileName = fileName,
+                inputStream = inputStream,
+                onProgress = onProgress,
+                options = options,
+            ).sha256
+    }
+}

--- a/app/src/main/java/com/glancemap/glancemapwearos/data/repository/PoiGpxWaypointLinks.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/data/repository/PoiGpxWaypointLinks.kt
@@ -1,0 +1,104 @@
+package com.glancemap.glancemapwearos.data.repository
+
+import android.database.sqlite.SQLiteDatabase
+import java.io.File
+import java.util.Locale
+
+/** Handles the small POI-file metadata index created for GPX waypoints. */
+internal class PoiGpxWaypointLinks(
+    private val poiDir: File,
+) {
+    fun read(path: String): String? {
+        val poiFile = File(path)
+        if (!poiFile.exists() || !poiFile.isFile) return null
+        return readMetadataFileName(poiFile) ?: legacyFileName(poiFile)
+    }
+
+    fun find(linkedGpxFileName: String): List<File> {
+        val normalizedFileName = normalizeFileName(linkedGpxFileName)
+        if (normalizedFileName.isBlank() || !poiDir.exists()) return emptyList()
+        val legacyFileName = legacyPoiFileName(normalizedFileName)
+        return poiDir
+            .listFiles { _, name -> name.endsWith(".poi", ignoreCase = true) }
+            .orEmpty()
+            .filter { poiFile ->
+                readMetadataFileName(poiFile)?.equals(normalizedFileName, ignoreCase = true) == true ||
+                    poiFile.name.equals(legacyFileName, ignoreCase = true)
+            }.sortedBy { it.name.lowercase(Locale.ROOT) }
+    }
+
+    fun update(
+        previousGpxFileName: String,
+        newGpxFileName: String,
+    ): Int {
+        val previousName = normalizeFileName(previousGpxFileName)
+        val newName = normalizeFileName(newGpxFileName)
+        if (previousName.isBlank() || newName.isBlank() || !poiDir.exists()) return 0
+        return poiDir
+            .listFiles { _, name -> name.endsWith(".poi", ignoreCase = true) }
+            .orEmpty()
+            .filter { poiFile ->
+                readMetadataFileName(poiFile)?.equals(previousName, ignoreCase = true) == true
+            }.count { poiFile ->
+                runCatching {
+                    SQLiteDatabase
+                        .openDatabase(
+                            poiFile.absolutePath,
+                            null,
+                            SQLiteDatabase.OPEN_READWRITE,
+                        ).use { db ->
+                            db.execSQL(
+                                "UPDATE metadata SET value = ? WHERE name = ?",
+                                arrayOf(newName, LINKED_GPX_FILE_NAME_KEY),
+                            )
+                        }
+                }.isSuccess
+            }
+    }
+
+    private fun readMetadataFileName(poiFile: File): String? =
+        runCatching {
+            SQLiteDatabase
+                .openDatabase(poiFile.absolutePath, null, SQLiteDatabase.OPEN_READONLY)
+                .use { db ->
+                    db
+                        .rawQuery(
+                            "SELECT value FROM metadata WHERE name = ? LIMIT 1",
+                            arrayOf(LINKED_GPX_FILE_NAME_KEY),
+                        ).use { cursor ->
+                            if (!cursor.moveToFirst()) return@use null
+                            cursor
+                                .getString(0)
+                                ?.trim()
+                                ?.takeIf { it.isNotBlank() }
+                                ?.let(::normalizeFileName)
+                        }
+                }
+        }.getOrNull()
+
+    private fun legacyFileName(poiFile: File): String? {
+        val name = poiFile.name
+        if (!name.endsWith(LEGACY_WAYPOINT_SUFFIX, ignoreCase = true)) return null
+        return name
+            .substring(0, name.length - LEGACY_WAYPOINT_SUFFIX.length)
+            .takeIf { it.isNotBlank() }
+            ?.plus(".gpx")
+    }
+
+    private fun legacyPoiFileName(gpxFileName: String): String {
+        val base =
+            normalizeFileName(gpxFileName)
+                .removeSuffix(".gpx")
+                .replace(Regex("[^A-Za-z0-9._-]"), "_")
+                .trim('_')
+                .ifBlank { "gpx-waypoints" }
+        return "${base}$LEGACY_WAYPOINT_SUFFIX"
+    }
+
+    private fun normalizeFileName(value: String): String = File(value).name.trim()
+
+    private companion object {
+        const val LINKED_GPX_FILE_NAME_KEY = "linked_gpx_file_name"
+        const val LEGACY_WAYPOINT_SUFFIX = "__waypoints.poi"
+    }
+}

--- a/app/src/main/java/com/glancemap/glancemapwearos/data/repository/PoiRepository.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/data/repository/PoiRepository.kt
@@ -76,7 +76,7 @@ interface PoiRepository {
     /** The GPX file that supplied this imported waypoint folder, if any. */
     suspend fun readLinkedGpxWaypointFileName(path: String): String?
 
-    suspend fun findGpxWaypointPoiFiles(linkedGpxFileName: String): List<File>
+    suspend fun findGpxWaypointPoiFiles(gpxFileName: String): List<File>
 
     suspend fun updateLinkedGpxWaypointFileName(
         previousGpxFileName: String,

--- a/app/src/main/java/com/glancemap/glancemapwearos/data/repository/PoiRepository.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/data/repository/PoiRepository.kt
@@ -73,6 +73,16 @@ interface PoiRepository {
 
     suspend fun readCoverageBounds(path: String): GeoBounds?
 
+    /** The GPX file that supplied this imported waypoint folder, if any. */
+    suspend fun readLinkedGpxWaypointFileName(path: String): String?
+
+    suspend fun findGpxWaypointPoiFiles(linkedGpxFileName: String): List<File>
+
+    suspend fun updateLinkedGpxWaypointFileName(
+        previousGpxFileName: String,
+        newGpxFileName: String,
+    ): Int
+
     suspend fun isFileEnabled(path: String): Boolean
 
     suspend fun setFileEnabled(

--- a/app/src/main/java/com/glancemap/glancemapwearos/data/repository/PoiRepositoryImpl.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/data/repository/PoiRepositoryImpl.kt
@@ -174,6 +174,68 @@ class PoiRepositoryImpl(
 
     override suspend fun readCoverageBounds(path: String) = withContext(Dispatchers.IO) { readPoiCoverageBounds(path) }
 
+    override suspend fun readLinkedGpxWaypointFileName(path: String): String? =
+        withContext(Dispatchers.IO) {
+            val poiFile = File(path)
+            if (!poiFile.exists() || !poiFile.isFile) return@withContext null
+            readLinkedGpxWaypointFileName(poiFile) ?: legacyLinkedGpxWaypointFileName(poiFile)
+        }
+
+    override suspend fun findGpxWaypointPoiFiles(linkedGpxFileName: String): List<File> =
+        withContext(Dispatchers.IO) {
+            val normalizedGpxFileName = File(linkedGpxFileName).name
+            if (normalizedGpxFileName.isBlank() || !poiDir.exists()) return@withContext emptyList()
+            poiDir
+                .listFiles { _, name -> name.endsWith(".poi", ignoreCase = true) }
+                .orEmpty()
+                .filter { poiFile ->
+                    val linkedFileName = readLinkedGpxWaypointFileName(poiFile)
+                    val matchesMetadata =
+                        linkedFileName.equals(
+                            normalizedGpxFileName,
+                            ignoreCase = true,
+                        )
+                    val matchesLegacyName =
+                        poiFile.name.equals(
+                            legacyWaypointPoiFileName(normalizedGpxFileName),
+                            ignoreCase = true,
+                        )
+                    matchesMetadata || matchesLegacyName
+                }.sortedBy { it.name.lowercase(Locale.ROOT) }
+        }
+
+    override suspend fun updateLinkedGpxWaypointFileName(
+        previousGpxFileName: String,
+        newGpxFileName: String,
+    ): Int =
+        withContext(Dispatchers.IO) {
+            val previousName = normalizeGpxFileName(previousGpxFileName)
+            val newName = normalizeGpxFileName(newGpxFileName)
+            if (previousName.isBlank() || newName.isBlank() || !poiDir.exists()) {
+                return@withContext 0
+            }
+            poiDir
+                .listFiles { _, name -> name.endsWith(".poi", ignoreCase = true) }
+                .orEmpty()
+                .filter { poiFile ->
+                    readLinkedGpxWaypointFileName(poiFile)?.equals(previousName, ignoreCase = true) == true
+                }.count { poiFile ->
+                    runCatching {
+                        SQLiteDatabase
+                            .openDatabase(
+                                poiFile.absolutePath,
+                                null,
+                                SQLiteDatabase.OPEN_READWRITE,
+                            ).use { db ->
+                                db.execSQL(
+                                    "UPDATE metadata SET value = ? WHERE name = ?",
+                                    arrayOf(newName, "linked_gpx_file_name"),
+                                )
+                            }
+                    }.isSuccess
+                }
+        }
+
     override suspend fun isFileEnabled(path: String): Boolean =
         withContext(Dispatchers.IO) {
             prefs.getBoolean(fileEnabledKey(path), false)
@@ -633,6 +695,43 @@ class PoiRepositoryImpl(
         }
 
     private fun openPoiDatabase(path: String): SQLiteDatabase = SQLiteDatabase.openDatabase(path, null, SQLiteDatabase.OPEN_READONLY)
+
+    private fun readLinkedGpxWaypointFileName(poiFile: File): String? =
+        runCatching {
+            openPoiDatabase(poiFile.absolutePath).use { db ->
+                db
+                    .rawQuery(
+                        "SELECT value FROM metadata WHERE name = ? LIMIT 1",
+                        arrayOf("linked_gpx_file_name"),
+                    ).use { cursor ->
+                        if (!cursor.moveToFirst()) return@use null
+                        val rawValue = cursor.getString(0)?.trim()
+                        rawValue?.takeIf { it.isNotBlank() }?.let(::normalizeGpxFileName)
+                    }
+            }
+        }.getOrNull()
+
+    private fun legacyLinkedGpxWaypointFileName(poiFile: File): String? {
+        val suffix = "__waypoints.poi"
+        val name = poiFile.name
+        if (!name.endsWith(suffix, ignoreCase = true)) return null
+        return name
+            .substring(0, name.length - suffix.length)
+            .takeIf { it.isNotBlank() }
+            ?.plus(".gpx")
+    }
+
+    private fun legacyWaypointPoiFileName(gpxFileName: String): String {
+        val base =
+            normalizeGpxFileName(gpxFileName)
+                .removeSuffix(".gpx")
+                .replace(Regex("[^A-Za-z0-9._-]"), "_")
+                .trim('_')
+                .ifBlank { "gpx-waypoints" }
+        return "${base}__waypoints.poi"
+    }
+
+    private fun normalizeGpxFileName(value: String): String = File(value).name.trim()
 
     private fun fileEnabledKey(path: String): String = KEY_FILE_ENABLED_PREFIX + File(path).name.lowercase(Locale.ROOT)
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/data/repository/PoiRepositoryImpl.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/data/repository/PoiRepositoryImpl.kt
@@ -3,7 +3,6 @@ package com.glancemap.glancemapwearos.data.repository
 import android.content.Context
 import android.content.SharedPreferences
 import android.database.sqlite.SQLiteDatabase
-import com.glancemap.glancemapwearos.data.repository.internal.AtomicStreamWriter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -15,6 +14,8 @@ class PoiRepositoryImpl(
     private val context: Context,
 ) : PoiRepository {
     private val poiDir by lazy { context.getDir("poi", Context.MODE_PRIVATE) }
+    private val poiFiles by lazy { PoiFileStorage(poiDir) }
+    private val links by lazy { PoiGpxWaypointLinks(poiDir) }
 
     private val prefs: SharedPreferences by lazy {
         context.getSharedPreferences("poi_metadata", Context.MODE_PRIVATE)
@@ -26,14 +27,7 @@ class PoiRepositoryImpl(
         private const val KEY_ENABLED_CATEGORY_PREFIX = "enabled_categories_"
     }
 
-    override suspend fun listPoiFiles(): List<File> =
-        withContext(Dispatchers.IO) {
-            if (!poiDir.exists()) return@withContext emptyList()
-            poiDir
-                .listFiles { _, name -> name.endsWith(".poi", ignoreCase = true) }
-                ?.sortedBy { it.name.lowercase(Locale.ROOT) }
-                ?: emptyList()
-        }
+    override suspend fun listPoiFiles(): List<File> = withContext(Dispatchers.IO) { poiFiles.list() }
 
     override suspend fun savePoiFileAtomic(
         fileName: String,
@@ -43,29 +37,7 @@ class PoiRepositoryImpl(
         resumeOffset: Long,
     ): String? =
         withContext(Dispatchers.IO) {
-            val exp = expectedSize?.takeIf { it > 0L }
-            val options =
-                AtomicStreamWriter.Options(
-                    bufferSize = 1024 * 1024,
-                    progressStepBytes = 2L * 1024 * 1024,
-                    fsync = true,
-                    failIfExists = false,
-                    expectedSize = exp,
-                    requireExactSize = (exp != null),
-                    resumeOffset = resumeOffset.coerceAtLeast(0L),
-                    keepPartialOnCancel = true,
-                    keepPartialOnFailure = true,
-                    computeSha256 = true,
-                )
-            val result =
-                AtomicStreamWriter.writeAtomic(
-                    dir = poiDir,
-                    fileName = fileName,
-                    inputStream = inputStream,
-                    onProgress = onProgress,
-                    options = options,
-                )
-            result.sha256
+            poiFiles.saveAtomic(fileName, inputStream, onProgress, expectedSize, resumeOffset)
         }
 
     override suspend fun deletePoiFile(path: String): Boolean =
@@ -174,66 +146,16 @@ class PoiRepositoryImpl(
 
     override suspend fun readCoverageBounds(path: String) = withContext(Dispatchers.IO) { readPoiCoverageBounds(path) }
 
-    override suspend fun readLinkedGpxWaypointFileName(path: String): String? =
-        withContext(Dispatchers.IO) {
-            val poiFile = File(path)
-            if (!poiFile.exists() || !poiFile.isFile) return@withContext null
-            readLinkedGpxWaypointFileName(poiFile) ?: legacyLinkedGpxWaypointFileName(poiFile)
-        }
+    override suspend fun readLinkedGpxWaypointFileName(path: String): String? = poiIo { links.read(path) }
 
-    override suspend fun findGpxWaypointPoiFiles(linkedGpxFileName: String): List<File> =
-        withContext(Dispatchers.IO) {
-            val normalizedGpxFileName = File(linkedGpxFileName).name
-            if (normalizedGpxFileName.isBlank() || !poiDir.exists()) return@withContext emptyList()
-            poiDir
-                .listFiles { _, name -> name.endsWith(".poi", ignoreCase = true) }
-                .orEmpty()
-                .filter { poiFile ->
-                    val linkedFileName = readLinkedGpxWaypointFileName(poiFile)
-                    val matchesMetadata =
-                        linkedFileName.equals(
-                            normalizedGpxFileName,
-                            ignoreCase = true,
-                        )
-                    val matchesLegacyName =
-                        poiFile.name.equals(
-                            legacyWaypointPoiFileName(normalizedGpxFileName),
-                            ignoreCase = true,
-                        )
-                    matchesMetadata || matchesLegacyName
-                }.sortedBy { it.name.lowercase(Locale.ROOT) }
-        }
+    override suspend fun findGpxWaypointPoiFiles(gpxFileName: String): List<File> = poiIo { links.find(gpxFileName) }
 
     override suspend fun updateLinkedGpxWaypointFileName(
         previousGpxFileName: String,
         newGpxFileName: String,
     ): Int =
         withContext(Dispatchers.IO) {
-            val previousName = normalizeGpxFileName(previousGpxFileName)
-            val newName = normalizeGpxFileName(newGpxFileName)
-            if (previousName.isBlank() || newName.isBlank() || !poiDir.exists()) {
-                return@withContext 0
-            }
-            poiDir
-                .listFiles { _, name -> name.endsWith(".poi", ignoreCase = true) }
-                .orEmpty()
-                .filter { poiFile ->
-                    readLinkedGpxWaypointFileName(poiFile)?.equals(previousName, ignoreCase = true) == true
-                }.count { poiFile ->
-                    runCatching {
-                        SQLiteDatabase
-                            .openDatabase(
-                                poiFile.absolutePath,
-                                null,
-                                SQLiteDatabase.OPEN_READWRITE,
-                            ).use { db ->
-                                db.execSQL(
-                                    "UPDATE metadata SET value = ? WHERE name = ?",
-                                    arrayOf(newName, "linked_gpx_file_name"),
-                                )
-                            }
-                    }.isSuccess
-                }
+            links.update(previousGpxFileName, newGpxFileName)
         }
 
     override suspend fun isFileEnabled(path: String): Boolean =
@@ -695,43 +617,6 @@ class PoiRepositoryImpl(
         }
 
     private fun openPoiDatabase(path: String): SQLiteDatabase = SQLiteDatabase.openDatabase(path, null, SQLiteDatabase.OPEN_READONLY)
-
-    private fun readLinkedGpxWaypointFileName(poiFile: File): String? =
-        runCatching {
-            openPoiDatabase(poiFile.absolutePath).use { db ->
-                db
-                    .rawQuery(
-                        "SELECT value FROM metadata WHERE name = ? LIMIT 1",
-                        arrayOf("linked_gpx_file_name"),
-                    ).use { cursor ->
-                        if (!cursor.moveToFirst()) return@use null
-                        val rawValue = cursor.getString(0)?.trim()
-                        rawValue?.takeIf { it.isNotBlank() }?.let(::normalizeGpxFileName)
-                    }
-            }
-        }.getOrNull()
-
-    private fun legacyLinkedGpxWaypointFileName(poiFile: File): String? {
-        val suffix = "__waypoints.poi"
-        val name = poiFile.name
-        if (!name.endsWith(suffix, ignoreCase = true)) return null
-        return name
-            .substring(0, name.length - suffix.length)
-            .takeIf { it.isNotBlank() }
-            ?.plus(".gpx")
-    }
-
-    private fun legacyWaypointPoiFileName(gpxFileName: String): String {
-        val base =
-            normalizeGpxFileName(gpxFileName)
-                .removeSuffix(".gpx")
-                .replace(Regex("[^A-Za-z0-9._-]"), "_")
-                .trim('_')
-                .ifBlank { "gpx-waypoints" }
-        return "${base}__waypoints.poi"
-    }
-
-    private fun normalizeGpxFileName(value: String): String = File(value).name.trim()
 
     private fun fileEnabledKey(path: String): String = KEY_FILE_ENABLED_PREFIX + File(path).name.lowercase(Locale.ROOT)
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/data/repository/PoiRepositoryIo.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/data/repository/PoiRepositoryIo.kt
@@ -1,0 +1,6 @@
+package com.glancemap.glancemapwearos.data.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+internal suspend fun <T> poiIo(block: () -> T): T = withContext(Dispatchers.IO) { block() }

--- a/app/src/main/java/com/glancemap/glancemapwearos/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/data/repository/SettingsRepository.kt
@@ -78,6 +78,7 @@ interface SettingsRepository {
         const val GPX_LIST_PAGE_HIKE_ACTIVITIES = "HIKE_ACTIVITIES"
         const val GPX_LIST_PAGE_BIKE_ACTIVITIES = "BIKE_ACTIVITIES"
         const val DEFAULT_GPX_LIST_PAGE = GPX_LIST_PAGE_TRACKS
+        const val DEFAULT_LINK_GPX_WAYPOINT_POI_FOLDERS = true
         const val DEFAULT_USER_WEIGHT_KG = 75f
         const val MIN_USER_WEIGHT_KG = 35f
         const val MAX_USER_WEIGHT_KG = 160f
@@ -725,6 +726,10 @@ interface SettingsRepository {
     val poiTapToCenterEnabled: Flow<Boolean>
 
     suspend fun setPoiTapToCenterEnabled(enabled: Boolean)
+
+    val linkGpxWaypointPoiFolders: Flow<Boolean>
+
+    suspend fun setLinkGpxWaypointPoiFolders(enabled: Boolean)
 
     val poiPopupTimeoutSeconds: Flow<Int>
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/data/repository/SettingsRepositoryImpl.kt
@@ -185,6 +185,7 @@ class SettingsRepositoryImpl private constructor(
         val POI_ICON_SIZE_PX = intPreferencesKey("poi_icon_size_px")
         val POI_MARKER_STYLE = stringPreferencesKey("poi_marker_style")
         val POI_TAP_TO_CENTER_ENABLED = booleanPreferencesKey("poi_tap_to_center_enabled")
+        val LINK_GPX_WAYPOINT_POI_FOLDERS = booleanPreferencesKey("link_gpx_waypoint_poi_folders")
         val POI_POPUP_TIMEOUT_SECONDS = intPreferencesKey("poi_popup_timeout_seconds")
         val POI_POPUP_MANUAL_CLOSE_ONLY = booleanPreferencesKey("poi_popup_manual_close_only")
     }
@@ -1662,6 +1663,16 @@ class SettingsRepositoryImpl private constructor(
 
     override suspend fun setPoiTapToCenterEnabled(enabled: Boolean) {
         context.dataStore.edit { it[PrefKeys.POI_TAP_TO_CENTER_ENABLED] = enabled }
+    }
+
+    override val linkGpxWaypointPoiFolders: Flow<Boolean> =
+        context.dataStore.data.map {
+            it[PrefKeys.LINK_GPX_WAYPOINT_POI_FOLDERS]
+                ?: SettingsRepository.DEFAULT_LINK_GPX_WAYPOINT_POI_FOLDERS
+        }
+
+    override suspend fun setLinkGpxWaypointPoiFolders(enabled: Boolean) {
+        context.dataStore.edit { it[PrefKeys.LINK_GPX_WAYPOINT_POI_FOLDERS] = enabled }
     }
 
     override val poiPopupTimeoutSeconds: Flow<Int> =

--- a/app/src/main/java/com/glancemap/glancemapwearos/domain/sensors/FusedOrientationProviderAdapter.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/domain/sensors/FusedOrientationProviderAdapter.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import java.util.concurrent.Executor
-import kotlin.math.abs
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class FusedOrientationProviderAdapter(
@@ -156,11 +155,14 @@ internal class FusedOrientationProviderAdapter(
 
     @Volatile private var lastFusedHeadingPublishAtElapsedMs = 0L
 
-    @Volatile private var activeTurnPublishUntilElapsedMs = 0L
-
-    @Volatile private var lastRelativeTurnHeadingDeg: Float? = null
-
-    @Volatile private var lastRelativeTurnAtElapsedMs = 0L
+    private val activeTurnPublicationTracker =
+        HeadingTurnRateHysteresis(
+            enterRateDegPerSec = FUSED_ACTIVE_TURN_ENTER_RATE_DEG_PER_SEC,
+            exitRateDegPerSec = FUSED_ACTIVE_TURN_EXIT_RATE_DEG_PER_SEC,
+            exitHoldMs = FUSED_ACTIVE_TURN_EXIT_HOLD_MS,
+            minimumEntryStepDeg = FUSED_ACTIVE_TURN_MIN_STEP_DEG,
+            maximumSampleGapMs = FUSED_ACTIVE_TURN_MAX_SAMPLE_GAP_MS,
+        )
 
     @Volatile private var lastConfirmedFusedSampleElapsedRealtimeMs = 0L
 
@@ -310,9 +312,7 @@ internal class FusedOrientationProviderAdapter(
         )
         latestIntegritySnapshot = headingIntegrityEngine.snapshot()
         lastFusedHeadingPublishAtElapsedMs = 0L
-        activeTurnPublishUntilElapsedMs = 0L
-        lastRelativeTurnHeadingDeg = null
-        lastRelativeTurnAtElapsedMs = 0L
+        activeTurnPublicationTracker.reset()
         lastConfirmedFusedSampleElapsedRealtimeMs = 0L
         fusedStaleRecoveryAttempted = false
         fusedStaleRecoveryStartedAtElapsedMs = 0L
@@ -551,9 +551,7 @@ internal class FusedOrientationProviderAdapter(
     ) {
         val nowElapsedMs = SystemClock.elapsedRealtime()
         lastFusedHeadingPublishAtElapsedMs = 0L
-        activeTurnPublishUntilElapsedMs = 0L
-        lastRelativeTurnHeadingDeg = null
-        lastRelativeTurnAtElapsedMs = 0L
+        activeTurnPublicationTracker.reset()
         markHeadingPendingRestart(
             preserveRecentFusedHeading = preserveRecentFusedHeading,
         )
@@ -598,7 +596,6 @@ internal class FusedOrientationProviderAdapter(
                             horizontalProjection = witness.horizontalProjection,
                         )
                 } else {
-                    updateActiveTurnPublicationState(headingDeg, atElapsedMs)
                     latestIntegritySnapshot =
                         headingIntegrityEngine.onRelativeHeading(
                             headingDeg = headingDeg,
@@ -736,6 +733,10 @@ internal class FusedOrientationProviderAdapter(
             atElapsedMs = arrivalElapsedMs,
         )
         val renderHeadingDeg = snapshot.renderHeadingDeg ?: return
+        activeTurnPublicationTracker.update(
+            headingDeg = renderHeadingDeg,
+            atElapsedMs = arrivalElapsedMs,
+        )
         if (firstUsableForRequest) {
             forcePublishFusedHeading(
                 displayHeading = renderHeadingDeg,
@@ -856,8 +857,7 @@ internal class FusedOrientationProviderAdapter(
     ) {
         val activeTurn =
             !lowPowerMode &&
-                latestIntegritySnapshot.relativeWitnessSupportsHighRate &&
-                nowElapsedMs <= activeTurnPublishUntilElapsedMs
+                activeTurnPublicationTracker.active
         if (
             !shouldPublishFusedHeading(
                 nowElapsedMs = nowElapsedMs,
@@ -880,23 +880,6 @@ internal class FusedOrientationProviderAdapter(
         updateHeadingSourceState(HeadingSource.FUSED_ORIENTATION)
         lastFusedHeadingPublishAtElapsedMs = nowElapsedMs
         recordFusedPerfHeadingPublish(nowElapsedMs, activeTurn)
-    }
-
-    private fun updateActiveTurnPublicationState(
-        relativeHeadingDeg: Float,
-        atElapsedMs: Long,
-    ) {
-        val previousHeadingDeg = lastRelativeTurnHeadingDeg
-        val previousAtElapsedMs = lastRelativeTurnAtElapsedMs
-        lastRelativeTurnHeadingDeg = relativeHeadingDeg
-        lastRelativeTurnAtElapsedMs = atElapsedMs
-        if (lowPowerMode || previousHeadingDeg == null || previousAtElapsedMs <= 0L) return
-        val elapsedMs = atElapsedMs - previousAtElapsedMs
-        if (elapsedMs !in 1L..FUSED_ACTIVE_TURN_MAX_SAMPLE_GAP_MS) return
-        val stepDeg = abs(shortestAngleDiffDeg(relativeHeadingDeg, previousHeadingDeg))
-        if (isActiveRelativeTurnStep(stepDeg, elapsedMs)) {
-            activeTurnPublishUntilElapsedMs = atElapsedMs + FUSED_ACTIVE_TURN_PUBLISH_HOLD_MS
-        }
     }
 
     private fun forcePublishFusedHeading(
@@ -1331,9 +1314,10 @@ private const val FUSED_NORMAL_PUBLISH_MIN_INTERVAL_MS = 40L // 25 Hz
 private const val FUSED_ACTIVE_TURN_PUBLISH_MIN_INTERVAL_MS = 20L // 50 Hz
 private const val FUSED_LOW_POWER_PUBLISH_MIN_INTERVAL_MS = 180L
 private const val FUSED_ACTIVE_TURN_MIN_STEP_DEG = 0.4f
-private const val FUSED_ACTIVE_TURN_MIN_RATE_DEG_PER_SEC = 30f
+private const val FUSED_ACTIVE_TURN_ENTER_RATE_DEG_PER_SEC = 30f
+private const val FUSED_ACTIVE_TURN_EXIT_RATE_DEG_PER_SEC = 15f
+private const val FUSED_ACTIVE_TURN_EXIT_HOLD_MS = 300L
 private const val FUSED_ACTIVE_TURN_MAX_SAMPLE_GAP_MS = 300L
-private const val FUSED_ACTIVE_TURN_PUBLISH_HOLD_MS = 300L
 private const val FUSED_RECALIBRATION_HIGH_POWER_WINDOW_MS = 6_000L
 private const val FUSED_WARM_RESTART_CACHED_HEADING_MAX_AGE_MS = 5_000L
 private const val FUSED_UNUSABLE_HEADING_FALLBACK_MIN_SAMPLES = 5
@@ -1356,14 +1340,4 @@ internal fun shouldPublishFusedHeading(
             FUSED_NORMAL_PUBLISH_MIN_INTERVAL_MS
         }
     return nowElapsedMs - lastPublishAtElapsedMs >= minimumIntervalMs
-}
-
-internal fun isActiveRelativeTurnStep(
-    stepDeg: Float,
-    elapsedMs: Long,
-): Boolean {
-    if (!stepDeg.isFinite() || elapsedMs !in 1L..FUSED_ACTIVE_TURN_MAX_SAMPLE_GAP_MS) return false
-    val rateDegPerSec = abs(stepDeg) * 1_000f / elapsedMs
-    return abs(stepDeg) >= FUSED_ACTIVE_TURN_MIN_STEP_DEG &&
-        rateDegPerSec >= FUSED_ACTIVE_TURN_MIN_RATE_DEG_PER_SEC
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/domain/sensors/HeadingTurnRateHysteresis.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/domain/sensors/HeadingTurnRateHysteresis.kt
@@ -1,0 +1,81 @@
+package com.glancemap.glancemapwearos.domain.sensors
+
+import kotlin.math.abs
+
+/**
+ * Tracks deliberate heading movement without repeatedly switching between steady and turning
+ * modes when the measured angular speed sits close to a threshold.
+ */
+internal class HeadingTurnRateHysteresis(
+    private val enterRateDegPerSec: Float,
+    private val exitRateDegPerSec: Float,
+    private val exitHoldMs: Long,
+    private val minimumEntryStepDeg: Float,
+    private val maximumSampleGapMs: Long,
+) {
+    @Volatile
+    var active: Boolean = false
+        private set
+
+    private var previousHeadingDeg: Float? = null
+    private var previousSampleAtElapsedMs: Long = 0L
+    private var belowExitRateSinceElapsedMs: Long = 0L
+
+    init {
+        require(enterRateDegPerSec > exitRateDegPerSec)
+        require(exitRateDegPerSec >= 0f)
+        require(exitHoldMs >= 0L)
+        require(minimumEntryStepDeg >= 0f)
+        require(maximumSampleGapMs > 0L)
+    }
+
+    fun update(
+        headingDeg: Float,
+        atElapsedMs: Long,
+    ): Boolean {
+        if (!headingDeg.isFinite()) return active
+        val previousHeading = previousHeadingDeg
+        val elapsedMs = atElapsedMs - previousSampleAtElapsedMs
+        previousHeadingDeg = headingDeg
+        previousSampleAtElapsedMs = atElapsedMs
+
+        if (previousHeading == null || elapsedMs !in 1L..maximumSampleGapMs) {
+            active = false
+            belowExitRateSinceElapsedMs = 0L
+        } else {
+            val stepDeg = abs(shortestAngleDiffDeg(headingDeg, previousHeading))
+            val rateDegPerSec = stepDeg * MILLIS_PER_SECOND / elapsedMs.toFloat()
+            when {
+                !active && stepDeg >= minimumEntryStepDeg && rateDegPerSec >= enterRateDegPerSec -> {
+                    active = true
+                    belowExitRateSinceElapsedMs = 0L
+                }
+                active && rateDegPerSec >= exitRateDegPerSec -> {
+                    belowExitRateSinceElapsedMs = 0L
+                }
+                active && belowExitRateSinceElapsedMs == 0L -> {
+                    belowExitRateSinceElapsedMs = atElapsedMs
+                }
+                active && atElapsedMs - belowExitRateSinceElapsedMs >= exitHoldMs -> {
+                    active = false
+                    belowExitRateSinceElapsedMs = 0L
+                }
+            }
+            if (!active) {
+                belowExitRateSinceElapsedMs = 0L
+            }
+        }
+        return active
+    }
+
+    fun reset() {
+        active = false
+        previousHeadingDeg = null
+        previousSampleAtElapsedMs = 0L
+        belowExitRateSinceElapsedMs = 0L
+    }
+
+    private companion object {
+        const val MILLIS_PER_SECOND = 1_000f
+    }
+}

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxProfileUtils.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxProfileUtils.kt
@@ -153,15 +153,21 @@ internal fun normalizeUserFacingGpxText(value: String?): String? =
 
 internal fun parseGpxData(file: File): ParsedGpxData {
     var trkName: String? = null
+    var routeName: String? = null
     var metaName: String? = null
-    val points = mutableListOf<TrackPoint>()
-    var totalDistance = 0.0
-    var lastPoint: LatLong? = null
+    val trackPoints = mutableListOf<TrackPoint>()
+    val routePoints = mutableListOf<TrackPoint>()
+    var trackDistance = 0.0
+    var routeDistance = 0.0
+    var lastTrackPoint: LatLong? = null
+    var lastRoutePoint: LatLong? = null
 
     var inTrk = false
+    var inRoute = false
     var inMetadata = false
     var inMetadataExtensions = false
     var trkDepth = -1
+    var routeDepth = -1
     var metadataDepth = -1
     var metadataExtensionsDepth = -1
     var isActivity = false
@@ -201,7 +207,8 @@ internal fun parseGpxData(file: File): ParsedGpxData {
     var summaryMaxPowerWatts: Int? = null
     var summaryPressureHpa: Double? = null
 
-    var inTrackPoint = false
+    var inGeometryPoint = false
+    var currentPointIsTrack = false
     var currentLat: Double? = null
     var currentLon: Double? = null
     var currentElevation: Double? = null
@@ -219,6 +226,7 @@ internal fun parseGpxData(file: File): ParsedGpxData {
     var currentBrouterVoiceHint: String? = null
     var currentStartsNewSegment = false
     var nextTrackPointStartsNewSegment = false
+    var nextRoutePointStartsNewSegment = false
 
     return try {
         val parser = XmlPullParserFactory.newInstance().newPullParser()
@@ -232,12 +240,17 @@ internal fun parseGpxData(file: File): ParsedGpxData {
                         val tagName = parser.name
                         when (tagName.localXmlName()) {
                             "trk" -> {
-                                if (points.isNotEmpty()) nextTrackPointStartsNewSegment = true
+                                if (trackPoints.isNotEmpty()) nextTrackPointStartsNewSegment = true
                                 inTrk = true
                                 trkDepth = parser.depth
                             }
                             "trkseg" -> {
-                                if (points.isNotEmpty()) nextTrackPointStartsNewSegment = true
+                                if (inTrk && trackPoints.isNotEmpty()) nextTrackPointStartsNewSegment = true
+                            }
+                            "rte" -> {
+                                if (routePoints.isNotEmpty()) nextRoutePointStartsNewSegment = true
+                                inRoute = true
+                                routeDepth = parser.depth
                             }
                             "metadata" -> {
                                 inMetadata = true
@@ -335,15 +348,27 @@ internal fun parseGpxData(file: File): ParsedGpxData {
                                     if (inTrk && trkName == null && depth == trkDepth + 1) {
                                         trkName = text
                                     }
+                                    if (inRoute && routeName == null && depth == routeDepth + 1) {
+                                        routeName = text
+                                    }
                                     if (inMetadata && metaName == null && depth == metadataDepth + 1) {
                                         metaName = text
                                     }
                                 }
                             }
-                            "trkpt" -> {
-                                inTrackPoint = true
-                                currentStartsNewSegment = nextTrackPointStartsNewSegment
-                                nextTrackPointStartsNewSegment = false
+                            "trkpt", "rtept" -> {
+                                currentPointIsTrack = tagName.localXmlName() == "trkpt"
+                                inGeometryPoint = true
+                                currentStartsNewSegment =
+                                    if (currentPointIsTrack) {
+                                        nextTrackPointStartsNewSegment.also {
+                                            nextTrackPointStartsNewSegment = false
+                                        }
+                                    } else {
+                                        nextRoutePointStartsNewSegment.also {
+                                            nextRoutePointStartsNewSegment = false
+                                        }
+                                    }
                                 currentLat = parser.getAttributeValue(null, "lat")?.toDoubleOrNull()
                                 currentLon = parser.getAttributeValue(null, "lon")?.toDoubleOrNull()
                                 currentElevation = null
@@ -361,17 +386,17 @@ internal fun parseGpxData(file: File): ParsedGpxData {
                                 currentBrouterVoiceHint = null
                             }
                             "ele" -> {
-                                if (inTrackPoint) {
+                                if (inGeometryPoint) {
                                     currentElevation = parser.nextText()?.trim()?.toDoubleOrNull()
                                 }
                             }
                             "desc" -> {
-                                if (inTrackPoint) {
+                                if (inGeometryPoint) {
                                     currentDesc = parser.nextText()?.trim()?.takeIf { it.isNotBlank() }
                                 }
                             }
                             "sym" -> {
-                                if (inTrackPoint) {
+                                if (inGeometryPoint) {
                                     currentSym = parser.nextText()?.trim()?.takeIf { it.isNotBlank() }
                                 }
                             }
@@ -380,13 +405,13 @@ internal fun parseGpxData(file: File): ParsedGpxData {
                                     parser.namespace?.contains("brouter", ignoreCase = true) == true ||
                                         parser.prefix?.equals("brouter", ignoreCase = true) == true ||
                                         tagName?.startsWith("brouter:", ignoreCase = true) == true
-                                if (inTrackPoint && isBrouterVoiceHint) {
+                                if (inGeometryPoint && isBrouterVoiceHint) {
                                     currentBrouterVoiceHint =
                                         parser.nextText()?.trim()?.takeIf { it.isNotBlank() }
                                 }
                             }
                             "time" -> {
-                                if (inTrackPoint) {
+                                if (inGeometryPoint) {
                                     val timeText = parser.nextText()?.trim()
                                     currentHasTimestamp = !timeText.isNullOrBlank()
                                     currentTimestampMillis =
@@ -398,19 +423,19 @@ internal fun parseGpxData(file: File): ParsedGpxData {
                                 }
                             }
                             "accuracyMeters" -> {
-                                if (inTrackPoint) {
+                                if (inGeometryPoint) {
                                     currentAccuracyMeters = parser.nextText()?.trim()?.toFloatOrNull()
                                 }
                             }
                             "speedMps" -> {
-                                if (inTrackPoint) {
+                                if (inGeometryPoint) {
                                     currentSpeedMps = parser.nextText()?.trim()?.toFloatOrNull()
                                 }
                             }
                             "heartRateBpm" -> {
                                 if (inMetadataExtensions) {
                                     summaryHeartRateBpm = parser.nextTextInt()
-                                } else if (inTrackPoint) {
+                                } else if (inGeometryPoint) {
                                     currentHeartRateBpm = parser.nextText()?.trim()?.toIntOrNull()
                                 }
                             }
@@ -423,14 +448,14 @@ internal fun parseGpxData(file: File): ParsedGpxData {
                             "stepCount" -> {
                                 if (inMetadataExtensions) {
                                     summaryStepCount = parser.nextTextInt()
-                                } else if (inTrackPoint) {
+                                } else if (inGeometryPoint) {
                                     currentStepCount = parser.nextText()?.trim()?.toIntOrNull()
                                 }
                             }
                             "cadenceSpm" -> {
                                 if (inMetadataExtensions) {
                                     summaryCadenceSpm = parser.nextTextInt()
-                                } else if (inTrackPoint) {
+                                } else if (inGeometryPoint) {
                                     currentCadenceSpm = parser.nextText()?.trim()?.toIntOrNull()
                                 }
                             }
@@ -443,7 +468,7 @@ internal fun parseGpxData(file: File): ParsedGpxData {
                             "powerWatts" -> {
                                 if (inMetadataExtensions) {
                                     summaryPowerWatts = parser.nextTextInt()
-                                } else if (inTrackPoint) {
+                                } else if (inGeometryPoint) {
                                     currentPowerWatts = parser.nextText()?.trim()?.toIntOrNull()
                                 }
                             }
@@ -456,7 +481,7 @@ internal fun parseGpxData(file: File): ParsedGpxData {
                             "pressureHpa" -> {
                                 if (inMetadataExtensions) {
                                     summaryPressureHpa = parser.nextTextDouble()
-                                } else if (inTrackPoint) {
+                                } else if (inGeometryPoint) {
                                     currentPressureHpa = parser.nextText()?.trim()?.toDoubleOrNull()
                                 }
                             }
@@ -466,19 +491,21 @@ internal fun parseGpxData(file: File): ParsedGpxData {
                     XmlPullParser.END_TAG -> {
                         when (parser.name.localXmlName()) {
                             "trk" -> inTrk = false
+                            "rte" -> inRoute = false
                             "metadata" -> inMetadata = false
                             "extensions" -> {
                                 if (inMetadataExtensions && parser.depth == metadataExtensionsDepth) {
                                     inMetadataExtensions = false
                                 }
                             }
-                            "trkpt" -> {
-                                if (inTrackPoint) {
+                            "trkpt", "rtept" -> {
+                                val closingTrackPoint = parser.name.localXmlName() == "trkpt"
+                                if (inGeometryPoint && currentPointIsTrack == closingTrackPoint) {
                                     val lat = currentLat
                                     val lon = currentLon
                                     if (lat != null && lon != null) {
                                         val latLong = LatLong(lat, lon)
-                                        points +=
+                                        val point =
                                             TrackPoint(
                                                 latLong = latLong,
                                                 elevation = currentElevation,
@@ -500,26 +527,42 @@ internal fun parseGpxData(file: File): ParsedGpxData {
                                                     ),
                                             )
 
-                                        lastPoint?.takeUnless { currentStartsNewSegment }?.let { previous ->
-                                            totalDistance +=
-                                                haversine(
-                                                    previous.latitude,
-                                                    previous.longitude,
-                                                    latLong.latitude,
-                                                    latLong.longitude,
-                                                )
-                                        }
-                                        lastPoint = latLong
-                                        currentTimestampMillis?.let { timestampMillis ->
-                                            if (firstTimestampMillis == null) {
-                                                firstTimestampMillis = timestampMillis
+                                        if (currentPointIsTrack) {
+                                            trackPoints += point
+                                            lastTrackPoint?.takeUnless { currentStartsNewSegment }?.let { previous ->
+                                                trackDistance +=
+                                                    haversine(
+                                                        previous.latitude,
+                                                        previous.longitude,
+                                                        latLong.latitude,
+                                                        latLong.longitude,
+                                                    )
                                             }
-                                            lastTimestampMillis = timestampMillis
+                                            lastTrackPoint = latLong
+                                            currentTimestampMillis?.let { timestampMillis ->
+                                                if (firstTimestampMillis == null) {
+                                                    firstTimestampMillis = timestampMillis
+                                                }
+                                                lastTimestampMillis = timestampMillis
+                                            }
+                                        } else {
+                                            routePoints += point
+                                            lastRoutePoint?.takeUnless { currentStartsNewSegment }?.let { previous ->
+                                                routeDistance +=
+                                                    haversine(
+                                                        previous.latitude,
+                                                        previous.longitude,
+                                                        latLong.latitude,
+                                                        latLong.longitude,
+                                                    )
+                                            }
+                                            lastRoutePoint = latLong
                                         }
                                     }
                                 }
 
-                                inTrackPoint = false
+                                inGeometryPoint = false
+                                currentPointIsTrack = false
                                 currentLat = null
                                 currentLon = null
                                 currentElevation = null
@@ -544,10 +587,13 @@ internal fun parseGpxData(file: File): ParsedGpxData {
             }
         }
 
+        val selectedPoints = if (trackPoints.isNotEmpty()) trackPoints else routePoints
+        val selectedDistance = if (trackPoints.isNotEmpty()) trackDistance else routeDistance
+
         ParsedGpxData(
-            title = normalizeUserFacingGpxText(trkName ?: metaName),
-            points = points,
-            totalDistance = totalDistance,
+            title = normalizeUserFacingGpxText(trkName ?: routeName ?: metaName),
+            points = selectedPoints,
+            totalDistance = selectedDistance,
             isActivity = isActivity || file.name.startsWith("Recording-", ignoreCase = true),
             activityDurationSec =
                 firstTimestampMillis?.let { first ->

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxRouteToolOperations.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxRouteToolOperations.kt
@@ -101,7 +101,7 @@ internal class GpxRouteToolOperations(
                 buildRouteToolReshapeOutput(
                     sourcePath = source.file.absolutePath,
                     sourceFileName = source.file.name,
-                    sourceTitle = source.fileState.title ?: source.parsed.title,
+                    sourceTitle = source.fileState.displayTitle,
                     profile = source.profile,
                     session = session,
                     firstLegPoints = reshapePlan.firstLegPoints,
@@ -122,7 +122,7 @@ internal class GpxRouteToolOperations(
                 val (origin, destination) =
                     resolveReplaceSectionEndpoints(
                         sourcePath = source.file.absolutePath,
-                        sourceTitle = source.fileState.title ?: source.parsed.title,
+                        sourceTitle = source.fileState.displayTitle,
                         profile = source.profile,
                         pointA = sectionStart,
                         pointB = sectionEnd,
@@ -139,7 +139,7 @@ internal class GpxRouteToolOperations(
                 buildRouteToolReplaceSectionOutput(
                     sourcePath = source.file.absolutePath,
                     sourceFileName = source.file.name,
-                    sourceTitle = source.fileState.title ?: source.parsed.title,
+                    sourceTitle = source.fileState.displayTitle,
                     profile = source.profile,
                     session = session,
                     routedPoints = route.points,
@@ -154,7 +154,7 @@ internal class GpxRouteToolOperations(
                 val match =
                     resolveRouteToolTrackMatch(
                         sourcePath = source.file.absolutePath,
-                        sourceTitle = source.fileState.title ?: source.parsed.title,
+                        sourceTitle = source.fileState.displayTitle,
                         profile = source.profile,
                         target = startTarget,
                     )
@@ -164,7 +164,7 @@ internal class GpxRouteToolOperations(
                     buildRouteToolEditOutput(
                         sourcePath = source.file.absolutePath,
                         sourceFileName = source.file.name,
-                        sourceTitle = source.fileState.title ?: source.parsed.title,
+                        sourceTitle = source.fileState.displayTitle,
                         profile = source.profile,
                         session = session.copy(pointATrackPosition = match.position),
                     )
@@ -182,7 +182,7 @@ internal class GpxRouteToolOperations(
                         )
                     buildRouteToolEndpointChangeOutput(
                         sourceFileName = source.file.name,
-                        sourceTitle = source.fileState.title ?: source.parsed.title,
+                        sourceTitle = source.fileState.displayTitle,
                         profile = source.profile,
                         session = session,
                         snappedPosition = endpointPosition,
@@ -201,7 +201,7 @@ internal class GpxRouteToolOperations(
                         )
                     buildRouteToolEndpointChangeOutput(
                         sourceFileName = source.file.name,
-                        sourceTitle = source.fileState.title ?: source.parsed.title,
+                        sourceTitle = source.fileState.displayTitle,
                         profile = source.profile,
                         session = session,
                         snappedPosition = match.position,
@@ -218,7 +218,7 @@ internal class GpxRouteToolOperations(
                 val match =
                     resolveRouteToolTrackMatch(
                         sourcePath = source.file.absolutePath,
-                        sourceTitle = source.fileState.title ?: source.parsed.title,
+                        sourceTitle = source.fileState.displayTitle,
                         profile = source.profile,
                         target = endTarget,
                     )
@@ -228,7 +228,7 @@ internal class GpxRouteToolOperations(
                     buildRouteToolEditOutput(
                         sourcePath = source.file.absolutePath,
                         sourceFileName = source.file.name,
-                        sourceTitle = source.fileState.title ?: source.parsed.title,
+                        sourceTitle = source.fileState.displayTitle,
                         profile = source.profile,
                         session = session.copy(pointBTrackPosition = match.position),
                     )
@@ -246,7 +246,7 @@ internal class GpxRouteToolOperations(
                         )
                     buildRouteToolEndpointChangeOutput(
                         sourceFileName = source.file.name,
-                        sourceTitle = source.fileState.title ?: source.parsed.title,
+                        sourceTitle = source.fileState.displayTitle,
                         profile = source.profile,
                         session = session,
                         snappedPosition = endpointPosition,
@@ -265,7 +265,7 @@ internal class GpxRouteToolOperations(
                         )
                     buildRouteToolEndpointChangeOutput(
                         sourceFileName = source.file.name,
-                        sourceTitle = source.fileState.title ?: source.parsed.title,
+                        sourceTitle = source.fileState.displayTitle,
                         profile = source.profile,
                         session = session,
                         snappedPosition = match.position,
@@ -278,7 +278,7 @@ internal class GpxRouteToolOperations(
                 buildRouteToolEditOutput(
                     sourcePath = source.file.absolutePath,
                     sourceFileName = source.file.name,
-                    sourceTitle = source.fileState.title ?: source.parsed.title,
+                    sourceTitle = source.fileState.displayTitle,
                     profile = source.profile,
                     session = session,
                 )
@@ -297,7 +297,7 @@ internal class GpxRouteToolOperations(
             val reshapePlan = buildReshapePlan(source = source, session = session)
             return buildRouteToolReshapePreview(
                 sourcePath = source.file.absolutePath,
-                sourceTitle = source.fileState.title ?: source.parsed.title,
+                sourceTitle = source.fileState.displayTitle,
                 profile = source.profile,
                 session = session,
                 firstLegPoints = reshapePlan.firstLegPoints,
@@ -391,7 +391,7 @@ internal class GpxRouteToolOperations(
                 val extensionOutput =
                     buildRouteToolExtensionOutput(
                         sourceFileName = source.file.name,
-                        sourceTitle = source.fileState.title ?: source.parsed.title,
+                        sourceTitle = source.fileState.displayTitle,
                         profile = source.profile,
                         routedPoints = route.points,
                     )
@@ -571,7 +571,7 @@ internal class GpxRouteToolOperations(
             requireNotNull(session.destination) {
                 "Pick the shaping point first."
             }
-        val sourceTitle = source.fileState.title ?: source.parsed.title
+        val sourceTitle = source.fileState.displayTitle
         val segmentStart =
             resolveRouteReshapeWaypoint(
                 sourcePath = source.file.absolutePath,
@@ -657,8 +657,7 @@ internal class GpxRouteToolOperations(
             fileName = savedFile.name,
             filePath = savedFile.absolutePath,
             displayTitle =
-                parsed.title?.takeIf { it.isNotBlank() }
-                    ?: normalizeUserFacingGpxText(savedFile.nameWithoutExtension)
+                normalizeUserFacingGpxText(savedFile.nameWithoutExtension)
                     ?: savedFile.nameWithoutExtension,
             distanceMeters = profile.totalDistance,
             elevationGainMeters = profile.totalAscent,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxScreen.kt
@@ -442,7 +442,7 @@ fun GpxScreen(
         DeleteConfirmationDialog(
             visible = showDeleteDialog,
             title = "Delete Track?",
-            message = "Delete '${fileToDelete?.title ?: fileToDelete?.name}'?",
+            message = "Delete '${fileToDelete?.displayTitle.orEmpty()}'?",
             messageTopPadding = dialogTextTopPadding,
             messageBottomPadding = dialogTextBottomPadding,
             onConfirm = {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxState.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxState.kt
@@ -21,7 +21,7 @@ data class GpxFileState(
     val activitySummary: RecordingDashboardSnapshot? = null,
 ) {
     val displayTitle: String
-        get() = title?.takeIf { it.isNotBlank() } ?: name
+        get() = name
 
     fun formattedDistance(isMetric: Boolean): Pair<String, String> = UnitFormatter.formatDistance(distance, isMetric)
 

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxViewModel.kt
@@ -58,14 +58,18 @@ private data class GpxGuidanceBuildResult(
     val guidanceMode: String = "exact_gpx",
 )
 
+data class GpxRouteServices(
+    val planner: RoutePlanner,
+    val elevationProvider: RecordingElevationProvider,
+)
+
 class GpxViewModel(
     private val gpxRepository: GpxRepository,
     private val gpxExportRepository: GpxExportRepository,
     private val syncManager: SyncManager,
     private val settingsRepository: SettingsRepository,
     private val poiRepository: PoiRepository,
-    private val routePlanner: RoutePlanner,
-    private val elevationProvider: RecordingElevationProvider,
+    private val routeServices: GpxRouteServices,
 ) : ViewModel() {
     private val _gpxFiles = MutableStateFlow<List<GpxFileState>>(emptyList())
     val gpxFiles: StateFlow<List<GpxFileState>> = _gpxFiles.asStateFlow()
@@ -173,7 +177,7 @@ class GpxViewModel(
     private val routeToolOperations =
         GpxRouteToolOperations(
             gpxRepository = gpxRepository,
-            routePlanner = routePlanner,
+            routePlanner = routeServices.planner,
             activeGpxFiles = { _gpxFiles.value },
             elevationFilterConfig = { elevationFilterConfig },
             etaModelConfig = { etaModelConfig },
@@ -644,7 +648,7 @@ class GpxViewModel(
         val recoveredPoints =
             profile.points.map { point ->
                 val demElevation =
-                    elevationProvider
+                    routeServices.elevationProvider
                         .resolveElevation(
                             latitude = point.latLong.latitude,
                             longitude = point.latLong.longitude,
@@ -905,21 +909,39 @@ class GpxViewModel(
         path: String,
         enabled: Boolean,
     ) {
-        if (!settingsRepository.linkGpxWaypointPoiFolders.first()) return
+        if (settingsRepository.linkGpxWaypointPoiFolders.first()) {
+            val gpxFileName = File(path).name
+            val linkedPoiFiles = findLinkedGpxWaypointPoiFiles(gpxFileName)
+            if (linkedPoiFiles.isNotEmpty()) {
+                val changed = syncLinkedGpxWaypointPoiFiles(linkedPoiFiles, gpxFileName, enabled)
+                if (changed) {
+                    syncManager.requestPoiSync()
+                    DebugTelemetry.log(
+                        "GpxViewModel",
+                        "event=linked_waypoints_sync file=${gpxFileName.telemetryToken()} " +
+                            "active=$enabled folders=${linkedPoiFiles.size}",
+                    )
+                }
+            }
+        }
+    }
 
-        val gpxFileName = File(path).name
-        val linkedPoiFiles =
-            runCatching {
-                poiRepository.findGpxWaypointPoiFiles(gpxFileName)
-            }.getOrElse { error ->
+    private suspend fun findLinkedGpxWaypointPoiFiles(gpxFileName: String): List<File> =
+        runCatching { poiRepository.findGpxWaypointPoiFiles(gpxFileName) }
+            .getOrElse { error ->
                 DebugTelemetry.log(
                     "GpxViewModel",
-                    "event=linked_waypoints_sync_failed file=${gpxFileName.telemetryToken()} reason=${error.javaClass.simpleName}",
+                    "event=linked_waypoints_sync_failed file=${gpxFileName.telemetryToken()} " +
+                        "reason=${error.javaClass.simpleName}",
                 )
-                return
+                emptyList()
             }
-        if (linkedPoiFiles.isEmpty()) return
 
+    private suspend fun syncLinkedGpxWaypointPoiFiles(
+        linkedPoiFiles: List<File>,
+        gpxFileName: String,
+        enabled: Boolean,
+    ): Boolean {
         var changed = false
         linkedPoiFiles.forEach { poiFile ->
             runCatching {
@@ -933,17 +955,12 @@ class GpxViewModel(
             }.onFailure { error ->
                 DebugTelemetry.log(
                     "GpxViewModel",
-                    "event=linked_waypoints_sync_failed file=${gpxFileName.telemetryToken()} poi=${poiFile.name.telemetryToken()} reason=${error.javaClass.simpleName}",
+                    "event=linked_waypoints_sync_failed file=${gpxFileName.telemetryToken()} " +
+                        "poi=${poiFile.name.telemetryToken()} reason=${error.javaClass.simpleName}",
                 )
             }
         }
-        if (changed) {
-            syncManager.requestPoiSync()
-            DebugTelemetry.log(
-                "GpxViewModel",
-                "event=linked_waypoints_sync file=${gpxFileName.telemetryToken()} active=$enabled folders=${linkedPoiFiles.size}",
-            )
-        }
+        return changed
     }
 
     fun startTurnByTurnGuidance(
@@ -1028,7 +1045,7 @@ class GpxViewModel(
             val result =
                 withContext(Dispatchers.IO) {
                     runCatching {
-                        routePlanner
+                        routeServices.planner
                             .createRoute(
                                 RoutePlannerRequest(
                                     origin = origin,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/gpx/GpxViewModel.kt
@@ -10,6 +10,7 @@ import com.glancemap.glancemapwearos.core.routing.RoutePlannerRequest
 import com.glancemap.glancemapwearos.core.service.diagnostics.DebugTelemetry
 import com.glancemap.glancemapwearos.data.repository.GpxExportRepository
 import com.glancemap.glancemapwearos.data.repository.GpxRepository
+import com.glancemap.glancemapwearos.data.repository.PoiRepository
 import com.glancemap.glancemapwearos.data.repository.SettingsRepository
 import com.glancemap.glancemapwearos.presentation.SyncManager
 import com.glancemap.glancemapwearos.presentation.features.navigate.guidance.GpxGuidanceSession
@@ -62,6 +63,7 @@ class GpxViewModel(
     private val gpxExportRepository: GpxExportRepository,
     private val syncManager: SyncManager,
     private val settingsRepository: SettingsRepository,
+    private val poiRepository: PoiRepository,
     private val routePlanner: RoutePlanner,
     private val elevationProvider: RecordingElevationProvider,
 ) : ViewModel() {
@@ -99,6 +101,9 @@ class GpxViewModel(
 
     private val _turnByTurnGuidancePaused = MutableStateFlow(false)
     val turnByTurnGuidancePaused: StateFlow<Boolean> = _turnByTurnGuidancePaused.asStateFlow()
+
+    private var lastObservedActiveGpxPaths: Set<String>? = null
+    private var previousGpxWaypointPoiFolderLinkEnabled: Boolean? = null
 
     // ----------------------------
     // Internal inspection session state
@@ -299,6 +304,19 @@ class GpxViewModel(
             .onEach { activePaths ->
                 val files = gpxRepository.listGpxFiles()
                 loadAndProcessGpxFiles(files, activePaths)
+                syncLinkedGpxWaypointPoiFolders(activePaths)
+            }.launchIn(viewModelScope)
+
+        settingsRepository.linkGpxWaypointPoiFolders
+            .onEach { enabled ->
+                val wasEnabled = previousGpxWaypointPoiFolderLinkEnabled
+                previousGpxWaypointPoiFolderLinkEnabled = enabled
+                if (enabled && wasEnabled == false) {
+                    gpxRepository
+                        .getActiveGpxFiles()
+                        .first()
+                        .forEach { path -> setLinkedGpxWaypointPoiEnabled(path = path, enabled = true) }
+                }
             }.launchIn(viewModelScope)
 
         syncManager.gpxSyncRequest
@@ -868,6 +886,66 @@ class GpxViewModel(
         DebugTelemetry.log("GpxViewModel", "event=reset_active_files")
     }
 
+    private suspend fun syncLinkedGpxWaypointPoiFolders(activePaths: Set<String>) {
+        val previousPaths = lastObservedActiveGpxPaths
+        lastObservedActiveGpxPaths = activePaths
+        if (previousPaths == null) {
+            activePaths.forEach { path -> setLinkedGpxWaypointPoiEnabled(path = path, enabled = true) }
+            return
+        }
+        (previousPaths - activePaths).forEach { path ->
+            setLinkedGpxWaypointPoiEnabled(path = path, enabled = false)
+        }
+        (activePaths - previousPaths).forEach { path ->
+            setLinkedGpxWaypointPoiEnabled(path = path, enabled = true)
+        }
+    }
+
+    private suspend fun setLinkedGpxWaypointPoiEnabled(
+        path: String,
+        enabled: Boolean,
+    ) {
+        if (!settingsRepository.linkGpxWaypointPoiFolders.first()) return
+
+        val gpxFileName = File(path).name
+        val linkedPoiFiles =
+            runCatching {
+                poiRepository.findGpxWaypointPoiFiles(gpxFileName)
+            }.getOrElse { error ->
+                DebugTelemetry.log(
+                    "GpxViewModel",
+                    "event=linked_waypoints_sync_failed file=${gpxFileName.telemetryToken()} reason=${error.javaClass.simpleName}",
+                )
+                return
+            }
+        if (linkedPoiFiles.isEmpty()) return
+
+        var changed = false
+        linkedPoiFiles.forEach { poiFile ->
+            runCatching {
+                val categories = poiRepository.readCategories(poiFile.absolutePath)
+                poiRepository.setFileEnabled(poiFile.absolutePath, enabled)
+                poiRepository.setEnabledCategories(
+                    path = poiFile.absolutePath,
+                    enabledCategoryIds = if (enabled) categories.map { it.id }.toSet() else emptySet(),
+                )
+                changed = true
+            }.onFailure { error ->
+                DebugTelemetry.log(
+                    "GpxViewModel",
+                    "event=linked_waypoints_sync_failed file=${gpxFileName.telemetryToken()} poi=${poiFile.name.telemetryToken()} reason=${error.javaClass.simpleName}",
+                )
+            }
+        }
+        if (changed) {
+            syncManager.requestPoiSync()
+            DebugTelemetry.log(
+                "GpxViewModel",
+                "event=linked_waypoints_sync file=${gpxFileName.telemetryToken()} active=$enabled folders=${linkedPoiFiles.size}",
+            )
+        }
+    }
+
     fun startTurnByTurnGuidance(
         path: String,
         onComplete: (Result<GpxGuidanceStartResult>) -> Unit,
@@ -1047,7 +1125,7 @@ class GpxViewModel(
         }
         val displayTitle =
             _gpxFiles.value.firstOrNull { it.path == absolutePath }?.displayTitle
-                ?: readBestGpxTitle(file)
+                ?: normalizeUserFacingGpxText(file.nameWithoutExtension)
                 ?: file.nameWithoutExtension
         val basePoints =
             if (reversed) {
@@ -1113,7 +1191,20 @@ class GpxViewModel(
                         )
                     }
                 }
-            if (result.isSuccess) {
+            result.getOrNull()?.let { savedFile ->
+                val renamedWaypointFolders =
+                    poiRepository.updateLinkedGpxWaypointFileName(
+                        previousGpxFileName = File(filePath).name,
+                        newGpxFileName = savedFile.name,
+                    )
+                if (renamedWaypointFolders > 0) {
+                    syncManager.requestPoiSync()
+                    val activePaths = gpxRepository.getActiveGpxFiles().first()
+                    setLinkedGpxWaypointPoiEnabled(
+                        path = savedFile.absolutePath,
+                        enabled = savedFile.absolutePath in activePaths,
+                    )
+                }
                 clearAllGpxCaches()
                 if (_turnByTurnGuidanceSession.value?.trackId == filePath) stopTurnByTurnGuidance()
                 if (aPos?.trackId == filePath) dismissInspection()
@@ -1300,7 +1391,7 @@ class GpxViewModel(
                         id = path,
                         points = profile.points.map { it.latLong },
                         trackPoints = profile.points,
-                        title = fileState.title,
+                        title = fileState.displayTitle,
                         distance = profile.totalDistance,
                         elevationGain = profile.totalAscent,
                         startPoint = start,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/effects/NavigateEffects.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/effects/NavigateEffects.kt
@@ -27,6 +27,7 @@ import com.glancemap.glancemapwearos.domain.sensors.COMPASS_TELEMETRY_TAG
 import com.glancemap.glancemapwearos.domain.sensors.CompassProviderType
 import com.glancemap.glancemapwearos.domain.sensors.CompassRenderState
 import com.glancemap.glancemapwearos.domain.sensors.HeadingSource
+import com.glancemap.glancemapwearos.domain.sensors.HeadingTurnRateHysteresis
 import com.glancemap.glancemapwearos.domain.sensors.hasRecentGoogleFusedCachedHeading
 import com.glancemap.glancemapwearos.presentation.features.maps.MapRenderer
 import com.glancemap.glancemapwearos.presentation.features.maps.RotatableMarker
@@ -40,6 +41,7 @@ import java.util.Collections
 import java.util.Locale
 import java.util.WeakHashMap
 import kotlin.math.abs
+import kotlin.math.exp
 
 /**
  * Synchronized Map + Marker rotation for Compass, North-Up and Panning modes.
@@ -288,10 +290,16 @@ fun NavigationOrientationEffect(
         // Local var: safe because both coroutines run on Main (single-threaded).
         var liveTarget = displayedHeading.floatValue
         var latestRenderState = renderStateFlow.value
-        var lastTargetUpdateAtElapsedMs = SystemClock.elapsedRealtime()
-        var fastTurnUntilElapsedMs = 0L
-        var activeMapTurnUntilElapsedMs = 0L
-        var previousRawHeading: Float? = null
+        var activeHeadingTurn = false
+        var previousFrameTimeNanos = 0L
+        val headingTurnTracker =
+            HeadingTurnRateHysteresis(
+                enterRateDegPerSec = RENDER_ACTIVE_TURN_ENTER_RATE_DEG_PER_SEC,
+                exitRateDegPerSec = RENDER_ACTIVE_TURN_EXIT_RATE_DEG_PER_SEC,
+                exitHoldMs = RENDER_ACTIVE_TURN_EXIT_HOLD_MS,
+                minimumEntryStepDeg = RENDER_ACTIVE_TURN_MIN_ENTRY_STEP_DEG,
+                maximumSampleGapMs = RENDER_ACTIVE_TURN_MAX_SAMPLE_GAP_MS,
+            )
 
         // Keep liveTarget current without blocking the animation loop.
         launch {
@@ -299,44 +307,31 @@ fun NavigationOrientationEffect(
                 latestRenderState = state
                 val canDriveHeading = shouldDriveHeadingForNavMode(navMode, state)
                 if (!canDriveHeading) {
-                    fastTurnUntilElapsedMs = 0L
-                    activeMapTurnUntilElapsedMs = 0L
-                    previousRawHeading = null
+                    headingTurnTracker.reset()
+                    activeHeadingTurn = false
                     return@collect
                 }
                 val heading = normalize360(state.headingDeg)
                 val nowElapsedMs = SystemClock.elapsedRealtime()
-                val elapsedSinceTargetMs = nowElapsedMs - lastTargetUpdateAtElapsedMs
-                previousRawHeading?.let { previous ->
-                    if (
-                        isFastHeadingTurn(
-                            previousHeadingDeg = previous,
-                            nextHeadingDeg = heading,
-                            elapsedMs = elapsedSinceTargetMs,
-                        )
-                    ) {
-                        fastTurnUntilElapsedMs = nowElapsedMs + FAST_TURN_RENDER_HOLD_MS
-                    }
-                    if (
-                        isActiveMapHeadingTurn(
-                            previousHeadingDeg = previous,
-                            nextHeadingDeg = heading,
-                            elapsedMs = elapsedSinceTargetMs,
-                        )
-                    ) {
-                        activeMapTurnUntilElapsedMs = nowElapsedMs + ACTIVE_MAP_TURN_RENDER_HOLD_MS
-                    }
-                }
+                activeHeadingTurn =
+                    headingTurnTracker.update(
+                        headingDeg = heading,
+                        atElapsedMs = nowElapsedMs,
+                    )
                 liveTarget = heading
-                previousRawHeading = heading
-                lastTargetUpdateAtElapsedMs = nowElapsedMs
                 CompassRenderPerfTelemetry.recordTargetUpdate(navMode)
             }
         }
 
         // Animate toward liveTarget on every display frame.
         while (true) {
-            withFrameNanos {
+            withFrameNanos { frameTimeNanos ->
+                val frameDeltaMs =
+                    resolveHeadingAnimationFrameDeltaMs(
+                        frameTimeNanos = frameTimeNanos,
+                        previousFrameTimeNanos = previousFrameTimeNanos,
+                    )
+                previousFrameTimeNanos = frameTimeNanos
                 if (navMode == NavMode.PANNING) return@withFrameNanos
                 if (!shouldDriveHeadingForNavMode(navMode, latestRenderState)) {
                     return@withFrameNanos
@@ -384,7 +379,8 @@ fun NavigationOrientationEffect(
                 val animationDelta =
                     resolveHeadingAnimationDelta(
                         diffDeg = diff,
-                        fastTurn = nowElapsedMs <= fastTurnUntilElapsedMs,
+                        activeTurn = activeHeadingTurn,
+                        frameDeltaMs = frameDeltaMs,
                     )
                 val next = normalize360(current + animationDelta)
                 displayedHeading.floatValue = next
@@ -394,8 +390,7 @@ fun NavigationOrientationEffect(
                     NavMode.COMPASS_FOLLOW -> {
                         applyMapRotation(
                             targetRotationDeg = -next,
-                            highFrequencyRotation =
-                                nowElapsedMs <= activeMapTurnUntilElapsedMs,
+                            highFrequencyRotation = activeHeadingTurn,
                         )
                     }
                     NavMode.NORTH_UP_FOLLOW -> {
@@ -605,63 +600,63 @@ internal fun shouldThrottleMapsforgeRotation(
         nowElapsedMs - lastAppliedAtElapsedMs < minimumIntervalMs
 }
 
-internal fun isFastHeadingTurn(
-    previousHeadingDeg: Float,
-    nextHeadingDeg: Float,
-    elapsedMs: Long,
-): Boolean =
-    isHeadingTurnAtLeastRate(
-        previousHeadingDeg = previousHeadingDeg,
-        nextHeadingDeg = nextHeadingDeg,
-        elapsedMs = elapsedMs,
-        minimumRateDegPerSec = FAST_TURN_MIN_RATE_DEG_PER_SEC,
-    )
-
-internal fun isActiveMapHeadingTurn(
-    previousHeadingDeg: Float,
-    nextHeadingDeg: Float,
-    elapsedMs: Long,
-): Boolean =
-    isHeadingTurnAtLeastRate(
-        previousHeadingDeg = previousHeadingDeg,
-        nextHeadingDeg = nextHeadingDeg,
-        elapsedMs = elapsedMs,
-        minimumRateDegPerSec = ACTIVE_MAP_TURN_MIN_RATE_DEG_PER_SEC,
-    )
-
-private fun isHeadingTurnAtLeastRate(
-    previousHeadingDeg: Float,
-    nextHeadingDeg: Float,
-    elapsedMs: Long,
-    minimumRateDegPerSec: Float,
-): Boolean {
-    if (!previousHeadingDeg.isFinite() || !nextHeadingDeg.isFinite()) return false
-    if (elapsedMs <= 0L || elapsedMs > FAST_TURN_MAX_SAMPLE_GAP_MS) return false
-    val rotationRateDegPerSec =
-        abs(angleDeltaDeg(nextHeadingDeg, previousHeadingDeg)) * 1_000f / elapsedMs.toFloat()
-    return rotationRateDegPerSec >= minimumRateDegPerSec
-}
-
 internal fun resolveHeadingAnimationAlpha(
     diffDeg: Float,
-    fastTurn: Boolean,
-): Float =
-    when {
-        !diffDeg.isFinite() -> 0f
-        fastTurn && abs(diffDeg) >= FAST_TURN_LARGE_ERROR_DEG -> FAST_TURN_LARGE_ERROR_ALPHA
-        fastTurn -> FAST_TURN_ANIMATION_ALPHA
-        else -> HEADING_ANIMATION_ALPHA
-    }
+    activeTurn: Boolean,
+    frameDeltaMs: Float,
+): Float {
+    if (!diffDeg.isFinite() || !frameDeltaMs.isFinite() || frameDeltaMs <= 0f) return 0f
+    val timeConstantMs =
+        when {
+            activeTurn && abs(diffDeg) >= ACTIVE_TURN_LARGE_ERROR_DEG ->
+                ACTIVE_TURN_LARGE_ERROR_TIME_CONSTANT_MS
+            activeTurn -> ACTIVE_TURN_ANIMATION_TIME_CONSTANT_MS
+            else -> HEADING_ANIMATION_TIME_CONSTANT_MS
+        }
+    return (1.0 - exp(-frameDeltaMs.toDouble() / timeConstantMs.toDouble())).toFloat()
+}
 
 internal fun resolveHeadingAnimationDelta(
     diffDeg: Float,
-    fastTurn: Boolean,
+    activeTurn: Boolean,
+    frameDeltaMs: Float,
 ): Float {
     if (!diffDeg.isFinite()) return 0f
-    val animatedDelta = diffDeg * resolveHeadingAnimationAlpha(diffDeg = diffDeg, fastTurn = fastTurn)
+    val animatedDelta =
+        diffDeg *
+            resolveHeadingAnimationAlpha(
+                diffDeg = diffDeg,
+                activeTurn = activeTurn,
+                frameDeltaMs = frameDeltaMs,
+            )
+    val maximumStepDeg =
+        (
+            HEADING_ANIMATION_MAX_STEP_DEG *
+                frameDeltaMs.coerceIn(
+                    minimumValue = HEADING_ANIMATION_MIN_FRAME_DELTA_MS,
+                    maximumValue = HEADING_ANIMATION_MAX_FRAME_DELTA_MS,
+                ) /
+                HEADING_ANIMATION_NOMINAL_FRAME_DELTA_MS
+        )
     return animatedDelta.coerceIn(
-        minimumValue = -HEADING_ANIMATION_MAX_STEP_DEG,
-        maximumValue = HEADING_ANIMATION_MAX_STEP_DEG,
+        minimumValue = -maximumStepDeg,
+        maximumValue = maximumStepDeg,
+    )
+}
+
+internal fun resolveHeadingAnimationFrameDeltaMs(
+    frameTimeNanos: Long,
+    previousFrameTimeNanos: Long,
+): Float {
+    if (previousFrameTimeNanos <= 0L || frameTimeNanos <= previousFrameTimeNanos) {
+        return HEADING_ANIMATION_NOMINAL_FRAME_DELTA_MS
+    }
+    return (
+        (frameTimeNanos - previousFrameTimeNanos).toDouble() /
+            NANOS_PER_MILLISECOND
+    ).toFloat().coerceIn(
+        minimumValue = HEADING_ANIMATION_MIN_FRAME_DELTA_MS,
+        maximumValue = HEADING_ANIMATION_MAX_FRAME_DELTA_MS,
     )
 }
 
@@ -695,19 +690,25 @@ private const val MAP_ROTATION_ACTIVE_TURN_MIN_APPLY_INTERVAL_MS = 16L
 // screen state at the same 25fps cadence as the existing map-overlay redraw flow.
 private const val RENDERED_COMPASS_UI_PUBLISH_INTERVAL_MS = 40L
 
-// Interpolation factor per display frame (~60fps). At 0.5, closes half the remaining
-// gap each frame: a 10° step reaches <0.1° in ~7 frames (~117ms). Tracks 50Hz sensor
-// updates with at most 1-2 frames of visual lag.
-private const val HEADING_ANIMATION_ALPHA = 0.5f
-private const val FAST_TURN_ANIMATION_ALPHA = 0.78f
-private const val FAST_TURN_LARGE_ERROR_ALPHA = 0.9f
-private const val FAST_TURN_LARGE_ERROR_DEG = 25f
-private const val FAST_TURN_MIN_RATE_DEG_PER_SEC = 55f
-private const val ACTIVE_MAP_TURN_MIN_RATE_DEG_PER_SEC = 24f
-private const val FAST_TURN_MAX_SAMPLE_GAP_MS = 250L
-private const val FAST_TURN_RENDER_HOLD_MS = 180L
-private const val ACTIVE_MAP_TURN_RENDER_HOLD_MS = 180L
+// Time-based interpolation keeps the same visual response when the watch renders at 30, 45 or
+// 60fps. A deliberate turn uses a shorter time constant, while large corrections remain bounded.
+private const val HEADING_ANIMATION_TIME_CONSTANT_MS = 80f
+private const val ACTIVE_TURN_ANIMATION_TIME_CONSTANT_MS = 42f
+private const val ACTIVE_TURN_LARGE_ERROR_TIME_CONSTANT_MS = 20f
+private const val ACTIVE_TURN_LARGE_ERROR_DEG = 25f
+private const val HEADING_ANIMATION_NOMINAL_FRAME_DELTA_MS = 16.666_667f
+private const val HEADING_ANIMATION_MIN_FRAME_DELTA_MS = 4f
+private const val HEADING_ANIMATION_MAX_FRAME_DELTA_MS = 50f
 private const val HEADING_ANIMATION_MAX_STEP_DEG = 12f
+private const val NANOS_PER_MILLISECOND = 1_000_000.0
+
+// Enter turning mode promptly, then leave only after angular movement stays low. This prevents a
+// slow 360-degree sweep from repeatedly switching between 25Hz and high-frequency rendering.
+private const val RENDER_ACTIVE_TURN_ENTER_RATE_DEG_PER_SEC = 25f
+private const val RENDER_ACTIVE_TURN_EXIT_RATE_DEG_PER_SEC = 15f
+private const val RENDER_ACTIVE_TURN_EXIT_HOLD_MS = 300L
+private const val RENDER_ACTIVE_TURN_MIN_ENTRY_STEP_DEG = 0.35f
+private const val RENDER_ACTIVE_TURN_MAX_SAMPLE_GAP_MS = 300L
 
 // Stop animating when within this threshold — below the useful visual precision of a watch map.
 private const val HEADING_ANIMATION_DONE_DEG = 0.2f

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/effects/NavigateLocationEffects.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/effects/NavigateLocationEffects.kt
@@ -206,6 +206,7 @@ internal fun rememberNavigateLocationUiState(
             reason = "interactive_start",
             nowElapsedMs = nowElapsedMs,
         )
+        var resumePredictionFromWakeAnchor = false
         val cachedLocation = locationViewModel.currentLocation.value
         val cachedAnchor =
             resolveWakeAnchorSeedOrNull(
@@ -246,9 +247,16 @@ internal fun rememberNavigateLocationUiState(
         listOfNotNull(cachedAnchor, retainedAnchor)
             .maxByOrNull { it.reading.fixElapsedMs }
             ?.let { anchor ->
+                resumePredictionFromWakeAnchor =
+                    shouldResumePredictionFromWakeAnchor(
+                        anchor = anchor,
+                        receivedAtElapsedMs = nowElapsedMs,
+                        expectedGpsIntervalMs = expectedGpsIntervalMs,
+                    )
                 markerMotionController.seedAnchor(
                     seed = anchor,
                     nowElapsedMs = nowElapsedMs,
+                    allowPredictionUntilFreshFix = resumePredictionFromWakeAnchor,
                 )
                 lastRenderedMarkerLatLong = anchor.latLong
                 wakeAnchorSeeded = true
@@ -290,7 +298,8 @@ internal fun rememberNavigateLocationUiState(
                     NAV_MARKER_TELEMETRY_TAG,
                     "warmReturn restored=true source=${anchor.origin.telemetryLabel} " +
                         "ageMs=${(nowElapsedMs - anchor.reading.fixElapsedMs).coerceAtLeast(0L)} " +
-                        "accuracyM=${anchor.reading.accuracyM} speedMps=${anchor.reading.speedMps}",
+                        "accuracyM=${anchor.reading.accuracyM} speedMps=${anchor.reading.speedMps} " +
+                        "predictionContinues=$resumePredictionFromWakeAnchor",
                 )
             }
         val wakeReacquireInCooldown =
@@ -308,13 +317,18 @@ internal fun rememberNavigateLocationUiState(
         nextWakeSessionId += 1L
         activeWakeSessionId = nextWakeSessionId
         lastWakeReacquireStartedAtElapsedMs = nowElapsedMs
-        holdMarkerUntilFreshFix = true
-        holdMarkerStartedAtElapsedMs = nowElapsedMs
+        holdMarkerUntilFreshFix = !resumePredictionFromWakeAnchor
+        holdMarkerStartedAtElapsedMs = nowElapsedMs.takeIf { holdMarkerUntilFreshFix } ?: 0L
         logWakeSessionEvent(
             stage = "start",
             sessionId = activeWakeSessionId,
             nowElapsedMs = nowElapsedMs,
-            reason = if (wakeAnchorSeeded) "seeded" else "no_anchor",
+            reason =
+                when {
+                    resumePredictionFromWakeAnchor -> "seeded_predicting"
+                    wakeAnchorSeeded -> "seeded_held"
+                    else -> "no_anchor"
+                },
         )
         val immediateRequestResult =
             locationViewModel.requestImmediateLocation(source = "ui_startup_fresh_fix")
@@ -331,7 +345,9 @@ internal fun rememberNavigateLocationUiState(
             )
             return@LaunchedEffect
         }
-        markerMotionController.requireFreshFixForPrediction()
+        if (!resumePredictionFromWakeAnchor) {
+            markerMotionController.requireFreshFixForPrediction()
+        }
     }
 
     LaunchedEffect(activeWakeSessionId, shouldTrackLocation, screenState, locationViewModel) {
@@ -637,6 +653,7 @@ internal fun rememberNavigateLocationUiState(
                         } else {
                             LocationSourceMode.AUTO_FUSED
                         }
+                val markerVisible = shouldRenderLocationVisualUpdate(latestScreenState.value)
 
                 val motionUpdate =
                     markerMotionController.onGpsFix(
@@ -660,6 +677,7 @@ internal fun rememberNavigateLocationUiState(
                                         expectedGpsIntervalMs = expectedGpsIntervalMs,
                                     ),
                                 sourceMode = markerSourceMode,
+                                isMarkerVisible = markerVisible,
                             ),
                     )
                 val displayLatLong = motionUpdate.displayedLatLong
@@ -674,7 +692,7 @@ internal fun rememberNavigateLocationUiState(
                 // Continue feeding the motion controller while the display is off, but avoid
                 // mutating Mapsforge state or requesting an invisible redraw. The interactive
                 // wake path restores the latest cached anchor before requesting a fresh fix.
-                if (!shouldRenderLocationVisualUpdate(latestScreenState.value)) return@collect
+                if (!markerVisible) return@collect
                 if (motionUpdate.fixAccepted) {
                     MarkerMotionTelemetry.recordFixAwaitingFirstRender(receivedAtElapsedMs)
                 }
@@ -995,6 +1013,7 @@ private const val INTERACTIVE_STALE_REFRESH_MIN_MOTION_IDLE_MS = 1_250L
 private const val INTERACTIVE_STALE_REFRESH_COOLDOWN_MS = 12_000L
 private const val WAKE_REACQUIRE_SNAP_MAX_ACCURACY_M = 35f
 private const val WARM_RETURN_ANCHOR_MAX_ACCURACY_M = 50f
+private const val WARM_RETURN_PREDICTION_MAX_ACCURACY_M = 25f
 private const val WARM_RETURN_MOVING_SPEED_THRESHOLD_MPS = 0.8f
 private const val WARM_RETURN_MOVING_MAX_AGE_MS = 12_000L
 private const val WARM_RETURN_STATIONARY_MAX_AGE_MS = 30_000L
@@ -1116,6 +1135,34 @@ internal fun computeWarmReturnAnchorMaxAgeMs(
             WARM_RETURN_STATIONARY_MAX_AGE_MS
         }
     return maxOf(baseline, warmReturnLimit)
+}
+
+internal fun shouldResumePredictionFromWakeAnchor(
+    anchor: MarkerMotionSeed,
+    receivedAtElapsedMs: Long,
+    expectedGpsIntervalMs: Long,
+): Boolean {
+    val reading = anchor.reading
+    val speedMps = reading.speedMps
+    val bearingDeg = reading.bearingDeg
+    val validElapsedTime =
+        reading.fixElapsedMs > 0L &&
+            receivedAtElapsedMs >= reading.fixElapsedMs
+    val fixAgeMs =
+        if (validElapsedTime) {
+            receivedAtElapsedMs - reading.fixElapsedMs
+        } else {
+            Long.MAX_VALUE
+        }
+    return validElapsedTime &&
+        reading.accuracyM.isFinite() &&
+        reading.accuracyM <= WARM_RETURN_PREDICTION_MAX_ACCURACY_M &&
+        speedMps != null &&
+        speedMps.isFinite() &&
+        speedMps >= WARM_RETURN_MOVING_SPEED_THRESHOLD_MPS &&
+        bearingDeg != null &&
+        bearingDeg.isFinite() &&
+        fixAgeMs <= resolveLocationTimingProfile(expectedGpsIntervalMs).markerPredictionFreshnessMaxAgeMs
 }
 
 internal fun resolveStartupFreshFixMaxAgeMs(

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionController.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionController.kt
@@ -37,6 +37,8 @@ internal data class MarkerMotionGpsFix(
     val reading: MarkerMotionReading,
     val allowLargeCorrection: Boolean = false,
     val sourceMode: LocationSourceMode = LocationSourceMode.AUTO_FUSED,
+    /** Whether the map can render this correction for the user. */
+    val isMarkerVisible: Boolean = true,
 )
 
 internal data class MarkerMotionUpdate(
@@ -131,6 +133,7 @@ internal class MarkerMotionController(
     fun seedAnchor(
         seed: MarkerMotionSeed,
         nowElapsedMs: Long = seed.reading.fixElapsedMs,
+        allowPredictionUntilFreshFix: Boolean = false,
     ) {
         val sanitizedSpeed = sanitizeSpeed(seed.reading.speedMps)
         val motionAccuracyM = effectiveMotionAccuracy(seed.reading.accuracyM, seed.sourceMode)
@@ -147,7 +150,7 @@ internal class MarkerMotionController(
         state.lastAcceptedFix = motionFix
         state.displayedLatLong = seed.latLong
         state.visualTrajectory.seed(motionFix.toVisualAnchor(seed.latLong)).recordTelemetryInterruption()
-        state.predictionRequiresFreshFix = true
+        state.predictionRequiresFreshFix = !allowPredictionUntilFreshFix
         state.clampedCorrectionStreak = 0
         MarkerMotionTelemetry.recordSeedAnchor(
             nowElapsedMs = nowElapsedMs,
@@ -550,8 +553,11 @@ private class MarkerMotionGpsFixProcessor(
     private fun applyAcceptedGpsFix(
         context: GpsFixContext,
         motion: ResolvedMotion,
-    ): LatLong =
-        context.currentDisplayed
+    ): LatLong {
+        if (shouldUpdateScreenOffAnchor(context)) {
+            return acceptScreenOffAnchor(context, motion)
+        }
+        return context.currentDisplayed
             ?.let { currentDisplayed ->
                 val correction =
                     CorrectionContext(
@@ -562,6 +568,42 @@ private class MarkerMotionGpsFixProcessor(
                 acceptCorrection(context, motion, correction)
             }
             ?: acceptInitialFix(context, motion)
+    }
+
+    private fun shouldUpdateScreenOffAnchor(context: GpsFixContext): Boolean =
+        !context.fix.isMarkerVisible &&
+            context.accuracyM <= settings.maxVisualCorrectionAccuracyM
+
+    private fun acceptScreenOffAnchor(
+        context: GpsFixContext,
+        motion: ResolvedMotion,
+    ): LatLong {
+        state.displayedLatLong = context.fix.latLong
+        state.visualTrajectory
+            .seed(
+                visualAnchor(
+                    context = context,
+                    motion = motion,
+                    latLong = context.fix.latLong,
+                ),
+            ).recordTelemetryInterruption()
+        state.clampedCorrectionStreak = 0
+        recordFixAccepted(
+            context = context,
+            motion = motion,
+            event =
+                FixAcceptedTelemetry(
+                    mode = MarkerMotionMode.FIXED,
+                    reason = "screen_off_anchor",
+                    correctionDistanceM =
+                        context.currentDisplayed?.let { displayed ->
+                            MarkerMotionGeometry.distanceMeters(displayed, context.fix.latLong)
+                        },
+                    blendDurationMs = null,
+                ),
+        )
+        return context.fix.latLong
+    }
 
     private fun acceptInitialFix(
         context: GpsFixContext,
@@ -763,6 +805,8 @@ private class MarkerMotionGpsFixProcessor(
     ): LatLong {
         val displayedLatLong = state.displayedLatLong ?: correctionTarget.targetLatLong
         val correctionReason = correctionReason(context, sustainedLagCatchUpReason, correctionTarget)
+        val correctionDurationMs =
+            fastReanchorDurationMs(correctionTarget.visibleCorrectionDistanceM)
         rebaseVisualTrajectory(
             context = context,
             motion = motion,
@@ -772,8 +816,11 @@ private class MarkerMotionGpsFixProcessor(
                     displayedLatLong = displayedLatLong,
                     correctionPlan =
                         MarkerVisualCorrectionPlan(
-                            durationMs = FAST_REANCHOR_CORRECTION_DURATION_MS,
+                            durationMs = correctionDurationMs,
                             reason = correctionReason,
+                            bypassRemovalRateLimit =
+                                context.fix.allowLargeCorrection ||
+                                    sustainedLagCatchUpReason != null,
                         ),
                 ),
         )
@@ -785,7 +832,7 @@ private class MarkerMotionGpsFixProcessor(
                     mode = MarkerMotionMode.BLEND,
                     reason = correctionReason,
                     correctionDistanceM = correctionTarget.visibleCorrectionDistanceM,
-                    blendDurationMs = FAST_REANCHOR_CORRECTION_DURATION_MS,
+                    blendDurationMs = correctionDurationMs,
                 ),
         )
         return displayedLatLong
@@ -901,6 +948,7 @@ private class MarkerMotionGpsFixProcessor(
         sustainedLagCatchUpReason: String?,
     ): Boolean =
         context.fix.sourceMode == LocationSourceMode.WATCH_GPS ||
+            context.fix.allowLargeCorrection ||
             sustainedLagCatchUpReason != null ||
             isSourceModeTransition(context)
 
@@ -939,6 +987,7 @@ private class MarkerMotionGpsFixProcessor(
                 residualDistanceM = residualDistanceM,
                 alongTrackErrorM = components?.alongTrackM,
                 crossTrackErrorM = components?.crossTrackM,
+                isMarkerVisible = context.fix.isMarkerVisible,
             )
         }
         MarkerMotionTelemetry.recordFixAccepted(
@@ -1074,13 +1123,58 @@ private class MarkerMotionGpsFixProcessor(
             LocationSourceMode.AUTO_FUSED,
             LocationSourceMode.PASSIVE_EXTERNAL,
             ->
-                "auto_fused_catch_up".takeIf {
+                when {
                     context.accuracyM <= AUTO_FUSED_CATCH_UP_MAX_ACCURACY_M &&
                         motion.speedMps >= AUTO_FUSED_CATCH_UP_MIN_SPEED_MPS &&
-                        correction.correctionDistanceM >= AUTO_FUSED_CATCH_UP_MIN_LAG_M
+                        correction.correctionDistanceM >= AUTO_FUSED_CATCH_UP_MIN_LAG_M ->
+                        "auto_fused_catch_up"
+                    context.accuracyM <= AUTO_FUSED_HIGH_SPEED_CATCH_UP_MAX_ACCURACY_M &&
+                        motion.speedMps >= AUTO_FUSED_HIGH_SPEED_CATCH_UP_MIN_SPEED_MPS &&
+                        isConfirmedHighSpeedMotion(context, motion) &&
+                        correction.correctionDistanceM >=
+                        maxOf(
+                            AUTO_FUSED_HIGH_SPEED_CATCH_UP_MIN_LAG_M,
+                            context.accuracyM * AUTO_FUSED_HIGH_SPEED_CATCH_UP_ACCURACY_MULTIPLIER,
+                        ) ->
+                        "auto_fused_high_speed_catch_up"
+                    else -> null
                 }
         }
     }
+
+    private fun isConfirmedHighSpeedMotion(
+        context: GpsFixContext,
+        motion: ResolvedMotion,
+    ): Boolean {
+        val previousFix = context.previousFix
+        val derivedMotion =
+            previousFix
+                ?.takeIf { it.sourceMode == context.fix.sourceMode }
+                ?.deriveMotionTo(
+                    target = context.fix.latLong,
+                    targetFixElapsedMs = context.timing.reliableFixElapsedMs,
+                )
+        val motionBearingDeg = motion.bearingDeg
+        val derivedBearingDeg = derivedMotion?.bearingDeg
+        if (derivedMotion == null || motionBearingDeg == null || derivedBearingDeg == null) return false
+        val speedDifferenceMps = abs(derivedMotion.speedMps - motion.speedMps)
+        val maximumSpeedDifferenceMps =
+            maxOf(
+                AUTO_FUSED_HIGH_SPEED_CATCH_UP_MIN_SPEED_DIFFERENCE_MPS,
+                motion.speedMps * AUTO_FUSED_HIGH_SPEED_CATCH_UP_SPEED_DIFFERENCE_RATIO,
+            )
+        return derivedMotion.speedMps >= AUTO_FUSED_HIGH_SPEED_CATCH_UP_MIN_SPEED_MPS &&
+            speedDifferenceMps <= maximumSpeedDifferenceMps &&
+            angularDistanceDegrees(motionBearingDeg, derivedBearingDeg) <=
+            AUTO_FUSED_HIGH_SPEED_CATCH_UP_MAX_BEARING_DIFFERENCE_DEG
+    }
+
+    private fun fastReanchorDurationMs(correctionDistanceM: Float): Long =
+        (
+            FAST_REANCHOR_MIN_DURATION_MS +
+                correctionDistanceM.coerceAtLeast(0f) * FAST_REANCHOR_DURATION_PER_METER_MS
+        ).toLong()
+            .coerceIn(FAST_REANCHOR_MIN_DURATION_MS, FAST_REANCHOR_MAX_DURATION_MS)
 
     private fun resolveMotionSpeedMps(
         rawSpeedMps: Float?,
@@ -1348,6 +1442,11 @@ private fun normalize360(angleDeg: Float): Float {
     return normalized
 }
 
+private fun angularDistanceDegrees(
+    firstDeg: Float,
+    secondDeg: Float,
+): Float = abs((((firstDeg - secondDeg) + 540f) % 360f) - 180f)
+
 private fun MarkerVisualCorrectionEnd?.recordTelemetryInterruption() {
     this?.let { interruption ->
         MarkerMotionTelemetry.recordCorrectionInterrupted(
@@ -1375,6 +1474,13 @@ private const val WATCH_GPS_CATCH_UP_MAX_ACCURACY_M = 25f
 private const val AUTO_FUSED_CATCH_UP_MIN_LAG_M = 35f
 private const val AUTO_FUSED_CATCH_UP_MIN_SPEED_MPS = 0.8f
 private const val AUTO_FUSED_CATCH_UP_MAX_ACCURACY_M = 12f
+private const val AUTO_FUSED_HIGH_SPEED_CATCH_UP_MIN_LAG_M = 60f
+private const val AUTO_FUSED_HIGH_SPEED_CATCH_UP_MIN_SPEED_MPS = 5f
+private const val AUTO_FUSED_HIGH_SPEED_CATCH_UP_MAX_ACCURACY_M = 25f
+private const val AUTO_FUSED_HIGH_SPEED_CATCH_UP_ACCURACY_MULTIPLIER = 3f
+private const val AUTO_FUSED_HIGH_SPEED_CATCH_UP_MIN_SPEED_DIFFERENCE_MPS = 5f
+private const val AUTO_FUSED_HIGH_SPEED_CATCH_UP_SPEED_DIFFERENCE_RATIO = 0.5f
+private const val AUTO_FUSED_HIGH_SPEED_CATCH_UP_MAX_BEARING_DIFFERENCE_DEG = 45f
 private const val GPS_BEARING_MIN_SPEED_MPS = 0.45f
 private const val MAX_TRUSTED_SPEED_ACCURACY_MPS = 1.5f
 private const val MAX_SPEED_ACCURACY_RATIO = 0.75f
@@ -1403,7 +1509,9 @@ private const val STATIONARY_JITTER_MIN_RADIUS_M = 3f
 private const val STATIONARY_JITTER_MAX_RADIUS_M = 10f
 private const val MOVING_CORRECTION_DEADBAND_M = 1.2f
 private const val SMALL_CORRECTION_DURATION_MS = 500L
-private const val FAST_REANCHOR_CORRECTION_DURATION_MS = 600L
+private const val FAST_REANCHOR_MIN_DURATION_MS = 600L
+private const val FAST_REANCHOR_MAX_DURATION_MS = 1_200L
+private const val FAST_REANCHOR_DURATION_PER_METER_MS = 2f
 private const val MIN_CONTINUOUS_CORRECTION_DURATION_MS = 600L
 private const val MAX_CONTINUOUS_CORRECTION_DURATION_MS = 1_800L
 private const val CORRECTION_CADENCE_FRACTION = 0.35

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionController.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionController.kt
@@ -106,7 +106,6 @@ internal class MarkerMotionController(
         state.visualTrajectory.reset(nowElapsedMs).recordTelemetryInterruption()
         state.predictionRequiresFreshFix = true
         state.clampedCorrectionStreak = 0
-        predictionCadence.resetObservedIntervals()
         MarkerMotionTelemetry.recordIdle(
             nowElapsedMs = nowElapsedMs,
             reason = reason,
@@ -224,12 +223,6 @@ internal class MarkerMotionController(
         val previousAcceptedFix = state.lastAcceptedFix
         val displayedLatLong = fixProcessor.onGpsFix(fix)
         val acceptedFix = state.lastAcceptedFix
-        if (acceptedFix !== previousAcceptedFix && previousAcceptedFix != null && acceptedFix != null) {
-            predictionCadence.recordAcceptedFixGap(
-                gapMs = (acceptedFix.fixElapsedMs - previousAcceptedFix.fixElapsedMs).coerceAtLeast(0L),
-                sourceChanged = acceptedFix.sourceMode != previousAcceptedFix.sourceMode,
-            )
-        }
         return MarkerMotionUpdate(
             displayedLatLong = displayedLatLong,
             fixAccepted = acceptedFix !== previousAcceptedFix,
@@ -1513,8 +1506,11 @@ private const val FAST_REANCHOR_MIN_DURATION_MS = 600L
 private const val FAST_REANCHOR_MAX_DURATION_MS = 1_200L
 private const val FAST_REANCHOR_DURATION_PER_METER_MS = 2f
 private const val MIN_CONTINUOUS_CORRECTION_DURATION_MS = 600L
-private const val MAX_CONTINUOUS_CORRECTION_DURATION_MS = 1_800L
-private const val CORRECTION_CADENCE_FRACTION = 0.35
+private const val MAX_CONTINUOUS_CORRECTION_DURATION_MS = 2_400L
+
+// Spread ordinary GPS residuals across most of the selected cadence, keeping the base trajectory
+// visibly forward-moving instead of front-loading every correction into a short deceleration.
+private const val CORRECTION_CADENCE_FRACTION = 0.75
 private const val CORRECTION_DURATION_PER_METER_MS = 100f
 private const val LARGE_CORRECTION_MIN_DISTANCE_M = 18f
 private const val LARGE_CORRECTION_MIN_ACCURACY_M = 14f

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionTelemetry.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionTelemetry.kt
@@ -48,6 +48,8 @@ internal data class MarkerMotionSummary(
     val activeRenderIntervalP95Ms: Long? = null,
     val activeRenderIntervalMaxMs: Long? = null,
     val nextFixPredictionResidualM: MarkerMotionMetricSummary = MarkerMotionMetricSummary(),
+    val visibleNextFixPredictionResidualM: MarkerMotionMetricSummary = MarkerMotionMetricSummary(),
+    val screenOffNextFixPredictionResidualM: MarkerMotionMetricSummary = MarkerMotionMetricSummary(),
     val correctionComponentSamples: Int = 0,
     val correctionAlongTrackMeanM: Float? = null,
     val correctionCrossTrackMeanM: Float? = null,
@@ -73,7 +75,12 @@ internal data class MarkerMotionSummary(
             append(" drop=$outlierDrops")
             firstRenderDelayMeanMs?.let { append(" firstRender=${it}ms") }
             activeRenderIntervalMeanMs?.let { append(" renderGap=${it}ms") }
-            nextFixPredictionResidualM.p95?.let { append(" residualP95=${it.format(1)}m") }
+            visibleNextFixPredictionResidualM.p95?.let {
+                append(" visibleResidualP95=${it.format(1)}m")
+            }
+            screenOffNextFixPredictionResidualM.p95?.let {
+                append(" screenOffResidualP95=${it.format(1)}m")
+            }
             renderDisplacementPx.p95?.let { append(" renderStepP95=${it.format(1)}px") }
         }
 }
@@ -160,6 +167,8 @@ internal object MarkerMotionTelemetry {
     private var activeRenderIntervalMaxMs: Long = 0L
     private val activeRenderIntervalsMs = StreamingMetricAccumulator(RENDER_INTERVAL_BUCKETS_MS)
     private val nextFixPredictionResidualsM = StreamingMetricAccumulator(DISTANCE_BUCKETS_M)
+    private val visibleNextFixPredictionResidualsM = StreamingMetricAccumulator(DISTANCE_BUCKETS_M)
+    private val screenOffNextFixPredictionResidualsM = StreamingMetricAccumulator(DISTANCE_BUCKETS_M)
     private val correctionAlongTrackAbsM = StreamingMetricAccumulator(DISTANCE_BUCKETS_M)
     private val correctionCrossTrackAbsM = StreamingMetricAccumulator(DISTANCE_BUCKETS_M)
     private var correctionComponentSamples: Int = 0
@@ -202,6 +211,8 @@ internal object MarkerMotionTelemetry {
             activeRenderIntervalMaxMs = 0L
             activeRenderIntervalsMs.clear()
             nextFixPredictionResidualsM.clear()
+            visibleNextFixPredictionResidualsM.clear()
+            screenOffNextFixPredictionResidualsM.clear()
             correctionAlongTrackAbsM.clear()
             correctionCrossTrackAbsM.clear()
             correctionComponentSamples = 0
@@ -269,6 +280,8 @@ internal object MarkerMotionTelemetry {
             activeRenderIntervalP95Ms = activeRenderIntervalsMs.percentile(0.95f)?.toLong(),
             activeRenderIntervalMaxMs = activeRenderIntervalMaxMs.takeIf { activeRenderIntervalSamples > 0 },
             nextFixPredictionResidualM = nextFixPredictionResidualsM.summary(),
+            visibleNextFixPredictionResidualM = visibleNextFixPredictionResidualsM.summary(),
+            screenOffNextFixPredictionResidualM = screenOffNextFixPredictionResidualsM.summary(),
             correctionComponentSamples = correctionComponentSamples,
             correctionAlongTrackMeanM = correctionAlongTrackTotalM.meanOrNull(correctionComponentSamples),
             correctionCrossTrackMeanM = correctionCrossTrackTotalM.meanOrNull(correctionComponentSamples),
@@ -634,15 +647,26 @@ internal object MarkerMotionTelemetry {
         }
     }
 
-    /** Records how far the last displayed prediction was from the next accepted fix. */
+    /**
+     * Records the motion-model residual at the next accepted fix.
+     *
+     * The aggregate is retained for continuity, while visible and screen-off buckets prevent
+     * invisible screen-off catch-up from being mistaken for on-screen marker quality.
+     */
     fun recordNextFixPredictionResidual(
         residualDistanceM: Float,
         alongTrackErrorM: Float? = null,
         crossTrackErrorM: Float? = null,
+        isMarkerVisible: Boolean = true,
     ) {
         if (!shouldCollect()) return
         synchronized(lock) {
             residualDistanceM.recordNonNegativeIn(nextFixPredictionResidualsM)
+            if (isMarkerVisible) {
+                residualDistanceM.recordNonNegativeIn(visibleNextFixPredictionResidualsM)
+            } else {
+                residualDistanceM.recordNonNegativeIn(screenOffNextFixPredictionResidualsM)
+            }
             recordCorrectionComponentsLocked(alongTrackErrorM, crossTrackErrorM)
         }
     }
@@ -919,6 +943,9 @@ private fun reasonLabel(reason: String?): String? =
         "between_fixes" -> "between"
         "degraded_gps" -> "gps weak"
         "watch_gps_catch_up" -> "watch catch up"
+        "auto_fused_catch_up" -> "fused catch up"
+        "auto_fused_high_speed_catch_up" -> "fused fast catch up"
+        "screen_off_anchor" -> "screen off anchor"
         "reset" -> "reset"
         "interactive_start" -> "screen wake"
         "tracking_stopped" -> "track off"

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerPredictionCadence.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerPredictionCadence.kt
@@ -1,56 +1,18 @@
 package com.glancemap.glancemapwearos.presentation.features.navigate.motion
 
-/** Robustly adapts the visual prediction horizon to the cadence actually delivered by GPS. */
+/** Keeps the visual prediction horizon aligned with the GPS cadence selected by the user. */
 internal class MarkerPredictionCadence(
     configuredIntervalMs: Long,
 ) {
-    private val recentIntervalsMs = LongArray(MAX_INTERVAL_SAMPLES)
-    private var sampleCount = 0
-    private var nextSampleIndex = 0
     private var configuredIntervalMs = sanitizeInterval(configuredIntervalMs)
-    private var observedMedianMs: Long? = null
 
     fun updateConfiguredInterval(intervalMs: Long) {
         val sanitizedIntervalMs = sanitizeInterval(intervalMs)
         if (sanitizedIntervalMs == configuredIntervalMs) return
         configuredIntervalMs = sanitizedIntervalMs
-        resetObservedIntervals()
     }
 
-    fun resetObservedIntervals() {
-        sampleCount = 0
-        nextSampleIndex = 0
-        observedMedianMs = null
-        recentIntervalsMs.fill(0L)
-    }
-
-    fun recordAcceptedFixGap(
-        gapMs: Long,
-        sourceChanged: Boolean,
-    ) {
-        if (sourceChanged) {
-            resetObservedIntervals()
-            return
-        }
-        if (gapMs !in MIN_OBSERVED_INTERVAL_MS..MAX_OBSERVED_INTERVAL_MS) return
-        recentIntervalsMs[nextSampleIndex] = gapMs
-        nextSampleIndex = (nextSampleIndex + 1) % recentIntervalsMs.size
-        sampleCount = (sampleCount + 1).coerceAtMost(recentIntervalsMs.size)
-        val sorted = LongArray(sampleCount) { recentIntervalsMs[it] }.sortedArray()
-        observedMedianMs = sorted[sorted.size / 2]
-    }
-
-    fun expectedIntervalMs(): Long {
-        val observedMedian = observedMedianMs
-        return if (sampleCount < MIN_INTERVAL_SAMPLES_FOR_ADAPTATION || observedMedian == null) {
-            configuredIntervalMs
-        } else {
-            observedMedian.coerceIn(
-                configuredIntervalMs / 2L,
-                configuredIntervalMs * 2L,
-            )
-        }
-    }
+    fun expectedIntervalMs(): Long = configuredIntervalMs
 
     fun predictionWindow(
         configuredFreshnessMaxAgeMs: Long,
@@ -83,12 +45,8 @@ internal class MarkerPredictionCadence(
     private fun sanitizeInterval(intervalMs: Long): Long = intervalMs.coerceIn(CONFIGURED_INTERVAL_RANGE)
 }
 
-private const val MAX_INTERVAL_SAMPLES = 5
-private const val MIN_INTERVAL_SAMPLES_FOR_ADAPTATION = 3
 private const val MIN_CONFIGURED_INTERVAL_MS = 1_000L
 private const val MAX_CONFIGURED_INTERVAL_MS = 30_000L
 private val CONFIGURED_INTERVAL_RANGE = MIN_CONFIGURED_INTERVAL_MS..MAX_CONFIGURED_INTERVAL_MS
-private const val MIN_OBSERVED_INTERVAL_MS = 500L
-private const val MAX_OBSERVED_INTERVAL_MS = 60_000L
 private const val MIN_PREDICTION_GRACE_MS = 500L
 private const val MIN_EASING_WINDOW_MS = 400L

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerVisualTrajectory.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerVisualTrajectory.kt
@@ -53,6 +53,7 @@ internal class MarkerVisualTrajectory {
                     startedAtElapsedMs = nowElapsedMs,
                     durationMs = correctionPlan.durationMs,
                     reason = correctionPlan.reason,
+                    bypassRemovalRateLimit = correctionPlan.bypassRemovalRateLimit,
                     remainingDistanceM = correctionDistanceM,
                     lastSampleAtElapsedMs = nowElapsedMs,
                 )
@@ -142,15 +143,19 @@ internal class MarkerVisualTrajectory {
                         context.predictionWindow,
                     )
             ).coerceAtLeast(0f)
-        val maximumRemovalM =
-            maximumCorrectionRemovalMeters(
-                anchor = context.anchor,
-                correction = activeCorrection,
-                projectedBaseAdvanceM = projectedBaseAdvanceM,
-                sampleIntervalMs = sampleIntervalMs,
-            )
         val rateLimitedRemainingDistanceM =
-            (activeCorrection.remainingDistanceM - maximumRemovalM).coerceAtLeast(0f)
+            if (activeCorrection.bypassRemovalRateLimit) {
+                scheduledRemainingDistanceM
+            } else {
+                val maximumRemovalM =
+                    maximumCorrectionRemovalMeters(
+                        anchor = context.anchor,
+                        correction = activeCorrection,
+                        projectedBaseAdvanceM = projectedBaseAdvanceM,
+                        sampleIntervalMs = sampleIntervalMs,
+                    )
+                (activeCorrection.remainingDistanceM - maximumRemovalM).coerceAtLeast(0f)
+            }
         val remainingDistanceM =
             maxOf(scheduledRemainingDistanceM, rateLimitedRemainingDistanceM)
                 .coerceAtMost(activeCorrection.remainingDistanceM)
@@ -201,6 +206,7 @@ internal data class MarkerPredictionWindow(
 internal data class MarkerVisualCorrectionPlan(
     val durationMs: Long,
     val reason: String = "gps_correction",
+    val bypassRemovalRateLimit: Boolean = false,
 )
 
 internal data class MarkerVisualCorrectionEnd(
@@ -225,6 +231,7 @@ private data class MarkerVisualCorrection(
     val startedAtElapsedMs: Long,
     val durationMs: Long,
     val reason: String,
+    val bypassRemovalRateLimit: Boolean,
     var remainingDistanceM: Float,
     var lastSampleAtElapsedMs: Long,
 )

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.RouteTools.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.RouteTools.kt
@@ -397,21 +397,123 @@ internal fun rememberNavigateRouteToolActions(
             selectedMapPath = latestSelectedMapPath.value,
         )
 
-    fun startRouteToolSelection(
-        session: RouteToolSession,
-        currentLocation: LatLong? = latestRecenterTarget.value,
-        gpsSignal: GpsSignalSnapshot = latestGpsSignalSnapshot.value,
-    ) {
-        pendingDirectPoiRoute.value = null
-        val preflight = preflightRouteToolStart(session, currentLocation, gpsSignal)
-        if (!preflight.canStart) {
-            preflight.message?.let(setRouteToolPreflightMessage)
-            if (preflight.shouldRequestFreshLocation) {
-                locationViewModel.requestImmediateLocation(source = "ui_route_tool_preflight")
-            }
-            return
-        }
+    fun showRouteToolSaveSuccess(saveResult: RouteToolSaveResult) {
+        setRouteToolExecutionMessage(null)
+        setCompletedRouteToolDraft(null)
+        setShortcutTrayExpanded(false)
+        setRouteToolRenameInProgress(false)
+        setRouteToolRenameError(null)
+        setRouteToolPreview(null)
+        setRouteToolResult(saveResult)
+    }
 
+    fun handleRouteToolCreationResult(
+        session: RouteToolSession,
+        result: Result<RouteToolSaveResult>,
+    ) {
+        finishRouteToolExecution()
+        result
+            .onSuccess(::showRouteToolSaveSuccess)
+            .onFailure { error ->
+                val message = error.localizedMessage?.takeIf { it.isNotBlank() } ?: "Failed to create the GPX."
+                setRouteToolExecutionMessage(message)
+                setRouteToolLoopRetryOptions(
+                    if (
+                        session.options.createMode == RouteCreateMode.LOOP_AROUND_HERE &&
+                        error is LoopRouteSuggestionException
+                    ) {
+                        buildLoopRetryOptions(session.options, error)
+                    } else {
+                        emptyList()
+                    },
+                )
+                setRouteToolResult(null)
+                setCompletedRouteToolDraft(session)
+            }
+    }
+
+    fun handleRouteToolModificationResult(
+        session: RouteToolSession,
+        result: Result<RouteToolSaveResult>,
+    ) {
+        finishRouteToolExecution()
+        result
+            .onSuccess(::showRouteToolSaveSuccess)
+            .onFailure { error ->
+                val message =
+                    error.localizedMessage?.takeIf { it.isNotBlank() }
+                        ?: "Failed to save the edited GPX."
+                setRouteToolExecutionMessage(message)
+                setRouteToolResult(null)
+                setCompletedRouteToolDraft(session)
+            }
+    }
+
+    fun startCompletedCreateRouteTool(
+        session: RouteToolSession,
+        currentLocation: LatLong?,
+    ) {
+        if (session.options.createMode == RouteCreateMode.LOOP_AROUND_HERE) {
+            if (!routeToolCreatePreviewInProgress && !routeToolExecutionInProgress) {
+                setRouteToolSession(session)
+                previewCreateDraft(
+                    draft = session,
+                    fallbackSession = null,
+                    showProgressToast = true,
+                )
+            }
+        } else if (!routeToolExecutionInProgress) {
+            setRouteToolSession(null)
+            beginRouteToolExecution("Finding route...")
+            gpxViewModel.applyRouteToolCreation(
+                session = session,
+                currentLocation = currentLocation,
+                onProgress = setRouteToolExecutionStatus,
+            ) { result ->
+                handleRouteToolCreationResult(session, result)
+            }
+        }
+    }
+
+    fun startCompletedModifyRouteTool(session: RouteToolSession) {
+        setRouteToolSession(null)
+        if (session.options.modifyMode.previewBeforeSaving) {
+            previewModifyDraft(session, true)
+        } else if (!routeToolExecutionInProgress) {
+            beginRouteToolExecution("Saving GPX...")
+            gpxViewModel.applyRouteToolModification(
+                session = session,
+                onProgress = setRouteToolExecutionStatus,
+            ) { result ->
+                handleRouteToolModificationResult(session, result)
+            }
+        }
+    }
+
+    fun startCompletedRouteToolSelection(
+        session: RouteToolSession,
+        currentLocation: LatLong?,
+    ) {
+        when {
+            session.options.toolKind == RouteToolKind.CREATE ->
+                startCompletedCreateRouteTool(session, currentLocation)
+            session.options.saveBehavior == RouteSaveBehavior.SAVE_AS_NEW ->
+                startCompletedModifyRouteTool(session)
+            else -> {
+                setRouteToolSession(null)
+                setCompletedRouteToolDraft(session)
+            }
+        }
+    }
+
+    fun handleRouteToolPreflightBlock(preflight: RouteToolPreflightResult) {
+        preflight.message?.let(setRouteToolPreflightMessage)
+        if (preflight.shouldRequestFreshLocation) {
+            locationViewModel.requestImmediateLocation(source = "ui_route_tool_preflight")
+        }
+    }
+
+    fun resetRouteToolSelectionUi() {
         setRouteToolPreflightMessage(null)
         setShowRouteToolsPanel(false)
         setPoiCreationSelectionActive(false)
@@ -421,99 +523,33 @@ internal fun rememberNavigateRouteToolActions(
         clearRouteToolResultState()
         clearRouteToolPreviewState()
         gpxViewModel.dismissInspection()
-        if (session.isComplete) {
-            when {
-                session.options.toolKind == RouteToolKind.CREATE -> {
-                    if (session.options.createMode == RouteCreateMode.LOOP_AROUND_HERE) {
-                        if (routeToolCreatePreviewInProgress || routeToolExecutionInProgress) return
-                        setRouteToolSession(session)
-                        previewCreateDraft(
-                            draft = session,
-                            fallbackSession = null,
-                            showProgressToast = true,
-                        )
-                        return
-                    }
-                    setRouteToolSession(null)
-                    if (routeToolExecutionInProgress) return
-                    beginRouteToolExecution("Finding route...")
-                    gpxViewModel.applyRouteToolCreation(
-                        session = session,
-                        currentLocation = currentLocation,
-                        onProgress = setRouteToolExecutionStatus,
-                    ) { result ->
-                        finishRouteToolExecution()
-                        result
-                            .onSuccess { saveResult ->
-                                setRouteToolExecutionMessage(null)
-                                setCompletedRouteToolDraft(null)
-                                setShortcutTrayExpanded(false)
-                                setRouteToolRenameInProgress(false)
-                                setRouteToolRenameError(null)
-                                setRouteToolPreview(null)
-                                setRouteToolResult(saveResult)
-                            }.onFailure { error ->
-                                val message =
-                                    error.localizedMessage?.takeIf { it.isNotBlank() }
-                                        ?: "Failed to create the GPX."
-                                setRouteToolExecutionMessage(message)
-                                setRouteToolLoopRetryOptions(
-                                    if (
-                                        session.options.createMode == RouteCreateMode.LOOP_AROUND_HERE &&
-                                        error is LoopRouteSuggestionException
-                                    ) {
-                                        buildLoopRetryOptions(session.options, error)
-                                    } else {
-                                        emptyList()
-                                    },
-                                )
-                                setRouteToolResult(null)
-                                setCompletedRouteToolDraft(session)
-                            }
-                    }
-                }
+    }
 
-                session.options.saveBehavior == RouteSaveBehavior.SAVE_AS_NEW -> {
-                    setRouteToolSession(null)
-                    if (session.options.modifyMode.previewBeforeSaving) {
-                        previewModifyDraft(session, true)
-                        return
-                    }
-                    if (routeToolExecutionInProgress) return
-                    beginRouteToolExecution("Saving GPX...")
-                    gpxViewModel.applyRouteToolModification(
-                        session = session,
-                        onProgress = setRouteToolExecutionStatus,
-                    ) { result ->
-                        finishRouteToolExecution()
-                        result
-                            .onSuccess { saveResult ->
-                                setRouteToolExecutionMessage(null)
-                                setCompletedRouteToolDraft(null)
-                                setShortcutTrayExpanded(false)
-                                setRouteToolRenameInProgress(false)
-                                setRouteToolRenameError(null)
-                                setRouteToolPreview(null)
-                                setRouteToolResult(saveResult)
-                            }.onFailure { error ->
-                                val message =
-                                    error.localizedMessage?.takeIf { it.isNotBlank() }
-                                        ?: "Failed to save the edited GPX."
-                                setRouteToolExecutionMessage(message)
-                                setRouteToolResult(null)
-                                setCompletedRouteToolDraft(session)
-                            }
-                    }
-                }
-
-                else -> {
-                    setRouteToolSession(null)
-                    setCompletedRouteToolDraft(session)
-                }
+    fun startRouteToolSelection(
+        session: RouteToolSession,
+        currentLocation: LatLong?,
+        gpsSignal: GpsSignalSnapshot,
+    ) {
+        pendingDirectPoiRoute.value = null
+        val preflight = preflightRouteToolStart(session, currentLocation, gpsSignal)
+        if (!preflight.canStart) {
+            handleRouteToolPreflightBlock(preflight)
+        } else {
+            resetRouteToolSelectionUi()
+            if (session.isComplete) {
+                startCompletedRouteToolSelection(session, currentLocation)
+            } else {
+                setRouteToolSession(session)
             }
-            return
         }
-        setRouteToolSession(session)
+    }
+
+    fun startRouteToolSelection(session: RouteToolSession) {
+        startRouteToolSelection(
+            session = session,
+            currentLocation = latestRecenterTarget.value,
+            gpsSignal = latestGpsSignalSnapshot.value,
+        )
     }
 
     fun evaluatePendingPoiRoutePreflight(
@@ -592,6 +628,20 @@ internal fun rememberNavigateRouteToolActions(
         previewCreateDraft(updated, current)
     }
 
+    fun createDirectPoiRouteSession(marker: PoiOverlayMarker): RouteToolSession {
+        val createOptions =
+            latestRouteToolOptions.value
+                .copy(
+                    toolKind = RouteToolKind.CREATE,
+                    createMode = RouteCreateMode.CURRENT_TO_HERE,
+                ).withVisibleLoopDefaults()
+        setRouteToolOptions(createOptions)
+        return RouteToolSession(
+            options = createOptions,
+            destination = LatLong(marker.lat, marker.lon),
+        )
+    }
+
     fun createRouteToPoi(marker: PoiOverlayMarker) {
         pendingDirectPoiRoute.value = null
         triggerHaptic()
@@ -605,18 +655,7 @@ internal fun rememberNavigateRouteToolActions(
         clearRouteToolPreviewState()
         val currentLocation = latestRecenterTarget.value
         val gpsSignal = latestGpsSignalSnapshot.value
-        val createOptions =
-            latestRouteToolOptions.value
-                .copy(
-                    toolKind = RouteToolKind.CREATE,
-                    createMode = RouteCreateMode.CURRENT_TO_HERE,
-                ).withVisibleLoopDefaults()
-        setRouteToolOptions(createOptions)
-        val session =
-            RouteToolSession(
-                options = createOptions,
-                destination = LatLong(marker.lat, marker.lon),
-            )
+        val session = createDirectPoiRouteSession(marker)
         val preflight =
             preflightRouteToolStart(
                 session = session,
@@ -625,10 +664,8 @@ internal fun rememberNavigateRouteToolActions(
             )
         logPoiRoutePreflight(
             event = "click_preflight",
-            currentLocationPresent = currentLocation != null,
-            locationAvailable = gpsSignal.isLocationAvailable,
-            lastFixElapsedRealtimeMs = gpsSignal.lastFixElapsedRealtimeMs,
-            lastFixAgeMs = gpsSignal.lastFixAgeMs,
+            currentLocation = currentLocation,
+            gpsSignal = gpsSignal,
             result =
                 when {
                     preflight.canStart -> "ready"
@@ -850,20 +887,16 @@ private fun logPoiRoutePreflight(
 ) {
     logPoiRoutePreflight(
         event = event,
-        currentLocationPresent = triggers.currentLocation != null,
-        locationAvailable = triggers.gpsSignalSnapshot.isLocationAvailable,
-        lastFixElapsedRealtimeMs = triggers.gpsSignalSnapshot.lastFixElapsedRealtimeMs,
-        lastFixAgeMs = triggers.gpsSignalSnapshot.lastFixAgeMs,
+        currentLocation = triggers.currentLocation,
+        gpsSignal = triggers.gpsSignalSnapshot,
         message = message,
     )
 }
 
 private fun logPoiRoutePreflight(
     event: String,
-    currentLocationPresent: Boolean,
-    locationAvailable: Boolean,
-    lastFixElapsedRealtimeMs: Long,
-    lastFixAgeMs: Long,
+    currentLocation: LatLong?,
+    gpsSignal: GpsSignalSnapshot,
     result: String? = null,
     message: String? = null,
 ) {
@@ -878,13 +911,13 @@ private fun logPoiRoutePreflight(
                 append(it)
             }
             append(" currentLocation=")
-            append(currentLocationPresent)
+            append(currentLocation != null)
             append(" locationAvailable=")
-            append(locationAvailable)
+            append(gpsSignal.isLocationAvailable)
             append(" fixElapsedMs=")
-            append(lastFixElapsedRealtimeMs)
+            append(gpsSignal.lastFixElapsedRealtimeMs)
             append(" fixAgeMs=")
-            append(lastFixAgeMs)
+            append(gpsSignal.lastFixAgeMs)
             message?.let {
                 append(" message=")
                 append(it.replace(' ', '_'))

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.RouteTools.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.RouteTools.kt
@@ -52,16 +52,14 @@ internal data class NavigateRouteToolActions(
 private data class PendingDirectPoiRouteTriggers(
     val session: RouteToolSession?,
     val currentLocation: LatLong?,
-    val locationAvailable: Boolean,
-    val lastFixElapsedRealtimeMs: Long,
-    val lastFixAgeMs: Long,
+    val gpsSignalSnapshot: GpsSignalSnapshot,
     val offlineMode: Boolean,
     val selectedMapPath: String?,
 )
 
 private data class PendingDirectPoiRouteActions(
-    val evaluatePreflight: (RouteToolSession) -> RouteToolPreflightResult,
-    val onReady: (RouteToolSession) -> Unit,
+    val evaluatePreflight: (RouteToolSession, LatLong?, GpsSignalSnapshot) -> RouteToolPreflightResult,
+    val onReady: (RouteToolSession, LatLong, GpsSignalSnapshot) -> Unit,
     val onBlocked: (String?) -> Unit,
     val onTimeout: (RouteToolSession) -> Unit,
 )
@@ -76,22 +74,31 @@ private fun PendingDirectPoiRouteEffect(
     LaunchedEffect(
         triggers.session,
         triggers.currentLocation,
-        triggers.locationAvailable,
-        triggers.lastFixElapsedRealtimeMs,
-        triggers.lastFixAgeMs,
+        triggers.gpsSignalSnapshot.isLocationAvailable,
+        triggers.gpsSignalSnapshot.lastFixElapsedRealtimeMs,
+        triggers.gpsSignalSnapshot.lastFixAgeMs,
         triggers.offlineMode,
         triggers.selectedMapPath,
     ) {
         val pendingSession = triggers.session ?: return@LaunchedEffect
         val currentActions = latestActions.value
-        val preflight = currentActions.evaluatePreflight(pendingSession)
+        val preflight =
+            currentActions.evaluatePreflight(
+                pendingSession,
+                triggers.currentLocation,
+                triggers.gpsSignalSnapshot,
+            )
         when {
-            preflight.canStart -> {
+            preflight.canStart && triggers.currentLocation != null -> {
                 logPoiRoutePreflight(
                     event = "pending_ready",
                     triggers = triggers,
                 )
-                currentActions.onReady(pendingSession)
+                currentActions.onReady(
+                    pendingSession,
+                    triggers.currentLocation,
+                    triggers.gpsSignalSnapshot,
+                )
             }
 
             !preflight.shouldRequestFreshLocation -> {
@@ -167,6 +174,15 @@ internal fun rememberNavigateRouteToolActions(
     setShowCreatedPoiRenameDialog: (Boolean) -> Unit,
 ): NavigateRouteToolActions {
     val pendingDirectPoiRoute = remember { mutableStateOf<RouteToolSession?>(null) }
+    // POI popups can outlive the composition that opened them. Route actions therefore read
+    // these values when invoked rather than using the GPS state captured when the popup opened.
+    val latestRecenterTarget = rememberUpdatedState(recenterTarget)
+    val latestGpsSignalSnapshot = rememberUpdatedState(gpsSignalSnapshot)
+    val latestOfflineMode = rememberUpdatedState(offlineMode)
+    val latestActiveGpxDetailsCount = rememberUpdatedState(activeGpxDetailsCount)
+    val latestSelectedMapPath = rememberUpdatedState(selectedMapPath)
+    val latestRouteToolOptions = rememberUpdatedState(routeToolOptions)
+    val latestRouteToolDefaultOptions = rememberUpdatedState(routeToolDefaultOptions)
 
     fun clearRouteToolPreviewState() {
         setRouteToolPreview(null)
@@ -240,7 +256,7 @@ internal fun rememberNavigateRouteToolActions(
         setRouteToolLoopRetryOptions(emptyList())
         gpxViewModel.previewRouteToolCreation(
             session = draft,
-            currentLocation = recenterTarget,
+            currentLocation = latestRecenterTarget.value,
         ) { result ->
             setRouteToolCreatePreviewInProgress(false)
             result
@@ -305,11 +321,11 @@ internal fun rememberNavigateRouteToolActions(
         setShortcutTrayExpanded(false)
         setPoiCreationSelectionActive(false)
         setRouteToolOptions(
-            routeToolOptions
+            latestRouteToolOptions.value
                 .copy(
-                    routeStyle = routeToolDefaultOptions.routeStyle,
-                    useElevation = routeToolDefaultOptions.useElevation,
-                    allowFerries = routeToolDefaultOptions.allowFerries,
+                    routeStyle = latestRouteToolDefaultOptions.value.routeStyle,
+                    useElevation = latestRouteToolDefaultOptions.value.useElevation,
+                    allowFerries = latestRouteToolDefaultOptions.value.allowFerries,
                 ).withVisibleLoopDefaults()
                 .copy(saveBehavior = RouteSaveBehavior.SAVE_AS_NEW),
         )
@@ -367,17 +383,27 @@ internal fun rememberNavigateRouteToolActions(
         savePoiAt(mapView.model.mapViewPosition.center)
     }
 
-    fun startRouteToolSelection(session: RouteToolSession) {
+    fun preflightRouteToolStart(
+        session: RouteToolSession,
+        currentLocation: LatLong? = latestRecenterTarget.value,
+        gpsSignal: GpsSignalSnapshot = latestGpsSignalSnapshot.value,
+    ): RouteToolPreflightResult =
+        session.preflightStart(
+            context = context,
+            currentLocation = currentLocation,
+            gpsSignalSnapshot = gpsSignal,
+            isOfflineMode = latestOfflineMode.value,
+            hasSingleActiveGpx = latestActiveGpxDetailsCount.value == 1,
+            selectedMapPath = latestSelectedMapPath.value,
+        )
+
+    fun startRouteToolSelection(
+        session: RouteToolSession,
+        currentLocation: LatLong? = latestRecenterTarget.value,
+        gpsSignal: GpsSignalSnapshot = latestGpsSignalSnapshot.value,
+    ) {
         pendingDirectPoiRoute.value = null
-        val preflight =
-            session.preflightStart(
-                context = context,
-                currentLocation = recenterTarget,
-                gpsSignalSnapshot = gpsSignalSnapshot,
-                isOfflineMode = offlineMode,
-                hasSingleActiveGpx = activeGpxDetailsCount == 1,
-                selectedMapPath = selectedMapPath,
-            )
+        val preflight = preflightRouteToolStart(session, currentLocation, gpsSignal)
         if (!preflight.canStart) {
             preflight.message?.let(setRouteToolPreflightMessage)
             if (preflight.shouldRequestFreshLocation) {
@@ -413,7 +439,7 @@ internal fun rememberNavigateRouteToolActions(
                     beginRouteToolExecution("Finding route...")
                     gpxViewModel.applyRouteToolCreation(
                         session = session,
-                        currentLocation = recenterTarget,
+                        currentLocation = currentLocation,
                         onProgress = setRouteToolExecutionStatus,
                     ) { result ->
                         finishRouteToolExecution()
@@ -490,19 +516,28 @@ internal fun rememberNavigateRouteToolActions(
         setRouteToolSession(session)
     }
 
-    fun evaluatePendingPoiRoutePreflight(session: RouteToolSession): RouteToolPreflightResult =
-        session.preflightStart(
-            context = context,
-            currentLocation = recenterTarget,
-            gpsSignalSnapshot = gpsSignalSnapshot,
-            isOfflineMode = offlineMode,
-            hasSingleActiveGpx = activeGpxDetailsCount == 1,
-            selectedMapPath = selectedMapPath,
+    fun evaluatePendingPoiRoutePreflight(
+        session: RouteToolSession,
+        currentLocation: LatLong?,
+        gpsSignal: GpsSignalSnapshot,
+    ): RouteToolPreflightResult =
+        preflightRouteToolStart(
+            session = session,
+            currentLocation = currentLocation,
+            gpsSignal = gpsSignal,
         )
 
-    fun startPendingPoiRoute(session: RouteToolSession) {
+    fun startPendingPoiRoute(
+        session: RouteToolSession,
+        currentLocation: LatLong,
+        gpsSignal: GpsSignalSnapshot,
+    ) {
         pendingDirectPoiRoute.value = null
-        startRouteToolSelection(session)
+        startRouteToolSelection(
+            session = session,
+            currentLocation = currentLocation,
+            gpsSignal = gpsSignal,
+        )
     }
 
     fun showPendingPoiRouteBlocker(message: String?) {
@@ -527,9 +562,7 @@ internal fun rememberNavigateRouteToolActions(
             PendingDirectPoiRouteTriggers(
                 session = pendingDirectPoiRoute.value,
                 currentLocation = recenterTarget,
-                locationAvailable = gpsSignalSnapshot.isLocationAvailable,
-                lastFixElapsedRealtimeMs = gpsSignalSnapshot.lastFixElapsedRealtimeMs,
-                lastFixAgeMs = gpsSignalSnapshot.lastFixAgeMs,
+                gpsSignalSnapshot = gpsSignalSnapshot,
                 offlineMode = offlineMode,
                 selectedMapPath = selectedMapPath,
             ),
@@ -570,8 +603,10 @@ internal fun rememberNavigateRouteToolActions(
         clearRouteToolExecutionFeedback()
         clearRouteToolResultState()
         clearRouteToolPreviewState()
+        val currentLocation = latestRecenterTarget.value
+        val gpsSignal = latestGpsSignalSnapshot.value
         val createOptions =
-            routeToolOptions
+            latestRouteToolOptions.value
                 .copy(
                     toolKind = RouteToolKind.CREATE,
                     createMode = RouteCreateMode.CURRENT_TO_HERE,
@@ -583,20 +618,17 @@ internal fun rememberNavigateRouteToolActions(
                 destination = LatLong(marker.lat, marker.lon),
             )
         val preflight =
-            session.preflightStart(
-                context = context,
-                currentLocation = recenterTarget,
-                gpsSignalSnapshot = gpsSignalSnapshot,
-                isOfflineMode = offlineMode,
-                hasSingleActiveGpx = activeGpxDetailsCount == 1,
-                selectedMapPath = selectedMapPath,
+            preflightRouteToolStart(
+                session = session,
+                currentLocation = currentLocation,
+                gpsSignal = gpsSignal,
             )
         logPoiRoutePreflight(
             event = "click_preflight",
-            currentLocationPresent = recenterTarget != null,
-            locationAvailable = gpsSignalSnapshot.isLocationAvailable,
-            lastFixElapsedRealtimeMs = gpsSignalSnapshot.lastFixElapsedRealtimeMs,
-            lastFixAgeMs = gpsSignalSnapshot.lastFixAgeMs,
+            currentLocationPresent = currentLocation != null,
+            locationAvailable = gpsSignal.isLocationAvailable,
+            lastFixElapsedRealtimeMs = gpsSignal.lastFixElapsedRealtimeMs,
+            lastFixAgeMs = gpsSignal.lastFixAgeMs,
             result =
                 when {
                     preflight.canStart -> "ready"
@@ -606,7 +638,12 @@ internal fun rememberNavigateRouteToolActions(
             message = preflight.message,
         )
         when {
-            preflight.canStart -> startRouteToolSelection(session)
+            preflight.canStart ->
+                startRouteToolSelection(
+                    session = session,
+                    currentLocation = currentLocation,
+                    gpsSignal = gpsSignal,
+                )
             preflight.shouldRequestFreshLocation -> {
                 pendingDirectPoiRoute.value = session
                 locationViewModel.requestImmediateLocation(source = "ui_poi_to_here")
@@ -628,7 +665,7 @@ internal fun rememberNavigateRouteToolActions(
         beginRouteToolExecution(if (preview != null) "Saving GPX..." else "Finding route...")
         gpxViewModel.applyRouteToolCreation(
             session = draft,
-            currentLocation = recenterTarget,
+            currentLocation = latestRecenterTarget.value,
             preview = preview,
             onProgress = setRouteToolExecutionStatus,
         ) { result ->
@@ -795,7 +832,7 @@ internal fun rememberNavigateRouteToolActions(
         startPoiCreationSelection = ::startPoiCreationSelection,
         savePoiAtCurrentMapCenter = ::savePoiAtCurrentMapCenter,
         savePoiAt = ::savePoiAt,
-        startRouteToolSelection = ::startRouteToolSelection,
+        startRouteToolSelection = { session -> startRouteToolSelection(session) },
         undoRouteToolPoint = ::undoRouteToolPoint,
         createRouteToPoi = ::createRouteToPoi,
         executeCreateDraft = ::executeCreateDraft,
@@ -814,9 +851,9 @@ private fun logPoiRoutePreflight(
     logPoiRoutePreflight(
         event = event,
         currentLocationPresent = triggers.currentLocation != null,
-        locationAvailable = triggers.locationAvailable,
-        lastFixElapsedRealtimeMs = triggers.lastFixElapsedRealtimeMs,
-        lastFixAgeMs = triggers.lastFixAgeMs,
+        locationAvailable = triggers.gpsSignalSnapshot.isLocationAvailable,
+        lastFixElapsedRealtimeMs = triggers.gpsSignalSnapshot.lastFixElapsedRealtimeMs,
+        lastFixAgeMs = triggers.gpsSignalSnapshot.lastFixAgeMs,
         message = message,
     )
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.RouteTools.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.RouteTools.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import com.glancemap.glancemapwearos.core.routing.LoopRouteSuggestionException
+import com.glancemap.glancemapwearos.core.service.diagnostics.DebugTelemetry
 import com.glancemap.glancemapwearos.core.service.location.model.GpsSignalSnapshot
 import com.glancemap.glancemapwearos.data.repository.UserPoiRecord
 import com.glancemap.glancemapwearos.presentation.features.gpx.GpxViewModel
@@ -52,14 +53,14 @@ private data class PendingDirectPoiRouteTriggers(
     val session: RouteToolSession?,
     val currentLocation: LatLong?,
     val locationAvailable: Boolean,
-    val lastFixFresh: Boolean,
+    val lastFixElapsedRealtimeMs: Long,
+    val lastFixAgeMs: Long,
     val offlineMode: Boolean,
     val selectedMapPath: String?,
 )
 
 private data class PendingDirectPoiRouteActions(
     val evaluatePreflight: (RouteToolSession) -> RouteToolPreflightResult,
-    val requestFreshLocation: () -> Unit,
     val onReady: (RouteToolSession) -> Unit,
     val onBlocked: (String?) -> Unit,
     val onTimeout: (RouteToolSession) -> Unit,
@@ -76,7 +77,8 @@ private fun PendingDirectPoiRouteEffect(
         triggers.session,
         triggers.currentLocation,
         triggers.locationAvailable,
-        triggers.lastFixFresh,
+        triggers.lastFixElapsedRealtimeMs,
+        triggers.lastFixAgeMs,
         triggers.offlineMode,
         triggers.selectedMapPath,
     ) {
@@ -84,11 +86,33 @@ private fun PendingDirectPoiRouteEffect(
         val currentActions = latestActions.value
         val preflight = currentActions.evaluatePreflight(pendingSession)
         when {
-            preflight.canStart -> currentActions.onReady(pendingSession)
-            !preflight.shouldRequestFreshLocation -> currentActions.onBlocked(preflight.message)
+            preflight.canStart -> {
+                logPoiRoutePreflight(
+                    event = "pending_ready",
+                    triggers = triggers,
+                )
+                currentActions.onReady(pendingSession)
+            }
+
+            !preflight.shouldRequestFreshLocation -> {
+                logPoiRoutePreflight(
+                    event = "pending_blocked",
+                    triggers = triggers,
+                    message = preflight.message,
+                )
+                currentActions.onBlocked(preflight.message)
+            }
+
             else -> {
-                currentActions.requestFreshLocation()
+                logPoiRoutePreflight(
+                    event = "pending_waiting",
+                    triggers = triggers,
+                )
                 delay(DIRECT_POI_ROUTE_GPS_WAIT_TIMEOUT_MS)
+                logPoiRoutePreflight(
+                    event = "pending_timeout",
+                    triggers = triggers,
+                )
                 latestActions.value.onTimeout(pendingSession)
             }
         }
@@ -504,16 +528,14 @@ internal fun rememberNavigateRouteToolActions(
                 session = pendingDirectPoiRoute.value,
                 currentLocation = recenterTarget,
                 locationAvailable = gpsSignalSnapshot.isLocationAvailable,
-                lastFixFresh = gpsSignalSnapshot.lastFixFresh,
+                lastFixElapsedRealtimeMs = gpsSignalSnapshot.lastFixElapsedRealtimeMs,
+                lastFixAgeMs = gpsSignalSnapshot.lastFixAgeMs,
                 offlineMode = offlineMode,
                 selectedMapPath = selectedMapPath,
             ),
         actions =
             PendingDirectPoiRouteActions(
                 evaluatePreflight = ::evaluatePendingPoiRoutePreflight,
-                requestFreshLocation = {
-                    locationViewModel.requestImmediateLocation(source = "ui_poi_to_here")
-                },
                 onReady = ::startPendingPoiRoute,
                 onBlocked = ::showPendingPoiRouteBlocker,
                 onTimeout = ::showPendingPoiRouteTimeout,
@@ -569,6 +591,20 @@ internal fun rememberNavigateRouteToolActions(
                 hasSingleActiveGpx = activeGpxDetailsCount == 1,
                 selectedMapPath = selectedMapPath,
             )
+        logPoiRoutePreflight(
+            event = "click_preflight",
+            currentLocationPresent = recenterTarget != null,
+            locationAvailable = gpsSignalSnapshot.isLocationAvailable,
+            lastFixElapsedRealtimeMs = gpsSignalSnapshot.lastFixElapsedRealtimeMs,
+            lastFixAgeMs = gpsSignalSnapshot.lastFixAgeMs,
+            result =
+                when {
+                    preflight.canStart -> "ready"
+                    preflight.shouldRequestFreshLocation -> "waiting"
+                    else -> "blocked"
+                },
+            message = preflight.message,
+        )
         when {
             preflight.canStart -> startRouteToolSelection(session)
             preflight.shouldRequestFreshLocation -> {
@@ -770,4 +806,55 @@ internal fun rememberNavigateRouteToolActions(
     )
 }
 
+private fun logPoiRoutePreflight(
+    event: String,
+    triggers: PendingDirectPoiRouteTriggers,
+    message: String? = null,
+) {
+    logPoiRoutePreflight(
+        event = event,
+        currentLocationPresent = triggers.currentLocation != null,
+        locationAvailable = triggers.locationAvailable,
+        lastFixElapsedRealtimeMs = triggers.lastFixElapsedRealtimeMs,
+        lastFixAgeMs = triggers.lastFixAgeMs,
+        message = message,
+    )
+}
+
+private fun logPoiRoutePreflight(
+    event: String,
+    currentLocationPresent: Boolean,
+    locationAvailable: Boolean,
+    lastFixElapsedRealtimeMs: Long,
+    lastFixAgeMs: Long,
+    result: String? = null,
+    message: String? = null,
+) {
+    if (!DebugTelemetry.isEnabled()) return
+    DebugTelemetry.log(
+        POI_ROUTE_TELEMETRY_TAG,
+        buildString {
+            append("event=")
+            append(event)
+            result?.let {
+                append(" result=")
+                append(it)
+            }
+            append(" currentLocation=")
+            append(currentLocationPresent)
+            append(" locationAvailable=")
+            append(locationAvailable)
+            append(" fixElapsedMs=")
+            append(lastFixElapsedRealtimeMs)
+            append(" fixAgeMs=")
+            append(lastFixAgeMs)
+            message?.let {
+                append(" message=")
+                append(it.replace(' ', '_'))
+            }
+        },
+    )
+}
+
 private const val DIRECT_POI_ROUTE_GPS_WAIT_TIMEOUT_MS = 12_000L
+private const val POI_ROUTE_TELEMETRY_TAG = "PoiRoute"

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiScreen.kt
@@ -75,6 +75,10 @@ import com.google.android.horologist.compose.layout.rememberResponsiveColumnStat
 import kotlinx.coroutines.launch
 
 private sealed interface PoiListRow {
+    data class SectionHeader(
+        val label: String,
+    ) : PoiListRow
+
     data class FileRow(
         val file: PoiFileUiState,
     ) : PoiListRow
@@ -346,58 +350,74 @@ fun PoiScreen(
     val rows =
         remember(poiFiles, categoryPreviews, isDeleteMode, expandedByFileSnapshot) {
             buildList<PoiListRow> {
-                poiFiles.forEach { file ->
-                    add(PoiListRow.FileRow(file))
-                    val showExpandedRows =
-                        file.isExpanded &&
-                            (
-                                !isDeleteMode || file.path == USER_POI_SOURCE_PATH
-                            )
-                    if (showExpandedRows) {
-                        if (file.path == USER_POI_SOURCE_PATH) {
-                            addCategoryPreviewRows(
-                                filePath = file.path,
-                                categoryId = USER_POI_CATEGORY_ID,
-                                depth = 1,
-                                preview =
-                                    categoryPreviews[
-                                        PoiCategoryPreviewKey(file.path, USER_POI_CATEGORY_ID),
-                                    ],
-                                emptyText = "No saved places yet.",
-                            )
-                            return@forEach
-                        }
-                        val expandedIds = expandedByFileSnapshot[file.path].orEmpty()
-                        val categoriesById = file.categories.associateBy { it.id }
-                        file.categories.forEach { category ->
-                            if (isCategoryVisible(category, categoriesById, expandedIds)) {
-                                val isCategoryExpanded = category.id in expandedIds
-                                add(
-                                    PoiListRow.CategoryRow(
-                                        filePath = file.path,
-                                        category = category,
-                                        isExpanded = isCategoryExpanded,
-                                    ),
+                val userFiles = poiFiles.filter { it.path == USER_POI_SOURCE_PATH }
+                val waypointFiles =
+                    poiFiles.filter { it.path != USER_POI_SOURCE_PATH && it.isGpxWaypointFolder }
+                val importedPoiFiles =
+                    poiFiles.filter { it.path != USER_POI_SOURCE_PATH && !it.isGpxWaypointFolder }
+                val sections =
+                    listOf(
+                        "My creation" to userFiles,
+                        "GPX waypoints" to waypointFiles,
+                        "POI files" to importedPoiFiles,
+                    )
+
+                sections.forEach { (label, files) ->
+                    if (files.isEmpty()) return@forEach
+                    add(PoiListRow.SectionHeader(label))
+                    files.forEach { file ->
+                        add(PoiListRow.FileRow(file))
+                        val showExpandedRows =
+                            file.isExpanded &&
+                                (
+                                    !isDeleteMode || file.path == USER_POI_SOURCE_PATH
                                 )
-                                if (isCategoryExpanded) {
-                                    val isSyntheticGroup = category.id < 0 && category.hasChildren
-                                    if (!isSyntheticGroup) {
-                                        val poiDepth = category.depth + 1
-                                        addCategoryPreviewRows(
+                        if (showExpandedRows) {
+                            if (file.path == USER_POI_SOURCE_PATH) {
+                                addCategoryPreviewRows(
+                                    filePath = file.path,
+                                    categoryId = USER_POI_CATEGORY_ID,
+                                    depth = 1,
+                                    preview =
+                                        categoryPreviews[
+                                            PoiCategoryPreviewKey(file.path, USER_POI_CATEGORY_ID),
+                                        ],
+                                    emptyText = "No saved places yet.",
+                                )
+                                return@forEach
+                            }
+                            val expandedIds = expandedByFileSnapshot[file.path].orEmpty()
+                            val categoriesById = file.categories.associateBy { it.id }
+                            file.categories.forEach { category ->
+                                if (isCategoryVisible(category, categoriesById, expandedIds)) {
+                                    val isCategoryExpanded = category.id in expandedIds
+                                    add(
+                                        PoiListRow.CategoryRow(
                                             filePath = file.path,
-                                            categoryId = category.id,
-                                            depth = poiDepth,
-                                            preview =
-                                                categoryPreviews[
-                                                    PoiCategoryPreviewKey(file.path, category.id),
-                                                ],
-                                            emptyText =
-                                                if (category.hasChildren) {
-                                                    "No direct POI. Expand sub-folders."
-                                                } else {
-                                                    "No POI in this folder."
-                                                },
-                                        )
+                                            category = category,
+                                            isExpanded = isCategoryExpanded,
+                                        ),
+                                    )
+                                    if (isCategoryExpanded) {
+                                        val isSyntheticGroup = category.id < 0 && category.hasChildren
+                                        if (!isSyntheticGroup) {
+                                            val poiDepth = category.depth + 1
+                                            addCategoryPreviewRows(
+                                                filePath = file.path,
+                                                categoryId = category.id,
+                                                depth = poiDepth,
+                                                preview =
+                                                    categoryPreviews[
+                                                        PoiCategoryPreviewKey(file.path, category.id),
+                                                    ],
+                                                emptyText =
+                                                    if (category.hasChildren) {
+                                                        "No direct POI. Expand sub-folders."
+                                                    } else {
+                                                        "No POI in this folder."
+                                                    },
+                                            )
+                                        }
                                     }
                                 }
                             }
@@ -700,6 +720,7 @@ fun PoiScreen(
                         items = rows,
                         key = { row ->
                             when (row) {
+                                is PoiListRow.SectionHeader -> "s:${row.label}"
                                 is PoiListRow.FileRow -> "f:${row.file.path}"
                                 is PoiListRow.CategoryRow -> "c:${row.filePath}:${row.category.id}"
                                 is PoiListRow.CategoryPoiRow -> {
@@ -712,6 +733,16 @@ fun PoiScreen(
                         },
                     ) { row ->
                         when (row) {
+                            is PoiListRow.SectionHeader -> {
+                                Text(
+                                    text = row.label,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.55f),
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                            }
+
                             is PoiListRow.FileRow -> {
                                 PoiFileRow(
                                     file = row.file,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/poi/PoiViewModel.kt
@@ -50,6 +50,7 @@ data class PoiCategoryUiState(
 data class PoiFileUiState(
     val name: String,
     val path: String,
+    val isGpxWaypointFolder: Boolean = false,
     val isEnabled: Boolean,
     val isExpanded: Boolean,
     val categories: List<PoiCategoryUiState>,
@@ -856,12 +857,18 @@ class PoiViewModel(
         withContext(Dispatchers.IO) {
             val coverage = mutableListOf<PoiCoverageAreaUiState>()
             files.map { file ->
+                val linkedGpxFileName = poiRepository.readLinkedGpxWaypointFileName(file.absolutePath)
+                val displayName =
+                    linkedGpxFileName
+                        ?.removeSuffix(".gpx")
+                        ?.takeIf { it.isNotBlank() }
+                        ?: file.nameWithoutExtension
                 val categories = poiRepository.readCategories(file.absolutePath)
                 poiRepository.readCoverageBounds(file.absolutePath)?.let { bounds ->
                     coverage +=
                         PoiCoverageAreaUiState(
                             filePath = file.absolutePath,
-                            fileName = file.nameWithoutExtension,
+                            fileName = displayName,
                             bounds = bounds,
                         )
                 }
@@ -875,8 +882,9 @@ class PoiViewModel(
                     )
 
                 PoiFileUiState(
-                    name = file.nameWithoutExtension,
+                    name = displayName,
                     path = file.absolutePath,
+                    isGpxWaypointFolder = linkedGpxFileName != null,
                     isEnabled = poiRepository.isFileEnabled(file.absolutePath),
                     isExpanded = previousExpanded[file.absolutePath] ?: false,
                     categories = categories.map { it.toUiState(enabled = it.id in enabledIds) },

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/recording/TraceRecordingViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/recording/TraceRecordingViewModel.kt
@@ -687,8 +687,8 @@ class TraceRecordingViewModel(
                     }
                 val pointCount = currentState.points.size + 1
                 updateGapTelemetry(
-                    pointTimeMillis = point.timeMillis,
-                    accuracyMeters = point.accuracyMeters,
+                    previousPoint = previous,
+                    point = point,
                     provider = location.provider,
                     nextPointCount = pointCount,
                 )
@@ -1456,21 +1456,25 @@ class TraceRecordingViewModel(
     }
 
     private fun updateGapTelemetry(
-        pointTimeMillis: Long,
-        accuracyMeters: Float?,
+        previousPoint: RecordedTracePoint?,
+        point: RecordedTracePoint,
         provider: String?,
         nextPointCount: Int,
     ) {
         val previousPointTimeMillis = lastAcceptedPointTimeMillis
         if (previousPointTimeMillis != null) {
-            val gapMillis = (pointTimeMillis - previousPointTimeMillis).coerceAtLeast(0L)
+            val gapMillis = (point.timeMillis - previousPointTimeMillis).coerceAtLeast(0L)
             val expectedActiveGapMillis = expectedActivePointGapMillis()
             gpsActiveDurationMillis += minOf(gapMillis, expectedActiveGapMillis)
             val thresholdMillis = recordingGapThresholdMillis()
             if (gapMillis > thresholdMillis) {
                 recordingGapCount += 1
                 recordingMaxGapMillis = maxOf(recordingMaxGapMillis, gapMillis)
-                val expectedPointCount = expectedPointCountForElapsed(elapsedSinceFirstPointMillis(pointTimeMillis))
+                val expectedPointCount = expectedPointCountForElapsed(elapsedSinceFirstPointMillis(point.timeMillis))
+                val endpointDistanceMeters =
+                    previousPoint?.let { previous ->
+                        haversineMeters(previous.latLong, point.latLong)
+                    }
                 DebugTelemetry.log(
                     "TraceRecording",
                     "event=gap gapMs=$gapMillis thresholdMs=$thresholdMillis " +
@@ -1478,7 +1482,12 @@ class TraceRecordingViewModel(
                         "acceptThresholdMs=${recordingSampleAcceptThresholdMillis()} " +
                         "expectedPointCount=$expectedPointCount " +
                         "acceptedPointCount=$nextPointCount " +
-                        "accuracyMeters=${accuracyMeters?.toInt() ?: -1} " +
+                        "accuracyMeters=${point.accuracyMeters?.toInt() ?: -1} " +
+                        "gapEndpointDistanceM=${endpointDistanceMeters?.formatTelemetry(1) ?: "na"} " +
+                        "gapPreviousSpeedMps=${previousPoint?.speedMps?.formatTelemetry(2) ?: "na"} " +
+                        "gapCurrentSpeedMps=${point.speedMps?.formatTelemetry(2) ?: "na"} " +
+                        "gapPreviousAccuracyM=${previousPoint?.accuracyMeters?.formatTelemetry(1) ?: "na"} " +
+                        "gapCurrentAccuracyM=${point.accuracyMeters?.formatTelemetry(1) ?: "na"} " +
                         "provider=${sanitizeTelemetryValue(provider ?: "na")} " +
                         "lastLiveFixAgeMs=${lastLiveFixAgeMillis()} " +
                         "lastLiveProvider=${sanitizeTelemetryValue(lastLiveFixProvider ?: "na")} " +
@@ -1491,7 +1500,7 @@ class TraceRecordingViewModel(
                 )
             }
         }
-        lastAcceptedPointTimeMillis = pointTimeMillis
+        lastAcceptedPointTimeMillis = point.timeMillis
     }
 
     private fun updateSensorEventTelemetry(

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolPreflight.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolPreflight.kt
@@ -1,6 +1,7 @@
 package com.glancemap.glancemapwearos.presentation.features.routetools
 
 import android.content.Context
+import android.os.SystemClock
 import com.glancemap.glancemapwearos.core.routing.RoutingCoverageUtils
 import com.glancemap.glancemapwearos.core.routing.isRoutingSegmentFileName
 import com.glancemap.glancemapwearos.core.routing.routingSegmentsDir
@@ -61,11 +62,13 @@ internal fun RouteToolSession.preflightStart(
         )
     }
 
-    val hasFreshLocation =
-        currentLocation != null &&
-            gpsSignalSnapshot.isLocationAvailable &&
-            gpsSignalSnapshot.lastFixFresh
-    if (hasFreshLocation) {
+    if (
+        hasUsableRouteToolCurrentLocation(
+            currentLocation = currentLocation,
+            gpsSignalSnapshot = gpsSignalSnapshot,
+            nowElapsedMs = SystemClock.elapsedRealtime(),
+        )
+    ) {
         return RouteToolPreflightResult(canStart = true)
     }
 
@@ -75,6 +78,24 @@ internal fun RouteToolSession.preflightStart(
         shouldRequestFreshLocation = true,
     )
 }
+
+/**
+ * A route can safely start from a recently accepted position even while the fused provider reports
+ * a transient availability change. This is deliberately less strict than the live-marker policy:
+ * the origin is used once to plan a route, rather than to continuously render the user's position.
+ */
+internal fun hasUsableRouteToolCurrentLocation(
+    currentLocation: LatLong?,
+    gpsSignalSnapshot: GpsSignalSnapshot,
+    nowElapsedMs: Long,
+): Boolean {
+    if (currentLocation == null || gpsSignalSnapshot.lastFixElapsedRealtimeMs <= 0L) return false
+    val fixAgeMs =
+        (nowElapsedMs - gpsSignalSnapshot.lastFixElapsedRealtimeMs).coerceAtLeast(0L)
+    return fixAgeMs <= ROUTE_TOOL_CURRENT_LOCATION_MAX_AGE_MS
+}
+
+internal const val ROUTE_TOOL_CURRENT_LOCATION_MAX_AGE_MS = 10_000L
 
 private fun hasInstalledRoutingData(context: Context): Boolean {
     val installedFiles = routingSegmentsDir(context).listFiles() ?: return false

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/MapSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/MapSettingsScreen.kt
@@ -104,11 +104,10 @@ fun MapSettingsScreen(
                 .first { source -> source != readiness.selectedSource }
         WearActionDialog(
             visible = true,
-            title = "Using available terrain",
+            title = "Live elevation",
             message =
-                "${readiness.selectedSource.displayName} is not fully downloaded for this map. " +
-                    "Live elevation is using ${fallbackSource.displayName} where needed. " +
-                    "Download ${readiness.selectedSource.displayName} in Maps to use it instead.",
+                "${readiness.selectedSource.displayName} is not available for all of this map.\n" +
+                    "Using ${fallbackSource.displayName} instead.",
             confirmText = "OK",
             onConfirm = { fallbackTerrainNotice = null },
             onDismissRequest = { fallbackTerrainNotice = null },

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/PoiSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/PoiSettingsScreen.kt
@@ -33,6 +33,7 @@ fun PoiSettingsScreen(
     val poiIconSizePx by viewModel.poiIconSizePx.collectAsState()
     val poiMarkerStyle by viewModel.poiMarkerStyle.collectAsState()
     val poiTapToCenterEnabled by viewModel.poiTapToCenterEnabled.collectAsState()
+    val linkGpxWaypointPoiFolders by viewModel.linkGpxWaypointPoiFolders.collectAsState()
     val poiPopupTimeoutSeconds by viewModel.poiPopupTimeoutSeconds.collectAsState()
     val poiPopupManualCloseOnly by viewModel.poiPopupManualCloseOnly.collectAsState()
     val iconSizeOptions =
@@ -92,6 +93,13 @@ fun PoiSettingsScreen(
                         "Disabled"
                     },
                 onSelect = viewModel::setPoiTapToCenterEnabled,
+            )
+        }
+        item {
+            SettingsToggleChip(
+                checked = linkGpxWaypointPoiFolders,
+                onCheckedChanged = viewModel::setLinkGpxWaypointPoiFolders,
+                label = "Link GPX waypoint folders",
             )
         }
         item {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/SettingsViewModel.kt
@@ -1243,6 +1243,19 @@ class SettingsViewModel(
             settingsRepository.setPoiTapToCenterEnabled(enabled)
         }
 
+    val linkGpxWaypointPoiFolders: StateFlow<Boolean> =
+        settingsRepository.linkGpxWaypointPoiFolders
+            .stateIn(
+                viewModelScope,
+                SharingStarted.WhileSubscribed(5000),
+                SettingsRepository.DEFAULT_LINK_GPX_WAYPOINT_POI_FOLDERS,
+            )
+
+    fun setLinkGpxWaypointPoiFolders(enabled: Boolean) =
+        viewModelScope.launch {
+            settingsRepository.setLinkGpxWaypointPoiFolders(enabled)
+        }
+
     val poiPopupTimeoutSeconds: StateFlow<Int> =
         settingsRepository.poiPopupTimeoutSeconds
             .stateIn(

--- a/app/src/test/java/com/glancemap/glancemapwearos/core/service/diagnostics/DiagnosticsExporterTelemetryTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/core/service/diagnostics/DiagnosticsExporterTelemetryTest.kt
@@ -204,6 +204,28 @@ class DiagnosticsExporterTelemetryTest {
     }
 
     @Test
+    fun recordingGapEndpointDistanceTelemetryIsSummarized() {
+        val lines =
+            listOf(
+                "2026-04-20 20:07:12.000 [TraceRecording] event=gap gapMs=16000 " +
+                    "gapEndpointDistanceM=3.0 gapPreviousSpeedMps=0.00 gapCurrentSpeedMps=0.00",
+                "2026-04-20 20:07:32.000 [TraceRecording] event=gap gapMs=17000 " +
+                    "gapEndpointDistanceM=21.0 gapPreviousSpeedMps=4.00 gapCurrentSpeedMps=4.50",
+            )
+
+        val insights =
+            deriveTelemetryInsights(
+                lines = lines,
+                captureWindowEndEpochMs = epochMs("2026-04-20T20:07:39"),
+            )
+
+        assertEquals(2, insights.recordingGapEventCount)
+        assertEquals(2, insights.recordingGapEndpointDistanceSampleCount)
+        assertEquals(12f, insights.recordingGapEndpointDistanceAvgMeters)
+        assertEquals(21f, insights.recordingGapEndpointDistanceMaxMeters)
+    }
+
+    @Test
     fun recordingTrackFilterTelemetryIsSummarized() {
         val lines =
             listOf(

--- a/app/src/test/java/com/glancemap/glancemapwearos/domain/sensors/FusedOrientationProviderAdapterSupportTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/domain/sensors/FusedOrientationProviderAdapterSupportTest.kt
@@ -65,14 +65,6 @@ class FusedOrientationProviderAdapterSupportTest {
     }
 
     @Test
-    fun activeTurnRequiresRelativeMovementRateInsteadOfAbsoluteHeadingNoise() {
-        assertFalse(isActiveRelativeTurnStep(stepDeg = 0.3f, elapsedMs = 20L))
-        assertFalse(isActiveRelativeTurnStep(stepDeg = 0.5f, elapsedMs = 40L))
-        assertTrue(isActiveRelativeTurnStep(stepDeg = 1.2f, elapsedMs = 40L))
-        assertFalse(isActiveRelativeTurnStep(stepDeg = 10f, elapsedMs = 500L))
-    }
-
-    @Test
     fun lowPowerHeadingPublishingKeepsFiveHertzCadence() {
         assertFalse(
             shouldPublishFusedHeading(

--- a/app/src/test/java/com/glancemap/glancemapwearos/domain/sensors/HeadingTurnRateHysteresisTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/domain/sensors/HeadingTurnRateHysteresisTest.kt
@@ -1,0 +1,57 @@
+package com.glancemap.glancemapwearos.domain.sensors
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HeadingTurnRateHysteresisTest {
+    @Test
+    fun entersOnDeliberateTurnAndStaysActiveThroughSlowerSamples() {
+        val tracker = createTracker()
+
+        assertFalse(tracker.update(headingDeg = 0f, atElapsedMs = 1_000L))
+        assertTrue(tracker.update(headingDeg = 1.2f, atElapsedMs = 1_040L))
+        assertTrue(tracker.update(headingDeg = 2.0f, atElapsedMs = 1_080L))
+        assertTrue(tracker.update(headingDeg = 2.7f, atElapsedMs = 1_120L))
+    }
+
+    @Test
+    fun exitsOnlyAfterAngularMovementStaysBelowExitRate() {
+        val tracker = createTracker()
+
+        tracker.update(headingDeg = 0f, atElapsedMs = 1_000L)
+        assertTrue(tracker.update(headingDeg = 1.2f, atElapsedMs = 1_040L))
+        assertTrue(tracker.update(headingDeg = 1.4f, atElapsedMs = 1_080L))
+        assertTrue(tracker.update(headingDeg = 6.0f, atElapsedMs = 1_300L))
+        assertTrue(tracker.update(headingDeg = 6.1f, atElapsedMs = 1_340L))
+        assertTrue(tracker.update(headingDeg = 6.2f, atElapsedMs = 1_600L))
+        assertFalse(tracker.update(headingDeg = 6.3f, atElapsedMs = 1_680L))
+    }
+
+    @Test
+    fun handlesNorthCrossingAndRejectsAnIsolatedSmallNoiseStep() {
+        val tracker = createTracker()
+
+        assertFalse(tracker.update(headingDeg = 359.5f, atElapsedMs = 1_000L))
+        assertFalse(tracker.update(headingDeg = 359.8f, atElapsedMs = 1_020L))
+        assertTrue(tracker.update(headingDeg = 0.8f, atElapsedMs = 1_060L))
+    }
+
+    @Test
+    fun resetsTurnStateAfterAStaleSampleGap() {
+        val tracker = createTracker()
+
+        tracker.update(headingDeg = 0f, atElapsedMs = 1_000L)
+        assertTrue(tracker.update(headingDeg = 1.2f, atElapsedMs = 1_040L))
+        assertFalse(tracker.update(headingDeg = 20f, atElapsedMs = 1_500L))
+    }
+
+    private fun createTracker() =
+        HeadingTurnRateHysteresis(
+            enterRateDegPerSec = 25f,
+            exitRateDegPerSec = 15f,
+            exitHoldMs = 300L,
+            minimumEntryStepDeg = 0.4f,
+            maximumSampleGapMs = 300L,
+        )
+}

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/effects/NavigateEffectsSupportTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/effects/NavigateEffectsSupportTest.kt
@@ -313,48 +313,43 @@ class NavigateEffectsSupportTest {
     }
 
     @Test
-    fun rapidHeadingChangesEnableFastTurnRendering() {
-        assertTrue(
-            isFastHeadingTurn(
-                previousHeadingDeg = 350f,
-                nextHeadingDeg = 10f,
-                elapsedMs = 100L,
-            ),
-        )
-        assertFalse(
-            isFastHeadingTurn(
-                previousHeadingDeg = 350f,
-                nextHeadingDeg = 352f,
-                elapsedMs = 100L,
-            ),
-        )
+    fun activeTurnAnimationClosesHeadingErrorMoreAggressively() {
+        val normalAlpha =
+            resolveHeadingAnimationAlpha(
+                diffDeg = 40f,
+                activeTurn = false,
+                frameDeltaMs = 16.667f,
+            )
+        val activeTurnAlpha =
+            resolveHeadingAnimationAlpha(
+                diffDeg = 40f,
+                activeTurn = true,
+                frameDeltaMs = 16.667f,
+            )
+
+        assertTrue(activeTurnAlpha > normalAlpha)
     }
 
     @Test
-    fun slowContinuousRotationEnablesHighFrequencyMapRendering() {
-        assertTrue(
-            isActiveMapHeadingTurn(
-                previousHeadingDeg = 350f,
-                nextHeadingDeg = 353f,
-                elapsedMs = 100L,
-            ),
-        )
-        assertFalse(
-            isActiveMapHeadingTurn(
-                previousHeadingDeg = 350f,
-                nextHeadingDeg = 351f,
-                elapsedMs = 100L,
-            ),
-        )
-    }
+    fun headingAnimationResponseIsIndependentOfFrameRate() {
+        fun renderOverOneHundredMilliseconds(frameDeltaMs: Float): Float {
+            var renderedHeading = 0f
+            repeat((100f / frameDeltaMs).toInt()) {
+                renderedHeading +=
+                    resolveHeadingAnimationDelta(
+                        diffDeg = 10f - renderedHeading,
+                        activeTurn = false,
+                        frameDeltaMs = frameDeltaMs,
+                    )
+            }
+            return renderedHeading
+        }
 
-    @Test
-    fun fastTurnAnimationClosesHeadingErrorMoreAggressively() {
-        val normalAlpha = resolveHeadingAnimationAlpha(diffDeg = 40f, fastTurn = false)
-        val fastAlpha = resolveHeadingAnimationAlpha(diffDeg = 40f, fastTurn = true)
-
-        assertTrue(fastAlpha > normalAlpha)
-        assertTrue(fastAlpha >= 0.85f)
+        assertEquals(
+            renderOverOneHundredMilliseconds(frameDeltaMs = 20f),
+            renderOverOneHundredMilliseconds(frameDeltaMs = 10f),
+            0.01f,
+        )
     }
 
     @Test
@@ -396,9 +391,10 @@ class NavigateEffectsSupportTest {
             12f,
             resolveHeadingAnimationDelta(
                 diffDeg = 40f,
-                fastTurn = true,
+                activeTurn = true,
+                frameDeltaMs = 16.667f,
             ),
-            0f,
+            0.01f,
         )
     }
 }

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/effects/NavigateLocationWakePredictionTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/effects/NavigateLocationWakePredictionTest.kt
@@ -1,0 +1,62 @@
+package com.glancemap.glancemapwearos.presentation.features.navigate.effects
+
+import com.glancemap.glancemapwearos.presentation.features.navigate.motion.MarkerMotionReading
+import com.glancemap.glancemapwearos.presentation.features.navigate.motion.MarkerMotionSeed
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mapsforge.core.model.LatLong
+
+class NavigateLocationWakePredictionTest {
+    @Test
+    fun recentAccurateMovingWakeAnchorCanResumePrediction() {
+        assertTrue(
+            shouldResumePredictionFromWakeAnchor(
+                anchor = wakeAnchor(fixElapsedMs = 98_700L),
+                receivedAtElapsedMs = 100_000L,
+                expectedGpsIntervalMs = 3_000L,
+            ),
+        )
+    }
+
+    @Test
+    fun uncertainWakeAnchorStillWaitsForFreshFix() {
+        assertFalse(
+            shouldResumePredictionFromWakeAnchor(
+                anchor = wakeAnchor(fixElapsedMs = 94_000L),
+                receivedAtElapsedMs = 100_000L,
+                expectedGpsIntervalMs = 3_000L,
+            ),
+        )
+        assertFalse(
+            shouldResumePredictionFromWakeAnchor(
+                anchor = wakeAnchor(fixElapsedMs = 99_000L, accuracyM = 30f),
+                receivedAtElapsedMs = 100_000L,
+                expectedGpsIntervalMs = 3_000L,
+            ),
+        )
+        assertFalse(
+            shouldResumePredictionFromWakeAnchor(
+                anchor = wakeAnchor(fixElapsedMs = 99_000L, bearingDeg = null),
+                receivedAtElapsedMs = 100_000L,
+                expectedGpsIntervalMs = 3_000L,
+            ),
+        )
+    }
+
+    private fun wakeAnchor(
+        fixElapsedMs: Long,
+        accuracyM: Float = 8f,
+        bearingDeg: Float? = 90f,
+    ): MarkerMotionSeed =
+        MarkerMotionSeed(
+            latLong = LatLong(48.8566, 2.3522),
+            reading =
+                MarkerMotionReading(
+                    fixElapsedMs = fixElapsedMs,
+                    accuracyM = accuracyM,
+                    speedMps = 13f,
+                    bearingDeg = bearingDeg,
+                ),
+        )
+}

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionControllerTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionControllerTest.kt
@@ -1071,6 +1071,141 @@ class MarkerMotionControllerTest {
     }
 
     @Test
+    fun screenOffFixesKeepHiddenAnchorCurrentWithoutRendering() {
+        MarkerMotionTelemetry.clear()
+        val controller = MarkerMotionController(predictionFreshnessMaxAgeMs = 4_500L, maxAcceptedFixAgeMs = 6_000L)
+        val base = LatLong(48.8566, 2.3522)
+        val firstTarget = moveLatLong(base, bearing = 90f, distanceMeters = 45f)
+        val latestTarget = moveLatLong(base, bearing = 90f, distanceMeters = 90f)
+
+        controller.onGpsFix(
+            latLong = base,
+            nowElapsedMs = 130_000L,
+            fixElapsedMs = 130_000L,
+            accuracyM = 8f,
+            rawSpeedMps = 15f,
+            rawBearingDeg = 90f,
+        )
+        controller.onGpsFix(
+            latLong = firstTarget,
+            nowElapsedMs = 133_000L,
+            fixElapsedMs = 133_000L,
+            accuracyM = 10f,
+            rawSpeedMps = 15f,
+            rawBearingDeg = 90f,
+            isMarkerVisible = false,
+        )
+        val hiddenDisplay =
+            controller.onGpsFix(
+                latLong = latestTarget,
+                nowElapsedMs = 136_000L,
+                fixElapsedMs = 136_000L,
+                accuracyM = 9f,
+                rawSpeedMps = 15f,
+                rawBearingDeg = 90f,
+                isMarkerVisible = false,
+            )
+
+        assertTrue(distanceMeters(hiddenDisplay, latestTarget) < 0.2f)
+        assertTrue(
+            distanceMeters(
+                controller.retainedAnchorSeed?.latLong ?: base,
+                latestTarget,
+            ) < 0.2f,
+        )
+        assertEquals("screen_off_anchor", MarkerMotionTelemetry.latestSnapshot().reason)
+        assertEquals(0, MarkerMotionTelemetry.summary().clampedCorrections)
+        assertEquals(2, MarkerMotionTelemetry.summary().screenOffNextFixPredictionResidualM.samples)
+    }
+
+    @Test
+    fun recentMovingWakeAnchorCanPredictBeforeFreshFix() {
+        MarkerMotionTelemetry.clear()
+        val controller = MarkerMotionController(predictionFreshnessMaxAgeMs = 4_500L, maxAcceptedFixAgeMs = 6_000L)
+        val base = LatLong(48.8566, 2.3522)
+
+        controller.seedAnchor(
+            seed =
+                MarkerMotionSeed(
+                    latLong = base,
+                    reading =
+                        MarkerMotionReading(
+                            fixElapsedMs = 140_000L,
+                            accuracyM = 8f,
+                            speedMps = 15f,
+                            bearingDeg = 90f,
+                        ),
+                ),
+            nowElapsedMs = 141_000L,
+            allowPredictionUntilFreshFix = true,
+        )
+        val predicted =
+            controller.predict(
+                nowElapsedMs = 142_000L,
+                serviceFreshnessMaxAgeMs = 4_500L,
+                watchGpsDegraded = false,
+            ) ?: base
+
+        assertTrue(distanceMeters(base, predicted) > 20f)
+    }
+
+    @Test
+    fun autoFusedConfirmedHighSpeedLagUsesFastCatchUp() {
+        MarkerMotionTelemetry.clear()
+        val controller = MarkerMotionController(predictionFreshnessMaxAgeMs = 4_500L, maxAcceptedFixAgeMs = 6_000L)
+        val base = LatLong(48.8566, 2.3522)
+        val target1 = moveLatLong(base, bearing = 90f, distanceMeters = 60f)
+        val target2 = moveLatLong(base, bearing = 90f, distanceMeters = 120f)
+        val target3 = moveLatLong(base, bearing = 90f, distanceMeters = 180f)
+
+        controller.onGpsFix(
+            latLong = base,
+            nowElapsedMs = 150_000L,
+            fixElapsedMs = 150_000L,
+            accuracyM = 18f,
+            rawSpeedMps = 15f,
+            rawBearingDeg = 90f,
+        )
+        controller.onGpsFix(
+            latLong = target1,
+            nowElapsedMs = 153_000L,
+            fixElapsedMs = 153_000L,
+            accuracyM = 18f,
+            rawSpeedMps = 15f,
+            rawBearingDeg = 90f,
+        )
+        controller.onGpsFix(
+            latLong = target2,
+            nowElapsedMs = 156_000L,
+            fixElapsedMs = 156_000L,
+            accuracyM = 18f,
+            rawSpeedMps = 15f,
+            rawBearingDeg = 90f,
+        )
+        val catchUpDisplay =
+            controller.onGpsFix(
+                latLong = target3,
+                nowElapsedMs = 159_000L,
+                fixElapsedMs = 159_000L,
+                accuracyM = 18f,
+                rawSpeedMps = 15f,
+                rawBearingDeg = 90f,
+            )
+
+        assertEquals("auto_fused_high_speed_catch_up", MarkerMotionTelemetry.latestSnapshot().reason)
+        val caughtUp =
+            controller.predict(
+                nowElapsedMs = 160_000L,
+                serviceFreshnessMaxAgeMs = 4_500L,
+                watchGpsDegraded = false,
+            ) ?: base
+
+        assertTrue(distanceMeters(catchUpDisplay, target3) > 150f)
+        assertTrue(distanceMeters(caughtUp, target3) < 25f)
+        assertEquals(2, MarkerMotionTelemetry.summary().clampedCorrections)
+    }
+
+    @Test
     fun watchGpsSustainedBikeLagCatchesUpAfterRepeatedClamps() {
         MarkerMotionTelemetry.clear()
         val controller = MarkerMotionController(predictionFreshnessMaxAgeMs = 4_500L, maxAcceptedFixAgeMs = 6_000L)
@@ -1285,6 +1420,7 @@ private fun MarkerMotionController.onGpsFix(
     bearingAccuracyDeg: Float? = null,
     allowLargeCorrection: Boolean = false,
     sourceMode: LocationSourceMode = LocationSourceMode.AUTO_FUSED,
+    isMarkerVisible: Boolean = true,
 ): LatLong =
     onGpsFix(
         fix =
@@ -1302,6 +1438,7 @@ private fun MarkerMotionController.onGpsFix(
                     ),
                 allowLargeCorrection = allowLargeCorrection,
                 sourceMode = sourceMode,
+                isMarkerVisible = isMarkerVisible,
             ),
     ).displayedLatLong
 

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionTelemetryTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerMotionTelemetryTest.kt
@@ -69,6 +69,25 @@ class MarkerMotionTelemetryTest {
     }
 
     @Test
+    fun separatesVisibleAndScreenOffPredictionResiduals() {
+        MarkerMotionTelemetry.recordNextFixPredictionResidual(
+            residualDistanceM = 2f,
+            isMarkerVisible = true,
+        )
+        MarkerMotionTelemetry.recordNextFixPredictionResidual(
+            residualDistanceM = 6f,
+            isMarkerVisible = false,
+        )
+
+        val summary = MarkerMotionTelemetry.summary()
+        assertEquals(2, summary.nextFixPredictionResidualM.samples)
+        assertEquals(1, summary.visibleNextFixPredictionResidualM.samples)
+        assertEquals(2f, summary.visibleNextFixPredictionResidualM.max ?: 0f, 0.001f)
+        assertEquals(1, summary.screenOffNextFixPredictionResidualM.samples)
+        assertEquals(6f, summary.screenOffNextFixPredictionResidualM.max ?: 0f, 0.001f)
+    }
+
+    @Test
     fun tracksModeDwellWithoutRetainingFrameSamples() {
         MarkerMotionTelemetry.clear()
 

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerPredictionCadenceTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerPredictionCadenceTest.kt
@@ -22,67 +22,13 @@ class MarkerPredictionCadenceTest {
     }
 
     @Test
-    fun observedMedianRejectsSingleLongGap() {
+    fun configuredCadenceChangesThePredictionCadenceImmediately() {
         val cadence = MarkerPredictionCadence(configuredIntervalMs = 3_000L)
-        listOf(3_000L, 3_200L, 2_800L, 30_000L, 3_100L).forEach { gapMs ->
-            cadence.recordAcceptedFixGap(gapMs = gapMs, sourceChanged = false)
-        }
-
-        assertEquals(3_100L, cadence.expectedIntervalMs())
-    }
-
-    @Test
-    fun observedCadenceRequiresThreeValidSameSourceGaps() {
-        val cadence = MarkerPredictionCadence(configuredIntervalMs = 3_000L)
-
-        cadence.recordAcceptedFixGap(gapMs = 5_000L, sourceChanged = false)
-        cadence.recordAcceptedFixGap(gapMs = 5_200L, sourceChanged = false)
         assertEquals(3_000L, cadence.expectedIntervalMs())
-
-        cadence.recordAcceptedFixGap(gapMs = 4_800L, sourceChanged = false)
-        assertEquals(5_000L, cadence.expectedIntervalMs())
-    }
-
-    @Test
-    fun configuredIntervalChangeImmediatelyClearsObservedCadence() {
-        val cadence = MarkerPredictionCadence(configuredIntervalMs = 3_000L)
-        repeat(3) {
-            cadence.recordAcceptedFixGap(gapMs = 5_000L, sourceChanged = false)
-        }
-        assertEquals(5_000L, cadence.expectedIntervalMs())
 
         cadence.updateConfiguredInterval(intervalMs = 8_000L)
 
         assertEquals(8_000L, cadence.expectedIntervalMs())
-    }
-
-    @Test
-    fun observedCadenceIsBoundedAroundConfiguredRequest() {
-        val cadence = MarkerPredictionCadence(configuredIntervalMs = 4_000L)
-
-        repeat(3) {
-            cadence.recordAcceptedFixGap(gapMs = 700L, sourceChanged = false)
-        }
-        assertEquals(2_000L, cadence.expectedIntervalMs())
-
-        cadence.resetObservedIntervals()
-        repeat(3) {
-            cadence.recordAcceptedFixGap(gapMs = 20_000L, sourceChanged = false)
-        }
-        assertEquals(8_000L, cadence.expectedIntervalMs())
-    }
-
-    @Test
-    fun sourceChangeResetsObservedCadence() {
-        val cadence = MarkerPredictionCadence(configuredIntervalMs = 3_000L)
-        repeat(3) {
-            cadence.recordAcceptedFixGap(gapMs = 5_000L, sourceChanged = false)
-        }
-        assertEquals(5_000L, cadence.expectedIntervalMs())
-
-        cadence.recordAcceptedFixGap(gapMs = 2_000L, sourceChanged = true)
-
-        assertEquals(3_000L, cadence.expectedIntervalMs())
     }
 
     @Test

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerVisualTrajectoryTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/motion/MarkerVisualTrajectoryTest.kt
@@ -144,6 +144,26 @@ class MarkerVisualTrajectoryTest {
     }
 
     @Test
+    fun leadingCorrectionPreservesMostForwardMotion() {
+        val trajectory = MarkerVisualTrajectory()
+        val displayedAhead = moveLatLong(base, bearing = 90f, distanceMeters = 5f)
+        trajectory.rebase(
+            anchor = movingAnchor(base, fixElapsedMs = 10_000L),
+            displayedAtRebase = displayedAhead,
+            nowElapsedMs = 10_000L,
+            predictionWindow = window,
+            correctionPlan = MarkerVisualCorrectionPlan(durationMs = 2_400L),
+        )
+
+        val initial = trajectory.sample(10_000L, window) ?: error("Expected initial sample")
+        val afterOneTick = trajectory.sample(10_100L, window) ?: error("Expected next sample")
+
+        // After the 50 ms prediction guard, the 2 m/s base trajectory has advanced 0.1 m. A
+        // cadence-length correction must retain most of that movement rather than visibly pausing.
+        assertTrue(distanceMeters(initial.latLong, afterOneTick.latLong) > 0.05f)
+    }
+
+    @Test
     fun predictionEasesToAStableStopAtHorizon() {
         val trajectory = MarkerVisualTrajectory()
         trajectory.seed(movingAnchor(base, fixElapsedMs = 10_000L, speedMps = 2f))

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolPreflightTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/routetools/RouteToolPreflightTest.kt
@@ -1,0 +1,50 @@
+package com.glancemap.glancemapwearos.presentation.features.routetools
+
+import com.glancemap.glancemapwearos.core.service.location.model.GpsSignalSnapshot
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mapsforge.core.model.LatLong
+
+class RouteToolPreflightTest {
+    @Test
+    fun routeToolAcceptsRecentOriginWhenProviderTemporarilyReportsUnavailable() {
+        val usable =
+            hasUsableRouteToolCurrentLocation(
+                currentLocation = LatLong(9.03, 38.74),
+                gpsSignalSnapshot =
+                    GpsSignalSnapshot(
+                        lastFixElapsedRealtimeMs = 90_000L,
+                        isLocationAvailable = false,
+                        lastFixFresh = false,
+                    ),
+                nowElapsedMs = 100_000L,
+            )
+
+        assertTrue(usable)
+    }
+
+    @Test
+    fun routeToolRejectsOriginOlderThanTenSeconds() {
+        val usable =
+            hasUsableRouteToolCurrentLocation(
+                currentLocation = LatLong(9.03, 38.74),
+                gpsSignalSnapshot = GpsSignalSnapshot(lastFixElapsedRealtimeMs = 90_000L),
+                nowElapsedMs = 100_001L,
+            )
+
+        assertFalse(usable)
+    }
+
+    @Test
+    fun routeToolRequiresAnAcceptedLocation() {
+        val usable =
+            hasUsableRouteToolCurrentLocation(
+                currentLocation = null,
+                gpsSignalSnapshot = GpsSignalSnapshot(lastFixElapsedRealtimeMs = 100_000L),
+                nowElapsedMs = 100_000L,
+            )
+
+        assertFalse(usable)
+    }
+}

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/FileTransferViewModel.UriSupport.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/FileTransferViewModel.UriSupport.kt
@@ -62,36 +62,50 @@ internal suspend fun prepareSelectedUrisForTransfer(
             prepared += result.poiUri
             convertedGeoJsonCount += 1
         } else if (isGpxUri(context, uri)) {
-            var gpxTextForName: String? = null
-            val gpxOutcome =
+            val gpxTextForName =
                 runCatching {
                     val gpxSize = queryUriSize(context, uri)
                     if (gpxSize != null && gpxSize > maxGpxWaypointImportBytes) {
                         return@runCatching null
                     }
-                    val gpxText = readGpxTextWithLimit(context, uri, maxGpxWaypointImportBytes)
-                    gpxTextForName = gpxText
-                    gpxWaypointPoiImporter.importWaypointsFromGpxText(
-                        gpxText = gpxText,
-                        fileNameInput = suggestPoiFileNameForGpxWaypoints(context, uri),
-                        categoryNameInput = suggestPoiCategoryNameForGpx(context, uri),
-                    )
+                    readGpxTextWithLimit(context, uri, maxGpxWaypointImportBytes)
                 }.getOrElse {
-                    Log.w("FileTransferVM", "Failed GPX waypoint extraction for $uri", it)
+                    Log.w("FileTransferVM", "Failed to read GPX waypoints for $uri", it)
                     null
+                }
+            val gpxTransferFileName =
+                chooseGpxTransferFileName(
+                    displayName = resolveUriDisplayName(context, uri),
+                    uriCandidates = uriNameCandidates(uri),
+                    gpxText = gpxTextForName,
+                    preferFallbackName = uri.authority.orEmpty().contains("whatsapp", ignoreCase = true),
+                )
+            val gpxOutcome =
+                gpxTextForName?.let { gpxText ->
+                    runCatching {
+                        gpxWaypointPoiImporter.importWaypointsFromGpxText(
+                            gpxText = gpxText,
+                            fileNameInput = suggestPoiFileNameForGpxWaypoints(gpxTransferFileName),
+                            categoryNameInput = suggestPoiCategoryNameForGpx(gpxTransferFileName),
+                            linkedGpxFileName = gpxTransferFileName,
+                        )
+                    }.getOrElse {
+                        Log.w("FileTransferVM", "Failed GPX waypoint extraction for $uri", it)
+                        null
+                    }
                 }
             val gpxTransferUri =
                 prepareGpxUriForTransferName(
                     context = context,
                     uri = uri,
-                    gpxText = gpxTextForName,
+                    preferredName = gpxTransferFileName,
                 )
             val poiResult = gpxOutcome?.poiResult
             if (poiResult == null) {
                 prepared += gpxTransferUri
             } else {
+                prepared += gpxTransferUri
                 if (gpxOutcome.hasTrackOrRoutePoints) {
-                    prepared += gpxTransferUri
                     extractedPoiFromMixedGpxCount += 1
                 }
                 prepared += poiResult.poiUri
@@ -213,11 +227,10 @@ internal fun isLikelyGpxTextPrefix(text: String): Boolean {
 }
 
 internal fun suggestPoiFileNameForGpxWaypoints(
-    context: Context,
-    uri: Uri,
+    gpxFileName: String,
 ): String {
     val base =
-        resolveUriDisplayName(context, uri)
+        gpxFileName
             .trim()
             .replace("\\", "_")
             .replace("/", "_")
@@ -229,10 +242,9 @@ internal fun suggestPoiFileNameForGpxWaypoints(
 }
 
 internal fun suggestPoiCategoryNameForGpx(
-    context: Context,
-    uri: Uri,
+    gpxFileName: String,
 ): String =
-    resolveUriDisplayName(context, uri)
+    gpxFileName
         .trim()
         .replace(Regex("\\.gpx$", RegexOption.IGNORE_CASE), "")
         .replace('_', ' ')
@@ -291,16 +303,9 @@ internal fun chooseGpxTransferFileName(
 private fun prepareGpxUriForTransferName(
     context: Context,
     uri: Uri,
-    gpxText: String?,
+    preferredName: String,
 ): Uri {
     val displayName = resolveUriDisplayName(context, uri)
-    val preferredName =
-        chooseGpxTransferFileName(
-            displayName = displayName,
-            uriCandidates = uriNameCandidates(uri),
-            gpxText = gpxText,
-            preferFallbackName = uri.authority.orEmpty().contains("whatsapp", ignoreCase = true),
-        )
     val currentName = displayName.toSafeFileName().ensureGpxExtension()
     if (preferredName.equals(currentName, ignoreCase = false)) return uri
 

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RoutingDownloadDialog.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RoutingDownloadDialog.kt
@@ -178,7 +178,7 @@ internal fun RoutingDownloadDialog(
         onDismissRequest = {
             if (!isDownloadingRouting) onDismiss()
         },
-        title = { Text("Download routing data") },
+        title = { Text("Plan routes offline") },
         text = {
             Box(
                 modifier =
@@ -195,8 +195,12 @@ internal fun RoutingDownloadDialog(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     Text(
-                        "BRouter routing packs (.rd5) are downloaded on the phone, " +
-                            "then added to section 2 so you can decide if you want to send them.",
+                        "Download data for the areas you use to create GPX routes directly on your watch, even without a connection.",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+
+                    Text(
+                        "The files are downloaded to your phone. In section 2, select the ones you want to send to the watch.",
                         style = MaterialTheme.typography.bodySmall,
                     )
 

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RoutingDownloadDialog.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/RoutingDownloadDialog.kt
@@ -195,12 +195,14 @@ internal fun RoutingDownloadDialog(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     Text(
-                        "Download data for the areas you use to create GPX routes directly on your watch, even without a connection.",
+                        "Download data for the areas you use to create GPX routes directly on your " +
+                            "watch, even without a connection.",
                         style = MaterialTheme.typography.bodySmall,
                     )
 
                     Text(
-                        "The files are downloaded to your phone. In section 2, select the ones you want to send to the watch.",
+                        "The files are downloaded to your phone. In section 2, select the ones you " +
+                            "want to send to the watch.",
                         style = MaterialTheme.typography.bodySmall,
                     )
 

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.Dialogs.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.Dialogs.kt
@@ -386,7 +386,7 @@ internal fun FilePickerQuickGuideDialog(
                                 listOf(
                                     "For POI and routing downloads, first choose the area you need.",
                                     "POI downloads OSM points of interest.",
-                                    "Routing downloads BRouter tiles for offline route calculation.",
+                                    "Plan route downloads data for creating GPX routes offline on the watch.",
                                     "You can choose an area on the map, pick a region.",
                                     "Refresh last import repeats the previous area.",
                                 ),

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.Dialogs.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.Dialogs.kt
@@ -386,7 +386,7 @@ internal fun FilePickerQuickGuideDialog(
                                 listOf(
                                     "For POI and routing downloads, first choose the area you need.",
                                     "POI downloads OSM points of interest.",
-                                    "Plan route downloads data for creating GPX routes offline on the watch.",
+                                    "Routing downloads data for creating GPX routes offline on the watch.",
                                     "You can choose an area on the map, pick a region.",
                                     "Refresh last import repeats the previous area.",
                                 ),

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.Sections.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.Sections.kt
@@ -322,7 +322,7 @@ internal fun FilePickerDownloadSection(
                     modifier = Modifier.weight(1f),
                 ) {
                     DownloadActionButton(
-                        label = "Plan route",
+                        label = "Routing",
                         buttonHeight = downloadButtonHeight,
                         iconSize = 22.dp,
                         onClick = { onShowRoutingMenuChange(true) },
@@ -331,7 +331,7 @@ internal fun FilePickerDownloadSection(
                         icon = {
                             Icon(
                                 Icons.Filled.Route,
-                                contentDescription = "Plan routes offline",
+                                contentDescription = "Download routing data",
                             )
                         },
                     )
@@ -340,7 +340,7 @@ internal fun FilePickerDownloadSection(
                         onDismissRequest = { onShowRoutingMenuChange(false) },
                     ) {
                         DropdownMenuItem(
-                            text = { Text("Download route data") },
+                            text = { Text("Download routing data") },
                             onClick = {
                                 onShowRoutingMenuChange(false)
                                 onShowRoutingDialog()

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.Sections.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/filepicker/FilePickerScreen.Sections.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Map
 import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Route
 import androidx.compose.material.icons.filled.Timeline
 import androidx.compose.material.icons.filled.Update
 import androidx.compose.material3.Button
@@ -129,6 +130,114 @@ internal fun FilePickerDownloadSection(
                     modifier = Modifier.weight(1f),
                 ) {
                     DownloadActionButton(
+                        label = "POI",
+                        buttonHeight = downloadButtonHeight,
+                        iconSize = 22.dp,
+                        onClick = { onShowRefugesMenuChange(true) },
+                        enabled = !uiLocked,
+                        modifier = Modifier.fillMaxWidth(),
+                        icon = {
+                            Icon(Icons.Filled.Place, contentDescription = "Download POI")
+                        },
+                    )
+                    DropdownMenu(
+                        expanded = showRefugesMenu,
+                        onDismissRequest = { onShowRefugesMenuChange(false) },
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("Import POI (Refuges / OSM)") },
+                            onClick = {
+                                onShowRefugesMenuChange(false)
+                                onShowRefugesDialog()
+                            },
+                            enabled = !uiLocked,
+                        )
+                        if (canRefreshLastRefuges) {
+                            DropdownMenuItem(
+                                text = { Text("Refresh last import") },
+                                leadingIcon = {
+                                    Icon(
+                                        Icons.Filled.Update,
+                                        contentDescription = null,
+                                    )
+                                },
+                                onClick = {
+                                    onShowRefugesMenuChange(false)
+                                    onRefreshLastRefuges()
+                                },
+                                enabled = !uiLocked,
+                            )
+                        }
+                    }
+                }
+
+                Box(
+                    modifier = Modifier.weight(1f),
+                ) {
+                    DownloadActionButton(
+                        label = "GPX",
+                        buttonHeight = downloadButtonHeight,
+                        iconSize = 22.dp,
+                        onClick = { showGpxSourcesMenu = true },
+                        enabled = !uiLocked,
+                        modifier = Modifier.fillMaxWidth(),
+                        icon = {
+                            Icon(Icons.Filled.Timeline, contentDescription = "Download GPX")
+                        },
+                    )
+                    DropdownMenu(
+                        expanded = showGpxSourcesMenu,
+                        onDismissRequest = { showGpxSourcesMenu = false },
+                    ) {
+                        Text(
+                            "GlanceMap can read and display .gpx tracks.",
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier =
+                                Modifier
+                                    .widthIn(max = 260.dp)
+                                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                        )
+                        Text(
+                            "Download GPX from your favorite website, or create your own route:",
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier =
+                                Modifier
+                                    .widthIn(max = 260.dp)
+                                    .padding(horizontal = 16.dp)
+                                    .padding(bottom = 8.dp),
+                        )
+                        GpxSourceMenuItem(
+                            label = "gpx.studio",
+                            url = "https://gpx.studio/",
+                            onOpen = { url ->
+                                showGpxSourcesMenu = false
+                                openUrl(url)
+                            },
+                        )
+                        GpxSourceMenuItem(
+                            label = "Trackbook",
+                            url = "https://trackbook.com/",
+                            onOpen = { url ->
+                                showGpxSourcesMenu = false
+                                openUrl(url)
+                            },
+                        )
+                        HorizontalDivider()
+                        Text(
+                            "Send route-planning data to the watch to create GPX routes directly in the watch app.",
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier =
+                                Modifier
+                                    .widthIn(max = 260.dp)
+                                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                        )
+                    }
+                }
+
+                Box(
+                    modifier = Modifier.weight(1f),
+                ) {
+                    DownloadActionButton(
                         label = "Maps",
                         buttonHeight = downloadButtonHeight,
                         iconSize = 22.dp,
@@ -213,115 +322,7 @@ internal fun FilePickerDownloadSection(
                     modifier = Modifier.weight(1f),
                 ) {
                     DownloadActionButton(
-                        label = "GPX",
-                        buttonHeight = downloadButtonHeight,
-                        iconSize = 22.dp,
-                        onClick = { showGpxSourcesMenu = true },
-                        enabled = !uiLocked,
-                        modifier = Modifier.fillMaxWidth(),
-                        icon = {
-                            Icon(Icons.Filled.Timeline, contentDescription = "Download GPX")
-                        },
-                    )
-                    DropdownMenu(
-                        expanded = showGpxSourcesMenu,
-                        onDismissRequest = { showGpxSourcesMenu = false },
-                    ) {
-                        Text(
-                            "GlanceMap can read and display .gpx tracks.",
-                            style = MaterialTheme.typography.bodySmall,
-                            modifier =
-                                Modifier
-                                    .widthIn(max = 260.dp)
-                                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                        )
-                        Text(
-                            "Download GPX from your favorite website, or create your own route:",
-                            style = MaterialTheme.typography.bodySmall,
-                            modifier =
-                                Modifier
-                                    .widthIn(max = 260.dp)
-                                    .padding(horizontal = 16.dp)
-                                    .padding(bottom = 8.dp),
-                        )
-                        GpxSourceMenuItem(
-                            label = "gpx.studio",
-                            url = "https://gpx.studio/",
-                            onOpen = { url ->
-                                showGpxSourcesMenu = false
-                                openUrl(url)
-                            },
-                        )
-                        GpxSourceMenuItem(
-                            label = "Trackbook",
-                            url = "https://trackbook.com/",
-                            onOpen = { url ->
-                                showGpxSourcesMenu = false
-                                openUrl(url)
-                            },
-                        )
-                        HorizontalDivider()
-                        Text(
-                            "Send routing files to the watch to create GPX routes directly in the watch app.",
-                            style = MaterialTheme.typography.bodySmall,
-                            modifier =
-                                Modifier
-                                    .widthIn(max = 260.dp)
-                                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                        )
-                    }
-                }
-
-                Box(
-                    modifier = Modifier.weight(1f),
-                ) {
-                    DownloadActionButton(
-                        label = "POI",
-                        buttonHeight = downloadButtonHeight,
-                        iconSize = 22.dp,
-                        onClick = { onShowRefugesMenuChange(true) },
-                        enabled = !uiLocked,
-                        modifier = Modifier.fillMaxWidth(),
-                        icon = {
-                            Icon(Icons.Filled.Place, contentDescription = "Download POI")
-                        },
-                    )
-                    DropdownMenu(
-                        expanded = showRefugesMenu,
-                        onDismissRequest = { onShowRefugesMenuChange(false) },
-                    ) {
-                        DropdownMenuItem(
-                            text = { Text("Import POI (Refuges / OSM)") },
-                            onClick = {
-                                onShowRefugesMenuChange(false)
-                                onShowRefugesDialog()
-                            },
-                            enabled = !uiLocked,
-                        )
-                        if (canRefreshLastRefuges) {
-                            DropdownMenuItem(
-                                text = { Text("Refresh last import") },
-                                leadingIcon = {
-                                    Icon(
-                                        Icons.Filled.Update,
-                                        contentDescription = null,
-                                    )
-                                },
-                                onClick = {
-                                    onShowRefugesMenuChange(false)
-                                    onRefreshLastRefuges()
-                                },
-                                enabled = !uiLocked,
-                            )
-                        }
-                    }
-                }
-
-                Box(
-                    modifier = Modifier.weight(1f),
-                ) {
-                    DownloadActionButton(
-                        label = "Routing",
+                        label = "Plan route",
                         buttonHeight = downloadButtonHeight,
                         iconSize = 22.dp,
                         onClick = { onShowRoutingMenuChange(true) },
@@ -329,8 +330,8 @@ internal fun FilePickerDownloadSection(
                         modifier = Modifier.fillMaxWidth(),
                         icon = {
                             Icon(
-                                Icons.Filled.Timeline,
-                                contentDescription = "Download routing data",
+                                Icons.Filled.Route,
+                                contentDescription = "Plan routes offline",
                             )
                         },
                     )
@@ -339,7 +340,7 @@ internal fun FilePickerDownloadSection(
                         onDismissRequest = { onShowRoutingMenuChange(false) },
                     ) {
                         DropdownMenuItem(
-                            text = { Text("Download routing data") },
+                            text = { Text("Download route data") },
                             onClick = {
                                 onShowRoutingMenuChange(false)
                                 onShowRoutingDialog()

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/refuges/GpxWaypointPoiImporter.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/refuges/GpxWaypointPoiImporter.kt
@@ -105,47 +105,13 @@ class GpxWaypointPoiImporter(
                 "rotatoria",
                 "uscita",
             )
-        private val STRONG_POI_KEYWORDS =
-            setOf(
-                "peak",
-                "summit",
-                "sommet",
-                "mountain",
-                "water",
-                "spring",
-                "source",
-                "font",
-                "fountain",
-                "drinking",
-                "camp",
-                "bivouac",
-                "bivacco",
-                "hut",
-                "refuge",
-                "cabane",
-                "abri",
-                "gite",
-                "gite",
-                "shelter",
-                "viewpoint",
-                "belved",
-                "panorama",
-                "lookout",
-                "toilet",
-                "wc",
-                "parking",
-                "restaurant",
-                "cafe",
-                "bar",
-                "grotte",
-                "cave",
-            )
     }
 
     suspend fun importWaypointsFromGpxText(
         gpxText: String,
         fileNameInput: String,
         categoryNameInput: String,
+        linkedGpxFileName: String,
     ): GpxWaypointPoiImportOutcome =
         withContext(Dispatchers.IO) {
             val parsed =
@@ -171,7 +137,11 @@ class GpxWaypointPoiImporter(
                         PoiSqliteWriteOptions(
                             comment = "Data source: GPX waypoints",
                             writer = "glancemap-gpx-waypoint-importer-1",
-                            extraMetadata = linkedMapOf("gpx_waypoints_import" to "true"),
+                            extraMetadata =
+                                linkedMapOf(
+                                    "gpx_waypoints_import" to "true",
+                                    "linked_gpx_file_name" to File(linkedGpxFileName).name,
+                                ),
                         ),
                 )
             val uri: Uri =
@@ -279,18 +249,6 @@ class GpxWaypointPoiImporter(
                     name = waypoint.name,
                     description = waypoint.description,
                     type = waypoint.type,
-                )
-            ) {
-                return@forEach
-            }
-            if (
-                hasTrackOrRoutePoints &&
-                !isLikelyRealPoiWaypoint(
-                    name = waypoint.name,
-                    description = waypoint.description,
-                    type = waypoint.type,
-                    website = waypoint.website,
-                    elevation = waypoint.elevation,
                 )
             ) {
                 return@forEach
@@ -412,48 +370,6 @@ class GpxWaypointPoiImporter(
 
         return (hasAction && (hasDirection || hasContext)) ||
             (hasDirection && hasContext && text.length <= 180)
-    }
-
-    private fun isLikelyRealPoiWaypoint(
-        name: String?,
-        description: String?,
-        type: String?,
-        website: String?,
-        elevation: String?,
-    ): Boolean {
-        if (!website.isNullOrBlank()) return true
-
-        val cleanName = name?.trim().takeUnless { it.isNullOrBlank() } ?: ""
-        val cleanDescription = sanitizeDescription(description).orEmpty()
-        val cleanType = type?.trim().orEmpty()
-        val parsedElevation =
-            elevation
-                ?.trim()
-                ?.toDoubleOrNull()
-                ?.toInt()
-                ?.takeIf { it > 0 }
-
-        val (poiKey, poiValue) =
-            inferPoiTag(
-                type = cleanType,
-                name = cleanName,
-                description = cleanDescription,
-            )
-        if (poiKey != "tourism" || poiValue != "information") return true
-
-        val haystack =
-            "$cleanType $cleanName $cleanDescription"
-                .lowercase(Locale.ROOT)
-                .replace('’', '\'')
-        if (STRONG_POI_KEYWORDS.any { keyword -> haystack.contains(keyword) }) return true
-
-        return parsedElevation != null &&
-            (
-                "summit" in haystack ||
-                    "sommet" in haystack ||
-                    "peak" in haystack ||
-                    "col" in haystack
-            )
     }
 
     private fun normalizeInstructionText(

--- a/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/FileTransferViewModelUriSupportTest.kt
+++ b/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/FileTransferViewModelUriSupportTest.kt
@@ -66,6 +66,12 @@ class FileTransferViewModelUriSupportTest {
     }
 
     @Test
+    fun `waypoint folder name follows resolved gpx filename`() {
+        assertEquals("Tour_du_lac__waypoints.poi", suggestPoiFileNameForGpxWaypoints("Tour du lac.gpx"))
+        assertEquals("Tour du lac", suggestPoiCategoryNameForGpx("Tour du lac.gpx"))
+    }
+
+    @Test
     fun `recognizes gpx document prefix with xml declaration`() {
         assertTrue(
             isLikelyGpxTextPrefix(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.3.0"
+agp = "9.3.1"
 kotlin = "2.4.0"
 playServicesWearable = "20.0.1"
 composeBom = "2026.06.01"


### PR DESCRIPTION
## What changed

Fixes the POI **To here** route action so it evaluates the current GPS location and signal state when the user taps it, rather than state captured when the popup was opened.

## Why

A fresh accepted GPS fix could arrive after the popup opened, yet the pending route action continued evaluating stale state and timed out while reporting that it was waiting for GPS.

## User impact

When a usable fix is available, **To here** now starts routing immediately. If a fix is genuinely still needed, the existing wait-and-retry flow continues using the newly received location.

## Validation

- `:app:testDebugUnitTest --tests com.glancemap.glancemapwearos.presentation.features.routetools.RouteToolPreflightTest`
- `:app:compileDebugKotlin`
- `:app:ktlintCheck`