### PR TITLE
fix: improve hillshade and live tracking reliability

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/core/maps/Dem3CoverageUtils.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/core/maps/Dem3CoverageUtils.kt
@@ -124,6 +124,13 @@ object Dem3CoverageUtils {
         return requiredTileIdsForMap(mapFile, mapSignature)
     }
 
+    fun tileIdsForBounds(
+        minLat: Double,
+        minLon: Double,
+        maxLat: Double,
+        maxLon: Double,
+    ): Set<String> = tilesFromBbox(minLat, minLon, maxLat, maxLon)
+
     fun tilesToDeleteForMap(
         deletedMapFile: File,
         remainingMapFiles: List<File>,

--- a/app/src/main/java/com/glancemap/glancemapwearos/core/service/diagnostics/DebugTelemetry.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/core/service/diagnostics/DebugTelemetry.kt
@@ -22,6 +22,9 @@ internal object DebugTelemetry {
 
     private val enabled = AtomicBoolean(false)
     private val lock = Any()
+    private var exportFreezeActive = false
+
+    @Volatile private var transitionMarkersEnabled = true
     private val lines = ArrayDeque<String>()
     private val lineTimesMs = ArrayDeque<Long>()
     private const val MAX_LINES = 30_000
@@ -35,28 +38,59 @@ internal object DebugTelemetry {
             .ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
             .withZone(ZoneId.systemDefault())
 
-    fun setEnabled(value: Boolean) {
-        val previous = enabled.getAndSet(value)
-        if (previous == value) return
-
-        var markerType: String? = null
-        var markerNote: String? = null
-        synchronized(lock) {
-            if (value) {
-                sessionId += 1L
-                sessionStartedAtMs = System.currentTimeMillis()
-                sessionEndedAtMs = null
-                markerType = "diagnostics_capture_start"
-                markerNote = "s$sessionId"
-            } else if (sessionStartedAtMs != null) {
-                sessionEndedAtMs = System.currentTimeMillis()
-                markerType = "diagnostics_capture_stop"
-                markerNote = "s$sessionId"
+    fun setEnabledFromLocationService(value: Boolean) {
+        val marker =
+            synchronized(lock) {
+                if (value && exportFreezeActive) return
+                if (!value) exportFreezeActive = false
+                setEnabledLocked(value)
             }
+        recordTransitionMarker(marker)
+    }
+
+    /**
+     * Stops capture without allowing an in-flight settings emission to reopen a short-lived
+     * session while the diagnostic export is taking its snapshot.
+     */
+    fun freezeForExport() {
+        val marker =
+            synchronized(lock) {
+                exportFreezeActive = true
+                setEnabledLocked(false)
+            }
+        recordTransitionMarker(marker)
+    }
+
+    private fun setEnabledLocked(value: Boolean): CaptureTransition? {
+        val previous = enabled.getAndSet(value)
+        if (previous == value) return null
+
+        return if (value) {
+            sessionId += 1L
+            sessionStartedAtMs = System.currentTimeMillis()
+            sessionEndedAtMs = null
+            CaptureTransition(type = "diagnostics_capture_start", note = "s$sessionId")
+        } else if (sessionStartedAtMs != null) {
+            sessionEndedAtMs = System.currentTimeMillis()
+            CaptureTransition(type = "diagnostics_capture_stop", note = "s$sessionId")
+        } else {
+            null
         }
-        markerType?.let { type ->
-            FieldMarkerDiagnostics.recordMarker(type = type, note = markerNote ?: "na")
-        }
+    }
+
+    private fun recordTransitionMarker(transition: CaptureTransition?) {
+        transition ?: return
+        if (!transitionMarkersEnabled) return
+        FieldMarkerDiagnostics.recordMarker(type = transition.type, note = transition.note)
+    }
+
+    private data class CaptureTransition(
+        val type: String,
+        val note: String,
+    )
+
+    internal fun setTransitionMarkersEnabledForTests(enabled: Boolean) {
+        transitionMarkersEnabled = enabled
     }
 
     fun isEnabled(): Boolean = enabled.get()

--- a/app/src/main/java/com/glancemap/glancemapwearos/core/service/diagnostics/DebugTelemetry.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/core/service/diagnostics/DebugTelemetry.kt
@@ -7,6 +7,7 @@ import java.time.format.DateTimeFormatter
 import java.util.ArrayDeque
 import java.util.concurrent.atomic.AtomicBoolean
 
+@Suppress("TooManyFunctions")
 internal object DebugTelemetry {
     internal data class CaptureSessionSnapshot(
         val sessionId: Long,

--- a/app/src/main/java/com/glancemap/glancemapwearos/core/service/location/telemetry/LocationServiceTelemetry.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/core/service/location/telemetry/LocationServiceTelemetry.kt
@@ -735,7 +735,7 @@ internal class LocationServiceTelemetry(
     }
 
     fun setDebugEnabled(enabled: Boolean) {
-        DebugTelemetry.setEnabled(enabled)
+        DebugTelemetry.setEnabledFromLocationService(enabled)
     }
 
     private fun recordAcceptedFix(nowElapsedMs: Long): Long? {

--- a/app/src/main/java/com/glancemap/glancemapwearos/domain/sensors/FusedHeadingIntegrityEngine.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/domain/sensors/FusedHeadingIntegrityEngine.kt
@@ -423,9 +423,8 @@ internal class FusedHeadingIntegrityEngine(
 
     fun snapshot(): FusedHeadingIntegritySnapshot = buildSnapshot()
 
-    private fun updateWhileAcquiring(evidence: AbsoluteHeadingEvidence): Float {
-        renderHeadingDeg = moveTowardFusedHeading(evidence)
-        return when {
+    private fun updateWhileAcquiring(evidence: AbsoluteHeadingEvidence): Float =
+        when {
             !evidence.fieldAcceptable -> {
                 reason = unavailableMagneticReason()
                 0f
@@ -450,11 +449,14 @@ internal class FusedHeadingIntegrityEngine(
                     reason = CompassTrackingReason.ABSOLUTE_WINDOW_UNSTABLE
                     0f
                 } else {
+                    // Preserve the previous rendered heading until the new provider has
+                    // established a stable reference. A first fused sample can be far from
+                    // the last known heading while its magnetic integrity is still unknown.
+                    renderHeadingDeg = moveTowardFusedHeading(evidence)
                     completeAcquisition()
                 }
             }
         }
-    }
 
     private fun completeAcquisition(): Float {
         trackingResidualAnchorDeg = residualWindow.lastOrNull()?.valueDeg

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/DemSetupBottomSheet.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/DemSetupBottomSheet.kt
@@ -29,7 +29,7 @@ enum class DemSetupReason {
     SLOPE_OVERLAY,
 }
 
-@Suppress("FunctionName", "LongMethod")
+@Suppress("CyclomaticComplexMethod", "FunctionName", "LongMethod")
 @Composable
 fun DemSetupBottomSheet(
     visible: Boolean,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/DemSetupBottomSheet.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/DemSetupBottomSheet.kt
@@ -23,6 +23,7 @@ import com.glancemap.glancemapwearos.presentation.ui.WearInfoDialog
 enum class DemSetupReason {
     GENERIC,
     HILL_SHADING,
+    HILL_SHADING_VISIBLE_AREA,
     LIVE_ELEVATION,
     SLOPE_OVERLAY,
 }
@@ -39,6 +40,7 @@ fun DemSetupBottomSheet(
         when (reason) {
             DemSetupReason.GENERIC -> "DEM Setup"
             DemSetupReason.HILL_SHADING -> "Elevation data needed"
+            DemSetupReason.HILL_SHADING_VISIBLE_AREA -> "No terrain data"
             DemSetupReason.LIVE_ELEVATION -> "Elevation data needed"
             DemSetupReason.SLOPE_OVERLAY -> "Elevation data needed"
         }
@@ -52,6 +54,9 @@ fun DemSetupBottomSheet(
                 "Hill shading needs DEM data for this map.\n" +
                     "Open Maps and tap the DEM icon to download it.\n" +
                     "When it is ready, come back and enable Hill shading again."
+            DemSetupReason.HILL_SHADING_VISIBLE_AREA ->
+                "No Detailed or Standard terrain data is available for this area.\n" +
+                    "Open Maps and download terrain data to display hill shading here."
             DemSetupReason.LIVE_ELEVATION ->
                 "Live elevation needs DEM data for this map.\n" +
                     "Open Maps and tap the DEM icon to download it.\n" +

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/DemSetupBottomSheet.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/DemSetupBottomSheet.kt
@@ -23,6 +23,7 @@ import com.glancemap.glancemapwearos.presentation.ui.WearInfoDialog
 enum class DemSetupReason {
     GENERIC,
     HILL_SHADING,
+    HILL_SHADING_MAP_REQUIRED,
     HILL_SHADING_VISIBLE_AREA,
     LIVE_ELEVATION,
     SLOPE_OVERLAY,
@@ -40,6 +41,7 @@ fun DemSetupBottomSheet(
         when (reason) {
             DemSetupReason.GENERIC -> "DEM Setup"
             DemSetupReason.HILL_SHADING -> "Elevation data needed"
+            DemSetupReason.HILL_SHADING_MAP_REQUIRED -> "Select a map"
             DemSetupReason.HILL_SHADING_VISIBLE_AREA -> "No terrain data"
             DemSetupReason.LIVE_ELEVATION -> "Elevation data needed"
             DemSetupReason.SLOPE_OVERLAY -> "Elevation data needed"
@@ -54,6 +56,8 @@ fun DemSetupBottomSheet(
                 "Hill shading needs DEM data for this map.\n" +
                     "Open Maps and tap the DEM icon to download it.\n" +
                     "When it is ready, come back and enable Hill shading again."
+            DemSetupReason.HILL_SHADING_MAP_REQUIRED ->
+                "Select an offline map first."
             DemSetupReason.HILL_SHADING_VISIBLE_AREA ->
                 "No Detailed or Standard terrain data is available for this area.\n" +
                     "Open Maps and download terrain data to display hill shading here."

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/FirstVisibleHillshadeTileRendererLayer.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/FirstVisibleHillshadeTileRendererLayer.kt
@@ -5,6 +5,7 @@ import org.mapsforge.core.graphics.GraphicFactory
 import org.mapsforge.core.model.BoundingBox
 import org.mapsforge.core.model.Point
 import org.mapsforge.core.model.Rotation
+import org.mapsforge.core.model.Tile
 import org.mapsforge.map.datastore.MapDataStore
 import org.mapsforge.map.layer.cache.TileCache
 import org.mapsforge.map.layer.hills.HillsRenderConfig
@@ -13,6 +14,23 @@ import org.mapsforge.map.model.MapViewPosition
 import org.mapsforge.map.util.LayerUtil
 import java.util.concurrent.atomic.AtomicBoolean
 
+internal data class HillshadeLayerCallbacks(
+    val onWorkStarted: (
+        FirstVisibleHillshadeTileRendererLayer,
+        zoomLevel: Byte,
+        visibleTileCount: Int,
+        terrainCoverage: VisibleHillshadeTerrainCoverage,
+    ) -> Unit,
+    val onWorkPaused: (FirstVisibleHillshadeTileRendererLayer, reason: String) -> Unit,
+    val resolveVisibleTerrainCoverage: (BoundingBox) -> VisibleHillshadeTerrainCoverage,
+    val onTerrainUnavailable: (
+        FirstVisibleHillshadeTileRendererLayer,
+        zoomLevel: Byte,
+        terrainCoverage: VisibleHillshadeTerrainCoverage,
+    ) -> Unit,
+    val onFirstVisibleTile: (FirstVisibleHillshadeTileRendererLayer) -> Unit,
+)
+
 /** Reports when the external hillshade layer has produced its first visible transparent tile. */
 internal class FirstVisibleHillshadeTileRendererLayer(
     tileCache: TileCache,
@@ -20,7 +38,7 @@ internal class FirstVisibleHillshadeTileRendererLayer(
     mapViewPosition: MapViewPosition,
     graphicFactory: GraphicFactory,
     hillsRenderConfig: HillsRenderConfig,
-    private val onFirstVisibleHillshadeTile: (FirstVisibleHillshadeTileRendererLayer) -> Unit,
+    private val callbacks: HillshadeLayerCallbacks,
 ) : TileRendererLayer(
         tileCache,
         mapDataStore,
@@ -40,26 +58,65 @@ internal class FirstVisibleHillshadeTileRendererLayer(
         topLeftPoint: Point,
         rotation: Rotation,
     ) {
+        if (!shouldRenderHillshadeAtZoom(zoomLevel)) {
+            if (
+                !firstVisibleTileReported.get() &&
+                visibleWorkStarted.compareAndSet(true, false)
+            ) {
+                callbacks.onWorkPaused(this, "below_min_zoom")
+            }
+            return
+        }
+
+        val terrainCoverage = callbacks.resolveVisibleTerrainCoverage(boundingBox)
+        if (!terrainCoverage.hasAnyTerrain) {
+            if (
+                !firstVisibleTileReported.get() &&
+                visibleWorkStarted.compareAndSet(true, false)
+            ) {
+                callbacks.onWorkPaused(this, "missing_visible_dem")
+            }
+            if (lastUnavailableTerrainKey != terrainCoverage.diagnosticKey) {
+                lastUnavailableTerrainKey = terrainCoverage.diagnosticKey
+                callbacks.onTerrainUnavailable(this, zoomLevel, terrainCoverage)
+            }
+            return
+        }
+        lastUnavailableTerrainKey = null
+
+        val visibleTiles = visibleTiles(boundingBox, zoomLevel)
+        if (
+            !firstVisibleTileReported.get() &&
+            visibleWorkStarted.compareAndSet(false, true)
+        ) {
+            callbacks.onWorkStarted(this, zoomLevel, visibleTiles.size, terrainCoverage)
+        }
+
         super.draw(boundingBox, zoomLevel, canvas, topLeftPoint, rotation)
 
         if (
             !firstVisibleTileReported.get() &&
-            hasCachedVisibleHillshadeTile(boundingBox, zoomLevel) &&
+            hasCachedVisibleHillshadeTile(visibleTiles) &&
             firstVisibleTileReported.compareAndSet(false, true)
         ) {
-            onFirstVisibleHillshadeTile(this)
+            callbacks.onFirstVisibleTile(this)
         }
     }
 
-    private fun hasCachedVisibleHillshadeTile(
+    private val visibleWorkStarted = AtomicBoolean(false)
+    private var lastUnavailableTerrainKey: String? = null
+
+    private fun visibleTiles(
         boundingBox: BoundingBox,
         zoomLevel: Byte,
-    ): Boolean =
+    ): Set<Tile> =
         runCatching {
-            if (renderThemeFuture == null) return@runCatching false
-            val tileSize = displayModel?.tileSize ?: return@runCatching false
-            LayerUtil
-                .getTiles(boundingBox, zoomLevel, tileSize)
-                .any { tile -> tileCache.containsKey(createJob(tile)) }
-        }.getOrDefault(false)
+            val tileSize = displayModel?.tileSize ?: return@runCatching emptySet()
+            LayerUtil.getTiles(boundingBox, zoomLevel, tileSize)
+        }.getOrDefault(emptySet())
+
+    private fun hasCachedVisibleHillshadeTile(visibleTiles: Set<Tile>): Boolean {
+        if (renderThemeFuture == null) return false
+        return visibleTiles.any { tile -> tileCache.containsKey(createJob(tile)) }
+    }
 }

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/FirstVisibleHillshadeTileRendererLayer.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/FirstVisibleHillshadeTileRendererLayer.kt
@@ -1,0 +1,65 @@
+package com.glancemap.glancemapwearos.presentation.features.maps
+
+import org.mapsforge.core.graphics.Canvas
+import org.mapsforge.core.graphics.GraphicFactory
+import org.mapsforge.core.model.BoundingBox
+import org.mapsforge.core.model.Point
+import org.mapsforge.core.model.Rotation
+import org.mapsforge.map.datastore.MapDataStore
+import org.mapsforge.map.layer.cache.TileCache
+import org.mapsforge.map.layer.hills.HillsRenderConfig
+import org.mapsforge.map.layer.renderer.TileRendererLayer
+import org.mapsforge.map.model.MapViewPosition
+import org.mapsforge.map.util.LayerUtil
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Reports when the external hillshade layer has produced its first visible transparent tile. */
+internal class FirstVisibleHillshadeTileRendererLayer(
+    tileCache: TileCache,
+    mapDataStore: MapDataStore,
+    mapViewPosition: MapViewPosition,
+    graphicFactory: GraphicFactory,
+    hillsRenderConfig: HillsRenderConfig,
+    private val onFirstVisibleHillshadeTile: (FirstVisibleHillshadeTileRendererLayer) -> Unit,
+) : TileRendererLayer(
+        tileCache,
+        mapDataStore,
+        mapViewPosition,
+        true,
+        false,
+        false,
+        graphicFactory,
+        hillsRenderConfig,
+    ) {
+    private val firstVisibleTileReported = AtomicBoolean(false)
+
+    override fun draw(
+        boundingBox: BoundingBox,
+        zoomLevel: Byte,
+        canvas: Canvas,
+        topLeftPoint: Point,
+        rotation: Rotation,
+    ) {
+        super.draw(boundingBox, zoomLevel, canvas, topLeftPoint, rotation)
+
+        if (
+            !firstVisibleTileReported.get() &&
+            hasCachedVisibleHillshadeTile(boundingBox, zoomLevel) &&
+            firstVisibleTileReported.compareAndSet(false, true)
+        ) {
+            onFirstVisibleHillshadeTile(this)
+        }
+    }
+
+    private fun hasCachedVisibleHillshadeTile(
+        boundingBox: BoundingBox,
+        zoomLevel: Byte,
+    ): Boolean =
+        runCatching {
+            if (renderThemeFuture == null) return@runCatching false
+            val tileSize = displayModel?.tileSize ?: return@runCatching false
+            LayerUtil
+                .getTiles(boundingBox, zoomLevel, tileSize)
+                .any { tile -> tileCache.containsKey(createJob(tile)) }
+        }.getOrDefault(false)
+}

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.CacheSupport.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.CacheSupport.kt
@@ -111,26 +111,12 @@ internal fun computeMapRendererMapSignature(mapPath: String?): String? {
 internal fun resolveMapRendererDesiredCacheId(
     mapSignature: String?,
     themeSignature: String,
-    demSignature: String?,
-    hillShadingEnabled: Boolean,
     elevationLabelsMetric: Boolean,
 ): String {
     val mapPart = mapSignature ?: "MAP:NONE"
     val themePart = themeSignature.ifBlank { "THEME:UNSET" }
-    val demPart =
-        if (hillShadingEnabled) {
-            demSignature ?: "DEM:NONE"
-        } else {
-            "DEM:OFF"
-        }
     val unitPart = if (elevationLabelsMetric) "UNITS:METRIC" else "UNITS:IMPERIAL"
-    val hillshadeCachePart =
-        if (hillShadingEnabled) {
-            "|HILLSHADE_CACHE:$HILLSHADE_TILE_CACHE_SCHEMA_VERSION"
-        } else {
-            ""
-        }
-    val signature = "$mapPart|$themePart|$demPart|$unitPart$hillshadeCachePart"
+    val signature = "$mapPart|$themePart|$unitPart"
 
     val digest = MessageDigest.getInstance("SHA-256").digest(signature.toByteArray(Charsets.UTF_8))
     val shortHex =

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.HillshadeSupport.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.HillshadeSupport.kt
@@ -2,10 +2,12 @@ package com.glancemap.glancemapwearos.presentation.features.maps
 
 import org.mapsforge.map.layer.hills.AClasyHillShading
 import org.mapsforge.map.layer.hills.AdaptiveClasyHillShading
+import org.mapsforge.map.layer.hills.HgtFileInfo
 import java.security.MessageDigest
 
 internal const val WEAR_HILLSHADE_QUALITY_SCALE = 0.5
-internal const val WEAR_HILLSHADE_MIN_ZOOM_LEVEL = 8
+internal const val WEAR_HILLSHADE_MIN_ZOOM_LEVEL = 10
+internal const val WEAR_HILLSHADE_MAX_OUTPUT_AXIS = 1800
 internal const val WEAR_HILLSHADE_READING_THREADS = 1
 internal const val WEAR_HILLSHADE_COMPUTING_THREADS = 1
 
@@ -17,12 +19,53 @@ internal fun createWearHillShadingParams(): AClasyHillShading.ClasyParams =
         .setPreprocess(false)
 
 internal fun createWearHillShadingAlgorithm(): AdaptiveClasyHillShading =
-    AdaptiveClasyHillShading(createWearHillShadingParams(), false)
+    WearAdaptiveClasyHillShading(createWearHillShadingParams())
         .setAdaptiveZoomEnabled(true)
         .setCustomQualityScale(WEAR_HILLSHADE_QUALITY_SCALE)
         .setZoomMinOverride(WEAR_HILLSHADE_MIN_ZOOM_LEVEL)
 
 internal fun shouldRenderHillshadeAtZoom(zoomLevel: Byte): Boolean = zoomLevel.toInt() >= WEAR_HILLSHADE_MIN_ZOOM_LEVEL
+
+internal fun resolveWearHillshadeQualityFactor(
+    inputAxisLen: Int,
+    adaptiveQualityFactor: Int,
+): Int {
+    val adaptiveOutputAxis =
+        AdaptiveClasyHillShading.scaleByQualityFactor(
+            inputAxisLen,
+            adaptiveQualityFactor,
+        )
+    if (adaptiveOutputAxis <= WEAR_HILLSHADE_MAX_OUTPUT_AXIS) return adaptiveQualityFactor
+
+    var stride =
+        ((inputAxisLen + WEAR_HILLSHADE_MAX_OUTPUT_AXIS - 1) / WEAR_HILLSHADE_MAX_OUTPUT_AXIS)
+            .coerceAtLeast(1)
+    while (stride < inputAxisLen && inputAxisLen % stride != 0) {
+        stride += 1
+    }
+    return -stride
+}
+
+private class WearAdaptiveClasyHillShading(
+    params: AClasyHillShading.ClasyParams,
+) : AdaptiveClasyHillShading(params, false) {
+    override fun getQualityFactor(
+        hgtFileInfo: HgtFileInfo,
+        zoomLevel: Int,
+        pxPerLat: Double,
+        pxPerLon: Double,
+    ): Int =
+        resolveWearHillshadeQualityFactor(
+            inputAxisLen = getInputAxisLen(hgtFileInfo),
+            adaptiveQualityFactor =
+                super.getQualityFactor(
+                    hgtFileInfo,
+                    zoomLevel,
+                    pxPerLat,
+                    pxPerLon,
+                ),
+        )
+}
 
 internal fun resolveMapRendererHillshadeCacheId(
     baseCacheId: String,
@@ -38,6 +81,7 @@ internal fun resolveMapRendererHillshadeCacheId(
             append("|ALGORITHM:adaptive_no_hq")
             append("|QUALITY:").append(WEAR_HILLSHADE_QUALITY_SCALE)
             append("|ZOOM_MIN:").append(WEAR_HILLSHADE_MIN_ZOOM_LEVEL)
+            append("|MAX_OUTPUT_AXIS:").append(WEAR_HILLSHADE_MAX_OUTPUT_AXIS)
             append("|READERS:").append(WEAR_HILLSHADE_READING_THREADS)
             append("|COMPUTERS:").append(WEAR_HILLSHADE_COMPUTING_THREADS)
             append("|PREPROCESS:false")

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.HillshadeSupport.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.HillshadeSupport.kt
@@ -1,14 +1,28 @@
 package com.glancemap.glancemapwearos.presentation.features.maps
 
+import org.mapsforge.map.layer.hills.AClasyHillShading
 import org.mapsforge.map.layer.hills.AdaptiveClasyHillShading
 import java.security.MessageDigest
 
 internal const val WEAR_HILLSHADE_QUALITY_SCALE = 0.5
+internal const val WEAR_HILLSHADE_MIN_ZOOM_LEVEL = 8
+internal const val WEAR_HILLSHADE_READING_THREADS = 1
+internal const val WEAR_HILLSHADE_COMPUTING_THREADS = 1
+
+internal fun createWearHillShadingParams(): AClasyHillShading.ClasyParams =
+    AClasyHillShading
+        .ClasyParams()
+        .setReadingThreadsCount(WEAR_HILLSHADE_READING_THREADS)
+        .setComputingThreadsCount(WEAR_HILLSHADE_COMPUTING_THREADS)
+        .setPreprocess(false)
 
 internal fun createWearHillShadingAlgorithm(): AdaptiveClasyHillShading =
-    AdaptiveClasyHillShading(false)
+    AdaptiveClasyHillShading(createWearHillShadingParams(), false)
         .setAdaptiveZoomEnabled(true)
         .setCustomQualityScale(WEAR_HILLSHADE_QUALITY_SCALE)
+        .setZoomMinOverride(WEAR_HILLSHADE_MIN_ZOOM_LEVEL)
+
+internal fun shouldRenderHillshadeAtZoom(zoomLevel: Byte): Boolean = zoomLevel.toInt() >= WEAR_HILLSHADE_MIN_ZOOM_LEVEL
 
 internal fun resolveMapRendererHillshadeCacheId(
     baseCacheId: String,
@@ -23,6 +37,10 @@ internal fun resolveMapRendererHillshadeCacheId(
             append("|HILLSHADE_CACHE:").append(HILLSHADE_TILE_CACHE_SCHEMA_VERSION)
             append("|ALGORITHM:adaptive_no_hq")
             append("|QUALITY:").append(WEAR_HILLSHADE_QUALITY_SCALE)
+            append("|ZOOM_MIN:").append(WEAR_HILLSHADE_MIN_ZOOM_LEVEL)
+            append("|READERS:").append(WEAR_HILLSHADE_READING_THREADS)
+            append("|COMPUTERS:").append(WEAR_HILLSHADE_COMPUTING_THREADS)
+            append("|PREPROCESS:false")
         }
     val digest = MessageDigest.getInstance("SHA-256").digest(signature.toByteArray(Charsets.UTF_8))
     val shortHex =

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.HillshadeSupport.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.HillshadeSupport.kt
@@ -7,6 +7,7 @@ import java.security.MessageDigest
 
 internal const val WEAR_HILLSHADE_QUALITY_SCALE = 0.5
 internal const val WEAR_HILLSHADE_MIN_ZOOM_LEVEL = 10
+internal const val WEAR_HILLSHADE_MAX_INPUT_AXIS = 1800
 internal const val WEAR_HILLSHADE_MAX_OUTPUT_AXIS = 1800
 internal const val WEAR_HILLSHADE_READING_THREADS = 1
 internal const val WEAR_HILLSHADE_COMPUTING_THREADS = 1
@@ -81,6 +82,7 @@ internal fun resolveMapRendererHillshadeCacheId(
             append("|ALGORITHM:adaptive_no_hq")
             append("|QUALITY:").append(WEAR_HILLSHADE_QUALITY_SCALE)
             append("|ZOOM_MIN:").append(WEAR_HILLSHADE_MIN_ZOOM_LEVEL)
+            append("|MAX_INPUT_AXIS:").append(WEAR_HILLSHADE_MAX_INPUT_AXIS)
             append("|MAX_OUTPUT_AXIS:").append(WEAR_HILLSHADE_MAX_OUTPUT_AXIS)
             append("|READERS:").append(WEAR_HILLSHADE_READING_THREADS)
             append("|COMPUTERS:").append(WEAR_HILLSHADE_COMPUTING_THREADS)

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.HillshadeSupport.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.HillshadeSupport.kt
@@ -1,0 +1,33 @@
+package com.glancemap.glancemapwearos.presentation.features.maps
+
+import org.mapsforge.map.layer.hills.AdaptiveClasyHillShading
+import java.security.MessageDigest
+
+internal const val WEAR_HILLSHADE_QUALITY_SCALE = 0.5
+
+internal fun createWearHillShadingAlgorithm(): AdaptiveClasyHillShading =
+    AdaptiveClasyHillShading(false)
+        .setAdaptiveZoomEnabled(true)
+        .setCustomQualityScale(WEAR_HILLSHADE_QUALITY_SCALE)
+
+internal fun resolveMapRendererHillshadeCacheId(
+    baseCacheId: String,
+    demSourceId: String,
+    demSignature: String,
+): String {
+    val signature =
+        buildString {
+            append("BASE:").append(baseCacheId)
+            append("|DEM_SOURCE:").append(demSourceId)
+            append("|DEM:").append(demSignature)
+            append("|HILLSHADE_CACHE:").append(HILLSHADE_TILE_CACHE_SCHEMA_VERSION)
+            append("|ALGORITHM:adaptive_no_hq")
+            append("|QUALITY:").append(WEAR_HILLSHADE_QUALITY_SCALE)
+        }
+    val digest = MessageDigest.getInstance("SHA-256").digest(signature.toByteArray(Charsets.UTF_8))
+    val shortHex =
+        digest.take(CACHE_HASH_BYTES).joinToString(separator = "") { byte ->
+            "%02x".format(byte)
+        }
+    return "${CACHE_ID_PREFIX}_hillshade_$shortHex"
+}

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.kt
@@ -12,6 +12,8 @@ import com.glancemap.glancemapwearos.core.service.diagnostics.BenchmarkTrace
 import com.glancemap.glancemapwearos.core.service.diagnostics.MapHotPathDiagnostics
 import com.glancemap.glancemapwearos.domain.model.maps.theme.mapsforge.MapsforgeThemeCatalog
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
@@ -71,7 +73,12 @@ class MapRenderer(
     private data class PendingFirstVisibleHillshadeTiming(
         val requestId: Long,
         val mapName: String,
-        val demSource: String,
+        val demSources: String,
+        val zoomLevel: Int,
+        val visibleTileCount: Int,
+        val detailedDemTileCount: Int,
+        val standardFallbackDemTileCount: Int,
+        val missingDemTileCount: Int,
         val startedAtElapsedMs: Long,
         val traceMarker: BenchmarkTrace.AsyncMarker,
     )
@@ -89,6 +96,13 @@ class MapRenderer(
         val enabled: Boolean,
         val processing: Boolean,
         val progressPercent: Int?,
+    )
+
+    data class HillshadeTerrainUnavailableEvent(
+        val mapName: String,
+        val zoomLevel: Int,
+        val missingTileCount: Int,
+        val areaKey: String,
     )
 
     data class CacheDiagnosticsSnapshot(
@@ -167,12 +181,15 @@ class MapRenderer(
         get() = Dem3CoverageUtils.demRootDir(context, currentDemSource)
     private val demRootDirs: List<File>
         get() = currentDemSource.readFallbackOrder().map { source -> Dem3CoverageUtils.demRootDir(context, source) }
+    private val hillshadeDemRootDirs: List<File>
+        get() = DemSource.LOAD_PRIORITY.map { source -> Dem3CoverageUtils.demRootDir(context, source) }
     private val reliefOverlayCacheRootDir: File by lazy {
         val root = context.externalCacheDir ?: context.cacheDir
         File(root, RELIEF_OVERLAY_CACHE_DIR_NAME)
     }
     private var hillsRenderConfig: HillsRenderConfig? = null
     private var hillsRenderConfigDemSignature: String? = null
+    private var activeHillshadeDemRootDirs: List<File> = emptyList()
     private var rebuildTileCacheRequested: Boolean = false
     private var currentTileCacheId: String = "$CACHE_ID_PREFIX-bootstrap"
     private var skipNextStartupTilePrewarm: Boolean = false
@@ -183,6 +200,10 @@ class MapRenderer(
     private val tileCacheUpdateVersion = MutableStateFlow(0L)
     private val firstVisibleMapCounter = AtomicLong(0L)
     private val firstVisibleMapEvent = MutableStateFlow<FirstVisibleMapEvent?>(null)
+    private val _hillshadeTerrainUnavailableEvent =
+        MutableStateFlow<HillshadeTerrainUnavailableEvent?>(null)
+    val hillshadeTerrainUnavailableEvent: StateFlow<HillshadeTerrainUnavailableEvent?> =
+        _hillshadeTerrainUnavailableEvent.asStateFlow()
     private var nextFirstVisibleMapRequestId: Long = 0L
     private var pendingFirstVisibleMapTiming: PendingFirstVisibleMapTiming? = null
     private var nextFirstVisibleHillshadeRequestId: Long = 0L
@@ -1013,18 +1034,20 @@ class MapRenderer(
                 timingStatus = "missing_dem"
                 Log.d(
                     TAG,
-                    "Hill shading enabled but no DEM files found in ${demRootDirs.joinToString { it.absolutePath }}.",
+                    "Hill shading enabled but no DEM files found in " +
+                        hillshadeDemRootDirs.joinToString { it.absolutePath },
                 )
                 destroyHillsRenderConfig()
                 return null
             }
-            val effectiveDemRootDirs = resolveHillshadeDemRootDirs(demRootDirs, requiredDemTileIds)
+            val effectiveDemRootDirs =
+                resolveHillshadeDemRootDirs(hillshadeDemRootDirs, requiredDemTileIds)
             if (effectiveDemRootDirs.isEmpty()) {
                 timingStatus = "missing_renderable_dem"
                 Log.d(
                     TAG,
                     "Hill shading enabled but no renderable DEM files found in " +
-                        demRootDirs.joinToString { it.absolutePath },
+                        hillshadeDemRootDirs.joinToString { it.absolutePath },
                 )
                 destroyHillsRenderConfig()
                 return null
@@ -1047,6 +1070,7 @@ class MapRenderer(
             hillsRenderConfig?.let { existing ->
                 if (hillsRenderConfigDemSignature == effectiveDemSignature) {
                     timingStatus = "reuse_cached_config"
+                    activeHillshadeDemRootDirs = effectiveDemRootDirs
                     return existing
                 }
             }
@@ -1074,7 +1098,8 @@ class MapRenderer(
                     timingStatus = "error_${e.javaClass.simpleName}"
                     Log.w(
                         TAG,
-                        "Failed to initialize DEM hillshading from ${demRootDirs.joinToString { it.absolutePath }}",
+                        "Failed to initialize DEM hillshading from " +
+                            hillshadeDemRootDirs.joinToString { it.absolutePath },
                         e,
                     )
                     return null
@@ -1083,6 +1108,7 @@ class MapRenderer(
             timingStatus = "built_new_config"
             hillsRenderConfig = config
             hillsRenderConfigDemSignature = effectiveDemSignature
+            activeHillshadeDemRootDirs = effectiveDemRootDirs
             config
         } finally {
             MapHotPathDiagnostics.end(
@@ -1127,20 +1153,39 @@ class MapRenderer(
             }
         }
 
-    @Suppress("ReturnCount")
+    @Suppress("LongMethod", "ReturnCount")
     private fun updateHillshadeLayer(
         mapFile: File,
         demSignature: String?,
         requiredDemTileIds: Set<String>?,
     ) {
         clearHillshadeLayer(reason = "replace")
-        if (!currentHillShadingEnabled || demSignature == null) return
+        if (!currentHillShadingEnabled) return
+        if (demSignature == null) {
+            publishHillshadeTerrainUnavailable(
+                mapFile = mapFile,
+                zoomLevel = mapView.model.mapViewPosition.zoomLevel,
+                missingTileCount = requiredDemTileIds?.size ?: 0,
+                areaKey = "map:${mapFile.name}",
+            )
+            return
+        }
 
-        val hillsConfig = buildHillsRenderConfigOrNull(demSignature, requiredDemTileIds) ?: return
+        val hillsConfig =
+            buildHillsRenderConfigOrNull(demSignature, requiredDemTileIds)
+                ?: run {
+                    publishHillshadeTerrainUnavailable(
+                        mapFile = mapFile,
+                        zoomLevel = mapView.model.mapViewPosition.zoomLevel,
+                        missingTileCount = requiredDemTileIds?.size ?: 0,
+                        areaKey = "map:${mapFile.name}",
+                    )
+                    return
+                }
         val cacheId =
             resolveMapRendererHillshadeCacheId(
                 baseCacheId = currentTileCacheId,
-                demSourceId = currentDemSource.id,
+                demSourceId = DemSource.LOAD_PRIORITY.joinToString(">") { source -> source.id },
                 demSignature = demSignature,
             )
         val cache = createHillshadeTileCache(cacheId)
@@ -1151,6 +1196,7 @@ class MapRenderer(
                     Log.w(TAG, "updateHillshadeLayer: Failed opening map store", error)
                     return
                 }
+        var cachedVisibleTerrainCoverage: VisibleHillshadeTerrainCoverage? = null
         val layer =
             runCatching {
                 FirstVisibleHillshadeTileRendererLayer(
@@ -1159,7 +1205,57 @@ class MapRenderer(
                     mapViewPosition = mapView.model.mapViewPosition,
                     graphicFactory = AndroidGraphicFactory.INSTANCE,
                     hillsRenderConfig = hillsConfig,
-                    onFirstVisibleHillshadeTile = ::handleFirstVisibleHillshadeTile,
+                    callbacks =
+                        HillshadeLayerCallbacks(
+                            onWorkStarted = {
+                                candidate,
+                                zoomLevel,
+                                visibleTileCount,
+                                terrainCoverage,
+                                ->
+                                _hillshadeTerrainUnavailableEvent.value = null
+                                startFirstVisibleHillshadeTiming(
+                                    layer = candidate,
+                                    mapFile = mapFile,
+                                    zoomLevel = zoomLevel,
+                                    visibleTileCount = visibleTileCount,
+                                    terrainCoverage = terrainCoverage,
+                                )
+                            },
+                            onWorkPaused = { candidate, reason ->
+                                if (hillshadeLayer === candidate) {
+                                    cancelFirstVisibleHillshadeTiming(reason = reason)
+                                }
+                            },
+                            resolveVisibleTerrainCoverage = { boundingBox ->
+                                val tileIds =
+                                    Dem3CoverageUtils.tileIdsForBounds(
+                                        minLat = boundingBox.minLatitude,
+                                        minLon = boundingBox.minLongitude,
+                                        maxLat = boundingBox.maxLatitude,
+                                        maxLon = boundingBox.maxLongitude,
+                                    )
+                                cachedVisibleTerrainCoverage
+                                    ?.takeIf { coverage -> coverage.requiredTileIds == tileIds }
+                                    ?: resolveVisibleHillshadeTerrainCoverage(
+                                        demRootDirs = activeHillshadeDemRootDirs,
+                                        requiredTileIds = tileIds,
+                                    ).also { coverage ->
+                                        cachedVisibleTerrainCoverage = coverage
+                                    }
+                            },
+                            onTerrainUnavailable = { candidate, zoomLevel, terrainCoverage ->
+                                if (hillshadeLayer === candidate) {
+                                    publishHillshadeTerrainUnavailable(
+                                        mapFile = mapFile,
+                                        zoomLevel = zoomLevel,
+                                        missingTileCount = terrainCoverage.missingTileCount,
+                                        areaKey = terrainCoverage.diagnosticKey,
+                                    )
+                                }
+                            },
+                            onFirstVisibleTile = ::handleFirstVisibleHillshadeTile,
+                        ),
                 ).apply {
                     setXmlRenderTheme(MapsforgeThemes.HILLSHADING)
                     setCacheZoomPlus(0)
@@ -1181,7 +1277,6 @@ class MapRenderer(
             val index = if (currentLayer != null && layers.size() > 0) 1 else 0
             layers.add(index, layer)
         }
-        startFirstVisibleHillshadeTiming(layer = layer, mapFile = mapFile)
     }
 
     private fun createHillshadeTileCache(cacheId: String): TileCache =
@@ -1195,6 +1290,7 @@ class MapRenderer(
 
     private fun clearHillshadeLayer(reason: String) {
         cancelFirstVisibleHillshadeTiming(reason)
+        _hillshadeTerrainUnavailableEvent.value = null
         hillshadeLayer?.let { layer ->
             disableLayerTileExpansion(layer, reason)
             mapView.mutateLayers { layers ->
@@ -1291,7 +1387,11 @@ class MapRenderer(
     private fun startFirstVisibleHillshadeTiming(
         layer: FirstVisibleHillshadeTileRendererLayer,
         mapFile: File,
+        zoomLevel: Byte,
+        visibleTileCount: Int,
+        terrainCoverage: VisibleHillshadeTerrainCoverage,
     ) {
+        if (hillshadeLayer !== layer || pendingFirstVisibleHillshadeTiming != null) return
         cancelFirstVisibleHillshadeTiming(reason = "superseded")
         val requestId = ++nextFirstVisibleHillshadeRequestId
         val startedAtElapsedMs = SystemClock.elapsedRealtime()
@@ -1299,7 +1399,12 @@ class MapRenderer(
             PendingFirstVisibleHillshadeTiming(
                 requestId = requestId,
                 mapName = mapFile.name,
-                demSource = currentDemSource.id,
+                demSources = DemSource.LOAD_PRIORITY.joinToString(">") { source -> source.id },
+                zoomLevel = zoomLevel.toInt(),
+                visibleTileCount = visibleTileCount,
+                detailedDemTileCount = terrainCoverage.detailedTileCount,
+                standardFallbackDemTileCount = terrainCoverage.standardFallbackTileCount,
+                missingDemTileCount = terrainCoverage.missingTileCount,
                 startedAtElapsedMs = startedAtElapsedMs,
                 traceMarker = BenchmarkTrace.beginAsync(FIRST_VISIBLE_HILLSHADE_TRACE_STAGE),
             )
@@ -1314,7 +1419,7 @@ class MapRenderer(
                     startedAtElapsedMs = timing.startedAtElapsedMs,
                     completedAtElapsedMs = SystemClock.elapsedRealtime(),
                     status = "timeout",
-                    detail = "map=${timing.mapName} demSource=${timing.demSource}",
+                    detail = timing.hillshadeDiagnosticDetail(),
                 )
                 clearHillshadeLayer(reason = "first_tile_timeout")
                 destroyHillsRenderConfig()
@@ -1334,7 +1439,7 @@ class MapRenderer(
             startedAtElapsedMs = timing.startedAtElapsedMs,
             completedAtElapsedMs = SystemClock.elapsedRealtime(),
             status = "ready",
-            detail = "map=${timing.mapName} demSource=${timing.demSource}",
+            detail = timing.hillshadeDiagnosticDetail(),
         )
     }
 
@@ -1347,14 +1452,40 @@ class MapRenderer(
             startedAtElapsedMs = timing.startedAtElapsedMs,
             completedAtElapsedMs = SystemClock.elapsedRealtime(),
             status = reason,
-            detail = "map=${timing.mapName} demSource=${timing.demSource}",
+            detail = timing.hillshadeDiagnosticDetail(),
         )
+    }
+
+    private fun PendingFirstVisibleHillshadeTiming.hillshadeDiagnosticDetail(): String =
+        "map=$mapName demSources=$demSources zoom=$zoomLevel visibleTiles=$visibleTileCount " +
+            "detailedDemTiles=$detailedDemTileCount standardFallbackDemTiles=$standardFallbackDemTileCount " +
+            "missingDemTiles=$missingDemTileCount"
+
+    private fun publishHillshadeTerrainUnavailable(
+        mapFile: File,
+        zoomLevel: Byte,
+        missingTileCount: Int,
+        areaKey: String,
+    ) {
+        Log.w(
+            TAG,
+            "No Detailed or Standard hillshade terrain available for visible area " +
+                "map=${mapFile.name} zoom=$zoomLevel missingTiles=$missingTileCount",
+        )
+        _hillshadeTerrainUnavailableEvent.value =
+            HillshadeTerrainUnavailableEvent(
+                mapName = mapFile.name,
+                zoomLevel = zoomLevel.toInt(),
+                missingTileCount = missingTileCount,
+                areaKey = areaKey,
+            )
     }
 
     private fun destroyHillsRenderConfig() {
         hillsRenderConfig?.interruptAndDestroy()
         hillsRenderConfig = null
         hillsRenderConfigDemSignature = null
+        activeHillshadeDemRootDirs = emptyList()
     }
 
     private fun recreateTileCache(newCacheId: String) {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.kt
@@ -913,6 +913,15 @@ class MapRenderer(
                     append(demSignature)
                     append("|ROOTS:")
                     append(effectiveDemRootDirs.joinToString("|") { it.absolutePath })
+                    append("|TILES:")
+                    append(
+                        requiredDemTileIds
+                            ?.asSequence()
+                            ?.map { tileId -> tileId.uppercase(Locale.ROOT) }
+                            ?.sorted()
+                            ?.joinToString(",")
+                            ?: "UNKNOWN",
+                    )
                 }
             hillsRenderConfig?.let { existing ->
                 if (hillsRenderConfigDemSignature == effectiveDemSignature) {
@@ -925,7 +934,11 @@ class MapRenderer(
 
             val config =
                 runCatching {
-                    val demFolder = MapsforgeHillshadeDemFolder(effectiveDemRootDirs)
+                    val demFolder =
+                        MapsforgeHillshadeDemFolder(
+                            demRootDirs = effectiveDemRootDirs,
+                            requiredTileIds = requiredDemTileIds,
+                        )
                     val tileSource =
                         MemoryCachingHgtReaderTileSource(
                             demFolder,

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.kt
@@ -22,10 +22,10 @@ import org.mapsforge.map.datastore.MapDataStore
 import org.mapsforge.map.layer.cache.TileCache
 import org.mapsforge.map.layer.hills.HillsRenderConfig
 import org.mapsforge.map.layer.hills.MemoryCachingHgtReaderTileSource
-import org.mapsforge.map.layer.hills.SimpleShadingAlgorithm
 import org.mapsforge.map.layer.renderer.TileRendererLayer
 import org.mapsforge.map.reader.MapFile
 import org.mapsforge.map.rendertheme.XmlRenderTheme
+import org.mapsforge.map.rendertheme.internal.MapsforgeThemes
 import java.io.File
 import java.util.Locale
 import java.util.concurrent.CopyOnWriteArraySet
@@ -66,6 +66,23 @@ class MapRenderer(
         val cacheId: String,
         val startedAtElapsedMs: Long,
         val traceMarker: BenchmarkTrace.AsyncMarker,
+    )
+
+    private data class PendingFirstVisibleHillshadeTiming(
+        val requestId: Long,
+        val mapName: String,
+        val demSource: String,
+        val startedAtElapsedMs: Long,
+        val traceMarker: BenchmarkTrace.AsyncMarker,
+    )
+
+    private data class ThemeConfigRequest(
+        val themeFile: File?,
+        val mapsforgeThemeName: String?,
+        val bundledThemeId: String,
+        val hillShadingEnabled: Boolean,
+        val reliefOverlayEnabled: Boolean,
+        val demSource: DemSource,
     )
 
     data class ReliefOverlayState(
@@ -124,6 +141,10 @@ class MapRenderer(
         private const val FIRST_VISIBLE_MAP_TRACE_STAGE = "mapRenderer.firstVisibleMap"
         private const val FIRST_VISIBLE_MAP_DIAGNOSTIC_STAGE = "mapRenderer.firstVisibleMap"
         private const val FIRST_VISIBLE_MAP_TIMING_TIMEOUT_MS = 10_000L
+        private const val FIRST_VISIBLE_HILLSHADE_TRACE_STAGE = "mapRenderer.firstVisibleHillshade"
+        private const val FIRST_VISIBLE_HILLSHADE_DIAGNOSTIC_STAGE = "mapRenderer.firstVisibleHillshade"
+        private const val FIRST_VISIBLE_HILLSHADE_TIMING_TIMEOUT_MS = 30_000L
+        private const val HILLSHADE_FIRST_LEVEL_TILES = 16
 
         fun captureCacheDiagnostics(context: Context): CacheDiagnosticsSnapshot = captureMapRendererCacheDiagnostics(context)
     }
@@ -164,6 +185,8 @@ class MapRenderer(
     private val firstVisibleMapEvent = MutableStateFlow<FirstVisibleMapEvent?>(null)
     private var nextFirstVisibleMapRequestId: Long = 0L
     private var pendingFirstVisibleMapTiming: PendingFirstVisibleMapTiming? = null
+    private var nextFirstVisibleHillshadeRequestId: Long = 0L
+    private var pendingFirstVisibleHillshadeTiming: PendingFirstVisibleHillshadeTiming? = null
     private val activityManager: ActivityManager? by lazy {
         context.getSystemService(ActivityManager::class.java)
     }
@@ -285,6 +308,9 @@ class MapRenderer(
     }
 
     private var currentLayer: TileRendererLayer? = null
+    private var hillshadeLayer: FirstVisibleHillshadeTileRendererLayer? = null
+    private var hillshadeTileCache: TileCache? = null
+    private var currentHillshadeTileCacheId: String? = null
     private var reliefOverlayLayer: ReliefOverlayLayer? = null
     private var liveElevationSampler: ReliefOverlayLayer? = null
     private var currentStore: MapDataStore? = null
@@ -326,32 +352,33 @@ class MapRenderer(
             } else {
                 MapsforgeThemeCatalog.ELEVATE_THEME_ID
             }
-        val reliefOverlayChanged = currentReliefOverlayEnabled != reliefOverlayEnabled
-        val demSourceChanged = currentDemSource != demSource
+        val request =
+            ThemeConfigRequest(
+                themeFile = themeFile,
+                mapsforgeThemeName = normalizedMapsforge,
+                bundledThemeId = normalizedBundledThemeId,
+                hillShadingEnabled = hillShadingEnabled,
+                reliefOverlayEnabled = reliefOverlayEnabled,
+                demSource = demSource,
+            )
         val newSignature =
             computeMapRendererThemeSignature(
                 file = themeFile,
                 mapsforgeThemeName = normalizedMapsforge,
                 bundledThemeId = normalizedBundledThemeId,
-                hillShadingEnabled = hillShadingEnabled,
-            ) + "|DEM:${demSource.id}"
-        // Avoid unnecessary work
-        if (currentThemeSignature == newSignature) {
-            timingStatus = if (reliefOverlayChanged) "relief_overlay_only" else "no_change"
-            if (reliefOverlayChanged) {
-                currentReliefOverlayEnabled = reliefOverlayEnabled
-                updateReliefOverlayLayer()
-                publishReliefOverlayState(force = true)
-                forceRedraw()
-            }
-            MapHotPathDiagnostics.end(
-                marker = timingMarker,
-                status = timingStatus,
-                detail = "mapsforge=${normalizedMapsforge != null} hill=$hillShadingEnabled reliefChanged=$reliefOverlayChanged",
+                hillShadingEnabled = false,
             )
-            return themeApplyResult
+
+        // Hillshade is an independent transparent layer. Updating it must not purge, remove, or
+        // rebuild the already-visible base map.
+        if (currentThemeSignature == newSignature) {
+            return applyLayerOnlyThemeConfig(
+                request = request,
+                timingMarker = timingMarker,
+            )
         }
 
+        val demSourceChanged = currentDemSource != demSource
         try {
             val theme =
                 MapHotPathDiagnostics.measure(
@@ -384,6 +411,7 @@ class MapRenderer(
                 liveElevationSampler = null
             }
             if (!currentHillShadingEnabled || demSourceChanged) {
+                clearHillshadeLayer(reason = "hill_config_changed")
                 destroyHillsRenderConfig()
             }
 
@@ -432,6 +460,91 @@ class MapRenderer(
             )
         }
         return themeApplyResult
+    }
+
+    private fun applyLayerOnlyThemeConfig(
+        request: ThemeConfigRequest,
+        timingMarker: MapHotPathDiagnostics.Marker?,
+    ): ThemeApplyResult {
+        val hillShadingChanged = currentHillShadingEnabled != request.hillShadingEnabled
+        val reliefOverlayChanged = currentReliefOverlayEnabled != request.reliefOverlayEnabled
+        val demSourceChanged = currentDemSource != request.demSource
+        val hillshadeLayerChanged = hillShadingChanged || demSourceChanged
+        val reliefLayerChanged = reliefOverlayChanged || demSourceChanged
+        if (!hillShadingChanged && !reliefOverlayChanged && !demSourceChanged) {
+            MapHotPathDiagnostics.end(
+                marker = timingMarker,
+                status = "no_change",
+                detail =
+                    "mapsforge=${request.mapsforgeThemeName != null} " +
+                        "hill=${request.hillShadingEnabled} reliefChanged=false",
+            )
+            return ThemeApplyResult()
+        }
+
+        currentThemeFile = request.themeFile
+        currentMapsforgeThemeName = request.mapsforgeThemeName
+        currentBundledThemeId = request.bundledThemeId
+        currentHillShadingEnabled = request.hillShadingEnabled
+        currentReliefOverlayEnabled = request.reliefOverlayEnabled
+        currentDemSource = request.demSource
+
+        if (demSourceChanged) {
+            clearReliefOverlayLayer()
+            liveElevationSampler?.let { sampler ->
+                runCatching { sampler.onDestroy() }
+            }
+            liveElevationSampler = null
+        }
+        if (hillshadeLayerChanged) {
+            clearHillshadeLayer(reason = "hill_config_changed")
+            destroyHillsRenderConfig()
+        }
+
+        val newDemSignature = computeDemSignatureOrNull()
+        currentDemSignature = newDemSignature
+        if (hillshadeLayerChanged) {
+            updateHillshadeLayerForCurrentMap(newDemSignature)
+        }
+        if (reliefLayerChanged) {
+            updateReliefOverlayLayer()
+            publishReliefOverlayState(force = true)
+        }
+        forceRedraw()
+
+        val timingStatus =
+            when {
+                demSourceChanged -> "dem_layer_only"
+                hillShadingChanged -> "hillshade_layer_only"
+                else -> "relief_overlay_only"
+            }
+        MapHotPathDiagnostics.end(
+            marker = timingMarker,
+            status = timingStatus,
+            detail =
+                "mapsforge=${request.mapsforgeThemeName != null} hill=${request.hillShadingEnabled} " +
+                    "hillChanged=$hillShadingChanged reliefChanged=$reliefOverlayChanged " +
+                    "demSourceChanged=$demSourceChanged",
+        )
+        return ThemeApplyResult()
+    }
+
+    private fun updateHillshadeLayerForCurrentMap(demSignature: String?) {
+        currentMapPath
+            ?.let(::File)
+            ?.takeIf { it.isFile }
+            ?.let { mapFile ->
+                updateHillshadeLayer(
+                    mapFile = mapFile,
+                    demSignature = demSignature,
+                    requiredDemTileIds =
+                        if (currentHillShadingEnabled) {
+                            Dem3CoverageUtils.requiredTileIdsForMap(mapFile)
+                        } else {
+                            null
+                        },
+                )
+            }
     }
 
     suspend fun awaitTileCacheUpdateAfter(
@@ -485,8 +598,6 @@ class MapRenderer(
             resolveMapRendererDesiredCacheId(
                 mapSignature = newMapSignature,
                 themeSignature = currentThemeSignature,
-                demSignature = newDemSignature,
-                hillShadingEnabled = currentHillShadingEnabled,
                 elevationLabelsMetric = currentElevationLabelsMetric,
             )
         desiredCacheIdForTiming = desiredCacheId
@@ -584,13 +695,6 @@ class MapRenderer(
                 createTileRendererLayer(
                     mapDataStore = mapDataStore,
                     theme = theme,
-                    demSignature = newDemSignature,
-                    requiredDemTileIds =
-                        if (currentHillShadingEnabled) {
-                            Dem3CoverageUtils.requiredTileIdsForMap(mapFile)
-                        } else {
-                            null
-                        },
                     warmStartupCache = warmStartupCache,
                 )
             skipNextStartupTilePrewarm = false
@@ -599,6 +703,16 @@ class MapRenderer(
             currentMapPath = mapPath
             currentMapSignature = newMapSignature
             currentDemSignature = newDemSignature
+            updateHillshadeLayer(
+                mapFile = mapFile,
+                demSignature = newDemSignature,
+                requiredDemTileIds =
+                    if (currentHillShadingEnabled) {
+                        Dem3CoverageUtils.requiredTileIdsForMap(mapFile)
+                    } else {
+                        null
+                    },
+            )
             updateReliefOverlayLayer()
 
             forceRedraw()
@@ -652,6 +766,7 @@ class MapRenderer(
 
     fun invalidateTileCache() {
         purgeTileCache(reason = "invalidate")
+        purgeHillshadeTileCache(reason = "invalidate")
         forceRedraw()
     }
 
@@ -714,6 +829,8 @@ class MapRenderer(
     private fun clearCurrentLayer(reason: String = "unspecified"): Boolean {
         val hadCurrentLayer = currentLayer != null
         val storeOwnedByCurrentLayer = currentLayer?.mapDataStore === currentStore
+
+        clearHillshadeLayer(reason = reason)
 
         currentLayer?.let { layer ->
             disableLayerTileExpansion(layer, reason)
@@ -806,17 +923,21 @@ class MapRenderer(
                 createTileRendererLayer(
                     mapDataStore = mapDataStore,
                     theme = theme,
-                    demSignature = demSignature,
-                    requiredDemTileIds =
-                        currentMapPath
-                            ?.let(::File)
-                            ?.takeIf { it.isFile }
-                            ?.let(Dem3CoverageUtils::requiredTileIdsForMap),
                     warmStartupCache = false,
                 )
             currentLayer = tileRendererLayer
             mapView.mutateLayers { layers -> layers.add(0, tileRendererLayer) }
             currentDemSignature = demSignature
+            currentMapPath
+                ?.let(::File)
+                ?.takeIf { it.isFile }
+                ?.let { mapFile ->
+                    updateHillshadeLayer(
+                        mapFile = mapFile,
+                        demSignature = demSignature,
+                        requiredDemTileIds = Dem3CoverageUtils.requiredTileIdsForMap(mapFile),
+                    )
+                }
             updateReliefOverlayLayer()
             publishReliefOverlayState(force = true)
             forceRedraw()
@@ -942,11 +1063,12 @@ class MapRenderer(
                     val tileSource =
                         MemoryCachingHgtReaderTileSource(
                             demFolder,
-                            SimpleShadingAlgorithm(),
+                            createWearHillShadingAlgorithm(),
                             AndroidGraphicFactory.INSTANCE,
                         )
                     HillsRenderConfig(tileSource)
                         .setMagnitudeScaleFactor(1f)
+                        .setExternal(true)
                         .indexOnThread()
                 }.getOrElse { e ->
                     timingStatus = "error_${e.javaClass.simpleName}"
@@ -974,21 +1096,18 @@ class MapRenderer(
     private fun createTileRendererLayer(
         mapDataStore: MapDataStore,
         theme: XmlRenderTheme,
-        demSignature: String?,
-        requiredDemTileIds: Set<String>?,
         warmStartupCache: Boolean,
     ): TileRendererLayer =
         MapHotPathDiagnostics.measure(
             stage = "mapRenderer.createTileRendererLayer",
-            detail = "warmStartupCache=$warmStartupCache demPresent=${demSignature != null}",
+            detail = "warmStartupCache=$warmStartupCache externalHillshade=true",
         ) {
-            val hillsConfig = buildHillsRenderConfigOrNull(demSignature, requiredDemTileIds)
             FirstVisibleTileRendererLayer(
                 tileCache,
                 mapDataStore,
                 mapView.model.mapViewPosition,
                 AndroidGraphicFactory.INSTANCE,
-                hillsConfig,
+                null,
                 onFirstVisibleBaseTile = { layer, source ->
                     val visibleAtElapsedMs = SystemClock.elapsedRealtime()
                     mapView.post {
@@ -1007,6 +1126,91 @@ class MapRenderer(
                 }
             }
         }
+
+    @Suppress("ReturnCount")
+    private fun updateHillshadeLayer(
+        mapFile: File,
+        demSignature: String?,
+        requiredDemTileIds: Set<String>?,
+    ) {
+        clearHillshadeLayer(reason = "replace")
+        if (!currentHillShadingEnabled || demSignature == null) return
+
+        val hillsConfig = buildHillsRenderConfigOrNull(demSignature, requiredDemTileIds) ?: return
+        val cacheId =
+            resolveMapRendererHillshadeCacheId(
+                baseCacheId = currentTileCacheId,
+                demSourceId = currentDemSource.id,
+                demSignature = demSignature,
+            )
+        val cache = createHillshadeTileCache(cacheId)
+        val hillshadeMapStore =
+            runCatching { MapFile(mapFile) }
+                .getOrElse { error ->
+                    runCatching { cache.destroy() }
+                    Log.w(TAG, "updateHillshadeLayer: Failed opening map store", error)
+                    return
+                }
+        val layer =
+            runCatching {
+                FirstVisibleHillshadeTileRendererLayer(
+                    tileCache = cache,
+                    mapDataStore = hillshadeMapStore,
+                    mapViewPosition = mapView.model.mapViewPosition,
+                    graphicFactory = AndroidGraphicFactory.INSTANCE,
+                    hillsRenderConfig = hillsConfig,
+                    onFirstVisibleHillshadeTile = ::handleFirstVisibleHillshadeTile,
+                ).apply {
+                    setXmlRenderTheme(MapsforgeThemes.HILLSHADING)
+                    setCacheZoomPlus(0)
+                    setCacheZoomMinus(0)
+                    setCacheTileMargin(0)
+                    trySetThreadPriority(Process.THREAD_PRIORITY_BACKGROUND)
+                }
+            }.getOrElse { error ->
+                runCatching { hillshadeMapStore.close() }
+                runCatching { cache.destroy() }
+                Log.w(TAG, "updateHillshadeLayer: Failed creating external hillshade layer", error)
+                return
+            }
+
+        hillshadeTileCache = cache
+        currentHillshadeTileCacheId = cacheId
+        hillshadeLayer = layer
+        mapView.mutateLayers { layers ->
+            val index = if (currentLayer != null && layers.size() > 0) 1 else 0
+            layers.add(index, layer)
+        }
+        startFirstVisibleHillshadeTiming(layer = layer, mapFile = mapFile)
+    }
+
+    private fun createHillshadeTileCache(cacheId: String): TileCache =
+        AndroidUtil.createExternalStorageTileCache(
+            context,
+            cacheId,
+            HILLSHADE_FIRST_LEVEL_TILES,
+            mapView.model.displayModel.tileSize,
+            true,
+        )
+
+    private fun clearHillshadeLayer(reason: String) {
+        cancelFirstVisibleHillshadeTiming(reason)
+        hillshadeLayer?.let { layer ->
+            disableLayerTileExpansion(layer, reason)
+            mapView.mutateLayers { layers ->
+                layers.remove(layer)
+                runCatching { layer.onDestroy() }
+                    .onFailure { Log.w(TAG, "clearHillshadeLayer: Failed to destroy layer", it) }
+            }
+        }
+        hillshadeLayer = null
+        hillshadeTileCache?.let { cache ->
+            runCatching { cache.destroy() }
+                .onFailure { Log.w(TAG, "clearHillshadeLayer: Failed to destroy tile cache", it) }
+        }
+        hillshadeTileCache = null
+        currentHillshadeTileCacheId = null
+    }
 
     private fun startFirstVisibleMapTiming(
         mapPath: String,
@@ -1084,6 +1288,69 @@ class MapRenderer(
         )
     }
 
+    private fun startFirstVisibleHillshadeTiming(
+        layer: FirstVisibleHillshadeTileRendererLayer,
+        mapFile: File,
+    ) {
+        cancelFirstVisibleHillshadeTiming(reason = "superseded")
+        val requestId = ++nextFirstVisibleHillshadeRequestId
+        val startedAtElapsedMs = SystemClock.elapsedRealtime()
+        pendingFirstVisibleHillshadeTiming =
+            PendingFirstVisibleHillshadeTiming(
+                requestId = requestId,
+                mapName = mapFile.name,
+                demSource = currentDemSource.id,
+                startedAtElapsedMs = startedAtElapsedMs,
+                traceMarker = BenchmarkTrace.beginAsync(FIRST_VISIBLE_HILLSHADE_TRACE_STAGE),
+            )
+        mapView.postDelayed(
+            {
+                val timing = pendingFirstVisibleHillshadeTiming
+                if (timing?.requestId != requestId || hillshadeLayer !== layer) return@postDelayed
+                pendingFirstVisibleHillshadeTiming = null
+                BenchmarkTrace.endAsync(timing.traceMarker)
+                MapHotPathDiagnostics.recordInterval(
+                    stage = "$FIRST_VISIBLE_HILLSHADE_DIAGNOSTIC_STAGE.cancelled",
+                    startedAtElapsedMs = timing.startedAtElapsedMs,
+                    completedAtElapsedMs = SystemClock.elapsedRealtime(),
+                    status = "timeout",
+                    detail = "map=${timing.mapName} demSource=${timing.demSource}",
+                )
+                clearHillshadeLayer(reason = "first_tile_timeout")
+                destroyHillsRenderConfig()
+                forceRedraw()
+            },
+            FIRST_VISIBLE_HILLSHADE_TIMING_TIMEOUT_MS,
+        )
+    }
+
+    private fun handleFirstVisibleHillshadeTile(layer: FirstVisibleHillshadeTileRendererLayer) {
+        if (hillshadeLayer !== layer) return
+        val timing = pendingFirstVisibleHillshadeTiming ?: return
+        pendingFirstVisibleHillshadeTiming = null
+        BenchmarkTrace.endAsync(timing.traceMarker)
+        MapHotPathDiagnostics.recordInterval(
+            stage = "$FIRST_VISIBLE_HILLSHADE_DIAGNOSTIC_STAGE.ready",
+            startedAtElapsedMs = timing.startedAtElapsedMs,
+            completedAtElapsedMs = SystemClock.elapsedRealtime(),
+            status = "ready",
+            detail = "map=${timing.mapName} demSource=${timing.demSource}",
+        )
+    }
+
+    private fun cancelFirstVisibleHillshadeTiming(reason: String) {
+        val timing = pendingFirstVisibleHillshadeTiming ?: return
+        pendingFirstVisibleHillshadeTiming = null
+        BenchmarkTrace.endAsync(timing.traceMarker)
+        MapHotPathDiagnostics.recordInterval(
+            stage = "$FIRST_VISIBLE_HILLSHADE_DIAGNOSTIC_STAGE.cancelled",
+            startedAtElapsedMs = timing.startedAtElapsedMs,
+            completedAtElapsedMs = SystemClock.elapsedRealtime(),
+            status = reason,
+            detail = "map=${timing.mapName} demSource=${timing.demSource}",
+        )
+    }
+
     private fun destroyHillsRenderConfig() {
         hillsRenderConfig?.interruptAndDestroy()
         hillsRenderConfig = null
@@ -1117,6 +1384,16 @@ class MapRenderer(
         }
     }
 
+    private fun purgeHillshadeTileCache(reason: String) {
+        val cache = hillshadeTileCache ?: return
+        MapHotPathDiagnostics.measure(
+            stage = "mapRenderer.purgeHillshadeTileCache",
+            detail = "reason=$reason cacheId=$currentHillshadeTileCacheId",
+        ) {
+            cache.tryPurge()
+        }
+    }
+
     private fun maybeCleanupPersistentCachesAsync() {
         val cacheRoot = context.externalCacheDir ?: return
         if (!cacheRoot.exists() || !cacheRoot.isDirectory) return
@@ -1127,13 +1404,18 @@ class MapRenderer(
         if (cacheCleanupInProgress) return
 
         cacheCleanupInProgress = true
+        val keepCacheIds =
+            buildSet {
+                add(currentTileCacheId)
+                currentHillshadeTileCacheId?.let(::add)
+            }
         Thread(
             {
                 try {
                     cleanupMapRendererPersistentCacheBuckets(
                         cacheRoot = cacheRoot,
                         nowMs = now,
-                        keepIds = setOf(currentTileCacheId),
+                        keepIds = keepCacheIds,
                     )
                     cacheMaintenancePrefs
                         .edit()
@@ -1160,13 +1442,7 @@ class MapRenderer(
 
     private fun updateReliefOverlayLayer() {
         if (!currentReliefOverlayEnabled || currentMapPath.isNullOrBlank()) {
-            reliefOverlayLayer?.let { existing ->
-                mapView.mutateLayers { layers ->
-                    layers.remove(existing)
-                    runCatching { existing.onDestroy() }
-                }
-            }
-            reliefOverlayLayer = null
+            clearReliefOverlayLayer()
             publishReliefOverlayState(force = true)
             return
         }
@@ -1183,12 +1459,27 @@ class MapRenderer(
                 ).also { layer ->
                     // Keep above rendered map but below interactive overlays.
                     mapView.mutateLayers { layers ->
-                        val index = if (layers.size() > 0) 1 else 0
+                        val index =
+                            when {
+                                currentLayer == null || layers.size() == 0 -> 0
+                                hillshadeLayer != null && layers.size() > 1 -> 2
+                                else -> 1
+                            }
                         layers.add(index, layer)
                     }
                 }
         }
         publishReliefOverlayState(force = true)
+    }
+
+    private fun clearReliefOverlayLayer() {
+        reliefOverlayLayer?.let { existing ->
+            mapView.mutateLayers { layers ->
+                layers.remove(existing)
+                runCatching { existing.onDestroy() }
+            }
+        }
+        reliefOverlayLayer = null
     }
 
     private fun getOrCreateLiveElevationSampler(): ReliefOverlayLayer? {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRenderer.kt
@@ -35,6 +35,12 @@ import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.min
 import org.mapsforge.map.model.common.Observer as MapsforgeObserver
 
+internal fun shouldWarmMapStartupTileCache(
+    prewarmingEnabled: Boolean,
+    skipNextStartupPrewarm: Boolean,
+    hillshadeEnabled: Boolean,
+): Boolean = prewarmingEnabled && !skipNextStartupPrewarm && !hillshadeEnabled
+
 class MapRenderer(
     private val context: Context,
     private val mapView: MapView,
@@ -711,7 +717,12 @@ class MapRenderer(
                     MapFile(mapFile)
                 }
             currentStore = mapDataStore
-            warmStartupCache = tileCacheConfig.startupPrewarmEnabled && !skipNextStartupTilePrewarm
+            warmStartupCache =
+                shouldWarmMapStartupTileCache(
+                    prewarmingEnabled = tileCacheConfig.startupPrewarmEnabled,
+                    skipNextStartupPrewarm = skipNextStartupTilePrewarm,
+                    hillshadeEnabled = currentHillShadingEnabled,
+                )
             val tileRendererLayer =
                 createTileRendererLayer(
                     mapDataStore = mapDataStore,
@@ -988,7 +999,15 @@ class MapRenderer(
 
     private fun armStartupTilePrewarm(layer: TileRendererLayer) {
         val config = tileCacheConfig
-        if (!config.startupPrewarmEnabled) return
+        if (
+            !shouldWarmMapStartupTileCache(
+                prewarmingEnabled = config.startupPrewarmEnabled,
+                skipNextStartupPrewarm = false,
+                hillshadeEnabled = currentHillShadingEnabled,
+            )
+        ) {
+            return
+        }
         if (config.startupPrewarmZoomPlus <= 0 &&
             config.startupPrewarmZoomMinus <= 0 &&
             config.startupPrewarmTileMargin <= 0
@@ -998,7 +1017,7 @@ class MapRenderer(
 
         mapView.postDelayed(
             {
-                if (currentLayer !== layer) return@postDelayed
+                if (currentLayer !== layer || currentHillShadingEnabled) return@postDelayed
                 // Warm adjacent zoom levels once startup rendering has had a chance to settle.
                 layer.setCacheZoomPlus(config.startupPrewarmZoomPlus)
                 layer.setCacheZoomMinus(config.startupPrewarmZoomMinus)

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapViewModel.kt
@@ -155,6 +155,10 @@ class MapViewModel(
 
     private val _mapAppearanceApplyInProgress = MutableStateFlow(false)
     val mapAppearanceApplyInProgress: StateFlow<Boolean> = _mapAppearanceApplyInProgress.asStateFlow()
+    private val _hillshadeTerrainUnavailableEvent =
+        MutableStateFlow<MapRenderer.HillshadeTerrainUnavailableEvent?>(null)
+    val hillshadeTerrainUnavailableEvent: StateFlow<MapRenderer.HillshadeTerrainUnavailableEvent?> =
+        _hillshadeTerrainUnavailableEvent.asStateFlow()
 
     val selectedMapPath: StateFlow<String?> =
         settingsRepository.selectedMapPath
@@ -178,6 +182,7 @@ class MapViewModel(
     private var rendererConfigApplyPending: Boolean = false
     private var themeApplyJob: Job? = null
     private var rendererWorkJob: Job? = null
+    private var hillshadeTerrainEventJob: Job? = null
     private var rendererWorkGeneration: Long = 0L
     private var pendingMapLayerPath: String? = null
     private var pendingExternalCacheClear: Boolean = false
@@ -323,6 +328,8 @@ class MapViewModel(
         mapHolder?.renderer?.destroy()
         runCatching { mapHolder?.mapView?.destroyAll() }
         mapHolder = null
+        hillshadeTerrainEventJob?.cancel()
+        hillshadeTerrainEventJob = null
         mapRenderer = null
         latestZoomMin = null
         latestZoomMax = null
@@ -572,9 +579,22 @@ class MapViewModel(
     }
 
     fun setMapRenderer(renderer: MapRenderer?) {
-        mapRenderer = renderer
+        if (mapRenderer !== renderer) {
+            hillshadeTerrainEventJob?.cancel()
+            _hillshadeTerrainUnavailableEvent.value = null
+            mapRenderer = renderer
+            hillshadeTerrainEventJob =
+                renderer
+                    ?.hillshadeTerrainUnavailableEvent
+                    ?.onEach { event -> _hillshadeTerrainUnavailableEvent.value = event }
+                    ?.launchIn(viewModelScope)
+        }
         applyRendererConfigIfReady()
         schedulePendingRendererWorkIfReady()
+    }
+
+    fun dismissHillshadeTerrainUnavailable() {
+        _hillshadeTerrainUnavailableEvent.value = null
     }
 
     fun setThemeRenderingDeferred(deferred: Boolean) {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapViewModel.kt
@@ -867,7 +867,10 @@ class MapViewModel(
                             themeId = latestBundledThemeId,
                             styleId = selection.styleId,
                             enabledOverlayLayerIds = selection.enabledOverlayLayerIds,
-                            hillShadingEnabled = selection.hillShadingEnabled,
+                            // Hillshade is rendered by an independent transparent Mapsforge layer.
+                            // Keep the base theme free of hill instructions so its tile jobs never
+                            // wait for DEM indexing or shading generation.
+                            hillShadingEnabled = false,
                         )
                     }
                 latestMapsforgeThemeName = null

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsforgeHillshadeDemFolder.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsforgeHillshadeDemFolder.kt
@@ -15,17 +15,38 @@ import java.util.zip.ZipFile
 
 internal class MapsforgeHillshadeDemFolder(
     private val demRootDirs: List<File>,
+    requiredTileIds: Set<String>? = null,
 ) : DemFolder {
+    private val normalizedRequiredTileIds =
+        requiredTileIds?.mapTo(linkedSetOf()) { tileId -> tileId.uppercase(Locale.ROOT) }
+
     override fun files(): Iterable<DemFile> =
-        demRootDirs
-            .asSequence()
-            .filter { it.exists() && it.isDirectory }
-            .flatMap { root -> root.walkTopDown().filter { it.isFile } }
+        selectedDemFiles()
             .mapNotNull(::toHillshadeDemFile)
             .distinctBy { demFile -> demFile.name.uppercase(Locale.ROOT) }
             .toList()
 
     override fun subs(): Iterable<DemFolder> = emptyList()
+
+    private fun selectedDemFiles(): Sequence<File> {
+        val requiredTiles = normalizedRequiredTileIds
+        return if (requiredTiles == null) {
+            demRootDirs
+                .asSequence()
+                .filter { it.exists() && it.isDirectory }
+                .flatMap { root -> root.walkTopDown().filter { it.isFile } }
+        } else {
+            demRootDirs
+                .asSequence()
+                .filter { it.exists() && it.isDirectory }
+                .flatMap { root ->
+                    requiredTiles
+                        .asSequence()
+                        .flatMap(root::hillshadeDemTileCandidates)
+                        .filter { candidate -> candidate.isFile }
+                }
+        }
+    }
 
     private fun toHillshadeDemFile(file: File): DemFile? {
         val lowerName = file.name.lowercase(Locale.ROOT)
@@ -95,19 +116,23 @@ private fun String.isHillshadeDemFileName(): Boolean {
 
 private fun File.containsHillshadeDemTile(tileId: String): Boolean {
     val normalizedTileId = tileId.uppercase(Locale.ROOT)
-    return if (!exists() || !isDirectory || normalizedTileId.length < 3) {
-        false
-    } else {
-        val folder = normalizedTileId.substring(0, 3)
-        listOf(
-            File(File(this, folder), "$normalizedTileId.hgt"),
-            File(File(this, folder), "$normalizedTileId.hgt.zip"),
-            File(File(this, folder), "$normalizedTileId.hgt.gz"),
-            File(this, "$normalizedTileId.hgt"),
-            File(this, "$normalizedTileId.hgt.zip"),
-            File(this, "$normalizedTileId.hgt.gz"),
-        ).any { candidate -> candidate.isFile }
-    }
+    return exists() &&
+        isDirectory &&
+        normalizedTileId.length >= 3 &&
+        hillshadeDemTileCandidates(normalizedTileId).any { candidate -> candidate.isFile }
+}
+
+private fun File.hillshadeDemTileCandidates(tileId: String): Sequence<File> {
+    if (tileId.length < 3) return emptySequence()
+    val folder = tileId.substring(0, 3)
+    return sequenceOf(
+        File(File(this, folder), "$tileId.hgt"),
+        File(File(this, folder), "$tileId.hgt.zip"),
+        File(File(this, folder), "$tileId.hgt.gz"),
+        File(this, "$tileId.hgt"),
+        File(this, "$tileId.hgt.zip"),
+        File(this, "$tileId.hgt.gz"),
+    )
 }
 
 private class ZipHgtDemFile(

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsforgeHillshadeDemFolder.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsforgeHillshadeDemFolder.kt
@@ -3,6 +3,7 @@ package com.glancemap.glancemapwearos.presentation.features.maps
 import org.mapsforge.map.layer.hills.DemFile
 import org.mapsforge.map.layer.hills.DemFileFS
 import org.mapsforge.map.layer.hills.DemFolder
+import org.mapsforge.map.layer.hills.HgtFileInfo
 import java.io.BufferedInputStream
 import java.io.File
 import java.io.FileInputStream
@@ -50,11 +51,158 @@ internal class MapsforgeHillshadeDemFolder(
 
     private fun toHillshadeDemFile(file: File): DemFile? {
         val lowerName = file.name.lowercase(Locale.ROOT)
-        return when {
-            lowerName.endsWith(".hgt") -> DemFileFS(file)
-            lowerName.endsWith(".hgt.zip") -> ZipHgtDemFile(file)
-            lowerName.endsWith(".hgt.gz") -> GzipHgtDemFile(file)
-            else -> null
+        val demFile =
+            when {
+                lowerName.endsWith(".hgt") -> DemFileFS(file)
+                lowerName.endsWith(".hgt.zip") -> ZipHgtDemFile(file)
+                lowerName.endsWith(".hgt.gz") -> GzipHgtDemFile(file)
+                else -> null
+            }
+        return demFile?.let(::limitHillshadeDemFileInput)
+    }
+}
+
+/**
+ * Makes high-resolution DEMs affordable for the watch before Mapsforge reads them into memory.
+ *
+ * Mapsforge derives the allocation size solely from [DemFile.size]. Reducing its shading output
+ * after that point still leaves it to allocate a full 3600x3600 Detailed HGT grid. This wrapper
+ * exposes every nth source sample instead, retaining the Detailed source while bounding the input
+ * grid that Mapsforge sees.
+ */
+internal fun limitHillshadeDemFileInput(
+    demFile: DemFile,
+    maxAxisLen: Int = WEAR_HILLSHADE_MAX_INPUT_AXIS,
+): DemFile {
+    val sourceAxisLen = HgtFileInfo.computeAxisLen(demFile.size)
+    val stride = hillshadeInputDownsamplingStride(sourceAxisLen, maxAxisLen)
+    return if (stride == 1) demFile else DownsampledHgtDemFile(demFile, sourceAxisLen, stride)
+}
+
+internal fun hillshadeInputDownsamplingStride(
+    sourceAxisLen: Int,
+    maxAxisLen: Int = WEAR_HILLSHADE_MAX_INPUT_AXIS,
+): Int {
+    if (sourceAxisLen <= maxAxisLen || sourceAxisLen <= 0) return 1
+
+    var stride = ((sourceAxisLen + maxAxisLen - 1) / maxAxisLen).coerceAtLeast(1)
+    while (sourceAxisLen % stride != 0) {
+        stride += 1
+    }
+    return stride
+}
+
+private class DownsampledHgtDemFile(
+    private val source: DemFile,
+    private val sourceAxisLen: Int,
+    private val stride: Int,
+) : DemFile {
+    private val outputAxisLen = sourceAxisLen / stride
+    private val outputSize = (outputAxisLen + 1L) * (outputAxisLen + 1L) * HGT_SAMPLE_BYTES
+
+    init {
+        require(sourceAxisLen > 0)
+        require(stride > 1)
+        require(sourceAxisLen % stride == 0)
+    }
+
+    override fun getName(): String = source.name
+
+    override fun getSize(): Long = outputSize
+
+    override fun openInputStream(bufferSize: Int): InputStream =
+        DownsamplingHgtInputStream(
+            source = source.openInputStream(bufferSize),
+            sourceAxisLen = sourceAxisLen,
+            stride = stride,
+        )
+
+    override fun asStream(): InputStream =
+        DownsamplingHgtInputStream(
+            source = source.asStream(),
+            sourceAxisLen = sourceAxisLen,
+            stride = stride,
+        )
+
+    override fun asRawStream(): InputStream =
+        DownsamplingHgtInputStream(
+            source = source.asRawStream(),
+            sourceAxisLen = sourceAxisLen,
+            stride = stride,
+        )
+}
+
+private class DownsamplingHgtInputStream(
+    private val source: InputStream,
+    sourceAxisLen: Int,
+    private val stride: Int,
+) : InputStream() {
+    private val sourcePointCount = sourceAxisLen + 1
+    private val outputPointCount = (sourceAxisLen / stride) + 1
+    private val sourceRow = ByteArray(sourcePointCount * HGT_SAMPLE_BYTES)
+    private val outputRow = ByteArray(outputPointCount * HGT_SAMPLE_BYTES)
+    private var emittedRowCount = 0
+    private var outputOffset = outputRow.size
+
+    override fun read(): Int {
+        if (!ensureOutputRow()) return -1
+        return outputRow[outputOffset++].toInt() and BYTE_MASK
+    }
+
+    override fun read(
+        buffer: ByteArray,
+        offset: Int,
+        length: Int,
+    ): Int {
+        require(offset >= 0 && length >= 0 && offset <= buffer.size - length)
+        if (length == 0) return 0
+
+        var written = 0
+        while (written < length && ensureOutputRow()) {
+            val available = outputRow.size - outputOffset
+            val count = minOf(length - written, available)
+            outputRow.copyInto(
+                destination = buffer,
+                destinationOffset = offset + written,
+                startIndex = outputOffset,
+                endIndex = outputOffset + count,
+            )
+            outputOffset += count
+            written += count
+        }
+        return written.takeIf { it > 0 } ?: -1
+    }
+
+    override fun close() {
+        source.close()
+    }
+
+    private fun ensureOutputRow(): Boolean {
+        if (outputOffset < outputRow.size) return true
+        if (emittedRowCount >= outputPointCount) return false
+
+        if (emittedRowCount > 0) {
+            repeat(stride - 1) { readFully(sourceRow) }
+        }
+        readFully(sourceRow)
+
+        var sourceOffset = 0
+        outputRow.indices.step(HGT_SAMPLE_BYTES).forEach { outputIndex ->
+            outputRow[outputIndex] = sourceRow[sourceOffset]
+            outputRow[outputIndex + 1] = sourceRow[sourceOffset + 1]
+            sourceOffset += stride * HGT_SAMPLE_BYTES
+        }
+        emittedRowCount += 1
+        outputOffset = 0
+        return true
+    }
+
+    private fun readFully(destination: ByteArray) {
+        var offset = 0
+        while (offset < destination.size) {
+            val count = source.read(destination, offset, destination.size - offset)
+            if (count <= 0) throw java.io.EOFException("Incomplete HGT input")
+            offset += count
         }
     }
 }
@@ -262,3 +410,5 @@ private fun readGzipUncompressedSize(file: File): Long {
 
 private const val GZIP_FOOTER_SIZE_BYTES = 4
 private const val HILLSHADE_DEM_SCAN_MAX_DEPTH = 6
+private const val HGT_SAMPLE_BYTES = 2
+private const val BYTE_MASK = 0xff

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsforgeHillshadeDemFolder.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsforgeHillshadeDemFolder.kt
@@ -3,7 +3,6 @@ package com.glancemap.glancemapwearos.presentation.features.maps
 import org.mapsforge.map.layer.hills.DemFile
 import org.mapsforge.map.layer.hills.DemFileFS
 import org.mapsforge.map.layer.hills.DemFolder
-import org.mapsforge.map.layer.hills.HgtFileInfo
 import java.io.BufferedInputStream
 import java.io.File
 import java.io.FileInputStream
@@ -59,151 +58,6 @@ internal class MapsforgeHillshadeDemFolder(
                 else -> null
             }
         return demFile?.let(::limitHillshadeDemFileInput)
-    }
-}
-
-/**
- * Makes high-resolution DEMs affordable for the watch before Mapsforge reads them into memory.
- *
- * Mapsforge derives the allocation size solely from [DemFile.size]. Reducing its shading output
- * after that point still leaves it to allocate a full 3600x3600 Detailed HGT grid. This wrapper
- * exposes every nth source sample instead, retaining the Detailed source while bounding the input
- * grid that Mapsforge sees.
- */
-internal fun limitHillshadeDemFileInput(
-    demFile: DemFile,
-    maxAxisLen: Int = WEAR_HILLSHADE_MAX_INPUT_AXIS,
-): DemFile {
-    val sourceAxisLen = HgtFileInfo.computeAxisLen(demFile.size)
-    val stride = hillshadeInputDownsamplingStride(sourceAxisLen, maxAxisLen)
-    return if (stride == 1) demFile else DownsampledHgtDemFile(demFile, sourceAxisLen, stride)
-}
-
-internal fun hillshadeInputDownsamplingStride(
-    sourceAxisLen: Int,
-    maxAxisLen: Int = WEAR_HILLSHADE_MAX_INPUT_AXIS,
-): Int {
-    if (sourceAxisLen <= maxAxisLen || sourceAxisLen <= 0) return 1
-
-    var stride = ((sourceAxisLen + maxAxisLen - 1) / maxAxisLen).coerceAtLeast(1)
-    while (sourceAxisLen % stride != 0) {
-        stride += 1
-    }
-    return stride
-}
-
-private class DownsampledHgtDemFile(
-    private val source: DemFile,
-    private val sourceAxisLen: Int,
-    private val stride: Int,
-) : DemFile {
-    private val outputAxisLen = sourceAxisLen / stride
-    private val outputSize = (outputAxisLen + 1L) * (outputAxisLen + 1L) * HGT_SAMPLE_BYTES
-
-    init {
-        require(sourceAxisLen > 0)
-        require(stride > 1)
-        require(sourceAxisLen % stride == 0)
-    }
-
-    override fun getName(): String = source.name
-
-    override fun getSize(): Long = outputSize
-
-    override fun openInputStream(bufferSize: Int): InputStream =
-        DownsamplingHgtInputStream(
-            source = source.openInputStream(bufferSize),
-            sourceAxisLen = sourceAxisLen,
-            stride = stride,
-        )
-
-    override fun asStream(): InputStream =
-        DownsamplingHgtInputStream(
-            source = source.asStream(),
-            sourceAxisLen = sourceAxisLen,
-            stride = stride,
-        )
-
-    override fun asRawStream(): InputStream =
-        DownsamplingHgtInputStream(
-            source = source.asRawStream(),
-            sourceAxisLen = sourceAxisLen,
-            stride = stride,
-        )
-}
-
-private class DownsamplingHgtInputStream(
-    private val source: InputStream,
-    sourceAxisLen: Int,
-    private val stride: Int,
-) : InputStream() {
-    private val sourcePointCount = sourceAxisLen + 1
-    private val outputPointCount = (sourceAxisLen / stride) + 1
-    private val sourceRow = ByteArray(sourcePointCount * HGT_SAMPLE_BYTES)
-    private val outputRow = ByteArray(outputPointCount * HGT_SAMPLE_BYTES)
-    private var emittedRowCount = 0
-    private var outputOffset = outputRow.size
-
-    override fun read(): Int {
-        if (!ensureOutputRow()) return -1
-        return outputRow[outputOffset++].toInt() and BYTE_MASK
-    }
-
-    override fun read(
-        buffer: ByteArray,
-        offset: Int,
-        length: Int,
-    ): Int {
-        require(offset >= 0 && length >= 0 && offset <= buffer.size - length)
-        if (length == 0) return 0
-
-        var written = 0
-        while (written < length && ensureOutputRow()) {
-            val available = outputRow.size - outputOffset
-            val count = minOf(length - written, available)
-            outputRow.copyInto(
-                destination = buffer,
-                destinationOffset = offset + written,
-                startIndex = outputOffset,
-                endIndex = outputOffset + count,
-            )
-            outputOffset += count
-            written += count
-        }
-        return written.takeIf { it > 0 } ?: -1
-    }
-
-    override fun close() {
-        source.close()
-    }
-
-    private fun ensureOutputRow(): Boolean {
-        if (outputOffset < outputRow.size) return true
-        if (emittedRowCount >= outputPointCount) return false
-
-        if (emittedRowCount > 0) {
-            repeat(stride - 1) { readFully(sourceRow) }
-        }
-        readFully(sourceRow)
-
-        var sourceOffset = 0
-        outputRow.indices.step(HGT_SAMPLE_BYTES).forEach { outputIndex ->
-            outputRow[outputIndex] = sourceRow[sourceOffset]
-            outputRow[outputIndex + 1] = sourceRow[sourceOffset + 1]
-            sourceOffset += stride * HGT_SAMPLE_BYTES
-        }
-        emittedRowCount += 1
-        outputOffset = 0
-        return true
-    }
-
-    private fun readFully(destination: ByteArray) {
-        var offset = 0
-        while (offset < destination.size) {
-            val count = source.read(destination, offset, destination.size - offset)
-            if (count <= 0) throw java.io.EOFException("Incomplete HGT input")
-            offset += count
-        }
     }
 }
 
@@ -410,5 +264,3 @@ private fun readGzipUncompressedSize(file: File): Long {
 
 private const val GZIP_FOOTER_SIZE_BYTES = 4
 private const val HILLSHADE_DEM_SCAN_MAX_DEPTH = 6
-private const val HGT_SAMPLE_BYTES = 2
-private const val BYTE_MASK = 0xff

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsforgeHillshadeDemFolder.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsforgeHillshadeDemFolder.kt
@@ -34,7 +34,7 @@ internal class MapsforgeHillshadeDemFolder(
             demRootDirs
                 .asSequence()
                 .filter { it.exists() && it.isDirectory }
-                .flatMap { root -> root.walkTopDown().filter { it.isFile } }
+                .flatMap { root -> root.walkTopDown().filter { it.isFile && it.length() > 0L } }
         } else {
             demRootDirs
                 .asSequence()
@@ -43,7 +43,7 @@ internal class MapsforgeHillshadeDemFolder(
                     requiredTiles
                         .asSequence()
                         .flatMap(root::hillshadeDemTileCandidates)
-                        .filter { candidate -> candidate.isFile }
+                        .filter { candidate -> candidate.isFile && candidate.length() > 0L }
                 }
         }
     }
@@ -59,43 +59,82 @@ internal class MapsforgeHillshadeDemFolder(
     }
 }
 
+internal data class VisibleHillshadeTerrainCoverage(
+    val requiredTileIds: Set<String>,
+    val detailedTileCount: Int,
+    val standardFallbackTileCount: Int,
+    val missingTileCount: Int,
+) {
+    val availableTileCount: Int
+        get() = detailedTileCount + standardFallbackTileCount
+
+    val hasAnyTerrain: Boolean
+        get() = availableTileCount > 0
+
+    val diagnosticKey: String
+        get() = requiredTileIds.sorted().joinToString(",")
+}
+
+internal fun resolveVisibleHillshadeTerrainCoverage(
+    demRootDirs: List<File>,
+    requiredTileIds: Set<String>,
+): VisibleHillshadeTerrainCoverage {
+    var detailedTileCount = 0
+    var standardFallbackTileCount = 0
+    var missingTileCount = 0
+
+    requiredTileIds.forEach { tileId ->
+        val rootIndex =
+            demRootDirs.indexOfFirst { root ->
+                root.containsHillshadeDemTile(tileId)
+            }
+        when {
+            rootIndex == 0 -> detailedTileCount += 1
+            rootIndex > 0 -> standardFallbackTileCount += 1
+            else -> missingTileCount += 1
+        }
+    }
+
+    return VisibleHillshadeTerrainCoverage(
+        requiredTileIds = requiredTileIds,
+        detailedTileCount = detailedTileCount,
+        standardFallbackTileCount = standardFallbackTileCount,
+        missingTileCount = missingTileCount,
+    )
+}
+
 /**
  * Keeps Mapsforge's hillshade index focused on roots that contain real elevation data.
  *
  * A DEM root can exist with only partial downloads or `.missing` markers. Passing that root to
  * Mapsforge makes it look like the preferred source is available even though there is nothing it
- * can render. In particular, Detailed selected with only Standard installed must use the exact
- * same single-root path as Standard selected.
+ * can render. Relevant roots remain in priority order so Detailed cells shadow Standard cells,
+ * while Standard can fill individual gaps in Detailed coverage.
  */
 internal fun resolveHillshadeDemRootDirs(
     demRootDirs: List<File>,
     requiredTileIds: Set<String>? = null,
-): List<File> {
+): List<File> =
     if (requiredTileIds.isNullOrEmpty()) {
-        return demRootDirs.filter(::containsHillshadeDemFile)
-    }
-
-    val coverageByRoot =
-        demRootDirs.map { root ->
-            root to requiredTileIds.count { tileId -> root.containsHillshadeDemTile(tileId) }
-        }
-
-    // Prefer one complete source. Detailed selected with incomplete or unrelated coverage must
-    // resolve to complete Standard terrain instead of building a mixed hillshade index.
-    val completeRoot =
-        coverageByRoot
-            .firstOrNull { (_, availableTiles) -> availableTiles == requiredTileIds.size }
-
-    // Neither source covers the whole map. Retain only roots that can contribute relevant tiles,
-    // preserving the selected-to-fallback preference order.
-    return if (completeRoot != null) {
-        listOf(completeRoot.first)
+        demRootDirs.filter(::containsHillshadeDemFile)
     } else {
-        coverageByRoot
-            .filter { (_, availableTiles) -> availableTiles > 0 }
-            .map { (root, _) -> root }
+        val coverageByRoot =
+            demRootDirs.map { root ->
+                root to requiredTileIds.count { tileId -> root.containsHillshadeDemTile(tileId) }
+            }
+
+        // If the preferred Detailed source covers the whole map, Standard cannot contribute.
+        // Otherwise keep every relevant root in preference order so each missing Detailed cell
+        // can fall back independently to its Standard counterpart.
+        val preferredCoverage = coverageByRoot.firstOrNull()?.second ?: 0
+        if (preferredCoverage == requiredTileIds.size) {
+            listOf(coverageByRoot.first().first)
+        } else {
+            coverageByRoot
+                .filter { (_, availableTiles) -> availableTiles > 0 }
+                .map { (root, _) -> root }
+        }
     }
-}
 
 private fun containsHillshadeDemFile(root: File): Boolean {
     if (!root.exists() || !root.isDirectory) return false
@@ -119,7 +158,9 @@ private fun File.containsHillshadeDemTile(tileId: String): Boolean {
     return exists() &&
         isDirectory &&
         normalizedTileId.length >= 3 &&
-        hillshadeDemTileCandidates(normalizedTileId).any { candidate -> candidate.isFile }
+        hillshadeDemTileCandidates(normalizedTileId).any { candidate ->
+            candidate.isFile && candidate.length() > 0L
+        }
 }
 
 private fun File.hillshadeDemTileCandidates(tileId: String): Sequence<File> {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsforgeHillshadeDemInputLimiter.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsforgeHillshadeDemInputLimiter.kt
@@ -1,0 +1,155 @@
+package com.glancemap.glancemapwearos.presentation.features.maps
+
+import org.mapsforge.map.layer.hills.DemFile
+import org.mapsforge.map.layer.hills.HgtFileInfo
+import java.io.InputStream
+
+/**
+ * Makes high-resolution DEMs affordable for the watch before Mapsforge reads them into memory.
+ *
+ * Mapsforge derives the allocation size solely from [DemFile.size]. Reducing its shading output
+ * after that point still leaves it to allocate a full 3600x3600 Detailed HGT grid. This wrapper
+ * exposes every nth source sample instead, retaining the Detailed source while bounding the input
+ * grid that Mapsforge sees.
+ */
+internal fun limitHillshadeDemFileInput(
+    demFile: DemFile,
+    maxAxisLen: Int = WEAR_HILLSHADE_MAX_INPUT_AXIS,
+): DemFile {
+    val sourceAxisLen = HgtFileInfo.computeAxisLen(demFile.size)
+    val stride = hillshadeInputDownsamplingStride(sourceAxisLen, maxAxisLen)
+    return if (stride == 1) demFile else DownsampledHgtDemFile(demFile, sourceAxisLen, stride)
+}
+
+internal fun hillshadeInputDownsamplingStride(
+    sourceAxisLen: Int,
+    maxAxisLen: Int = WEAR_HILLSHADE_MAX_INPUT_AXIS,
+): Int {
+    if (sourceAxisLen <= maxAxisLen || sourceAxisLen <= 0) return 1
+
+    var stride = ((sourceAxisLen + maxAxisLen - 1) / maxAxisLen).coerceAtLeast(1)
+    while (sourceAxisLen % stride != 0) {
+        stride += 1
+    }
+    return stride
+}
+
+private class DownsampledHgtDemFile(
+    private val source: DemFile,
+    private val sourceAxisLen: Int,
+    private val stride: Int,
+) : DemFile {
+    private val outputAxisLen = sourceAxisLen / stride
+    private val outputSize = (outputAxisLen + 1L) * (outputAxisLen + 1L) * HGT_SAMPLE_BYTES
+
+    init {
+        require(sourceAxisLen > 0)
+        require(stride > 1)
+        require(sourceAxisLen % stride == 0)
+    }
+
+    override fun getName(): String = source.name
+
+    override fun getSize(): Long = outputSize
+
+    override fun openInputStream(bufferSize: Int): InputStream =
+        DownsamplingHgtInputStream(
+            source = source.openInputStream(bufferSize),
+            sourceAxisLen = sourceAxisLen,
+            stride = stride,
+        )
+
+    override fun asStream(): InputStream =
+        DownsamplingHgtInputStream(
+            source = source.asStream(),
+            sourceAxisLen = sourceAxisLen,
+            stride = stride,
+        )
+
+    override fun asRawStream(): InputStream =
+        DownsamplingHgtInputStream(
+            source = source.asRawStream(),
+            sourceAxisLen = sourceAxisLen,
+            stride = stride,
+        )
+}
+
+private class DownsamplingHgtInputStream(
+    private val source: InputStream,
+    sourceAxisLen: Int,
+    private val stride: Int,
+) : InputStream() {
+    private val sourcePointCount = sourceAxisLen + 1
+    private val outputPointCount = (sourceAxisLen / stride) + 1
+    private val sourceRow = ByteArray(sourcePointCount * HGT_SAMPLE_BYTES)
+    private val outputRow = ByteArray(outputPointCount * HGT_SAMPLE_BYTES)
+    private var emittedRowCount = 0
+    private var outputOffset = outputRow.size
+
+    override fun read(): Int {
+        if (!ensureOutputRow()) return -1
+        return outputRow[outputOffset++].toInt() and BYTE_MASK
+    }
+
+    override fun read(
+        buffer: ByteArray,
+        offset: Int,
+        length: Int,
+    ): Int {
+        require(offset >= 0 && length >= 0 && offset <= buffer.size - length)
+        if (length == 0) return 0
+
+        var written = 0
+        while (written < length && ensureOutputRow()) {
+            val available = outputRow.size - outputOffset
+            val count = minOf(length - written, available)
+            outputRow.copyInto(
+                destination = buffer,
+                destinationOffset = offset + written,
+                startIndex = outputOffset,
+                endIndex = outputOffset + count,
+            )
+            outputOffset += count
+            written += count
+        }
+        return written.takeIf { it > 0 } ?: -1
+    }
+
+    override fun close() {
+        source.close()
+    }
+
+    private fun ensureOutputRow(): Boolean =
+        when {
+            outputOffset < outputRow.size -> true
+            emittedRowCount >= outputPointCount -> false
+            else -> {
+                if (emittedRowCount > 0) {
+                    repeat(stride - 1) { readFully(sourceRow) }
+                }
+                readFully(sourceRow)
+
+                var sourceOffset = 0
+                outputRow.indices.step(HGT_SAMPLE_BYTES).forEach { outputIndex ->
+                    outputRow[outputIndex] = sourceRow[sourceOffset]
+                    outputRow[outputIndex + 1] = sourceRow[sourceOffset + 1]
+                    sourceOffset += stride * HGT_SAMPLE_BYTES
+                }
+                emittedRowCount += 1
+                outputOffset = 0
+                true
+            }
+        }
+
+    private fun readFully(destination: ByteArray) {
+        var offset = 0
+        while (offset < destination.size) {
+            val count = source.read(destination, offset, destination.size - offset)
+            if (count <= 0) throw java.io.EOFException("Incomplete HGT input")
+            offset += count
+        }
+    }
+}
+
+private const val HGT_SAMPLE_BYTES = 2
+private const val BYTE_MASK = 0xff

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/maps/theme/ThemeViewModel.kt
@@ -70,6 +70,7 @@ data class DemDownloadUiState(
 
 data class DemMapReadiness(
     val isReady: Boolean,
+    val hasAnyTerrain: Boolean,
     val selectedSource: DemSource,
     val usesFallbackTerrain: Boolean,
 )
@@ -457,6 +458,7 @@ class ThemeViewModel(
                     ?.let(::File)
                     ?: return@withContext DemMapReadiness(
                         isReady = false,
+                        hasAnyTerrain = false,
                         selectedSource = selectedSource,
                         usesFallbackTerrain = false,
                     )
@@ -474,6 +476,7 @@ class ThemeViewModel(
                 )
             DemMapReadiness(
                 isReady = runtimeCoverage.isReady,
+                hasAnyTerrain = runtimeCoverage.availableTiles > 0,
                 selectedSource = selectedSource,
                 usesFallbackTerrain = runtimeCoverage.isReady && !selectedCoverage.isReady,
             )

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/screen/NavigateScreen.kt
@@ -29,6 +29,8 @@ import com.glancemap.glancemapwearos.data.repository.SettingsRepository
 import com.glancemap.glancemapwearos.data.repository.UserPoiRecord
 import com.glancemap.glancemapwearos.domain.sensors.CompassViewModel
 import com.glancemap.glancemapwearos.presentation.features.gpx.GpxViewModel
+import com.glancemap.glancemapwearos.presentation.features.maps.DemSetupBottomSheet
+import com.glancemap.glancemapwearos.presentation.features.maps.DemSetupReason
 import com.glancemap.glancemapwearos.presentation.features.maps.MapHolder
 import com.glancemap.glancemapwearos.presentation.features.maps.MapRenderer
 import com.glancemap.glancemapwearos.presentation.features.maps.MapViewModel
@@ -158,6 +160,13 @@ fun NavigateScreen(
         notificationPermissionState.copy(
             launchPermissionRequest = { showNotificationPermissionDialog = true },
         )
+
+    val hillshadeTerrainUnavailableEvent by mapViewModel.hillshadeTerrainUnavailableEvent.collectAsState()
+    DemSetupBottomSheet(
+        visible = hillshadeTerrainUnavailableEvent != null,
+        reason = DemSetupReason.HILL_SHADING_VISIBLE_AREA,
+        onDismiss = mapViewModel::dismissHillshadeTerrainUnavailable,
+    )
 
     // ---- SETTINGS ----
     val navigateSettings = collectNavigateSettingsState(settingsViewModel)

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/DebuggingSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/DebuggingSettingsScreen.kt
@@ -201,7 +201,6 @@ fun DebuggingSettingsScreen(
             )
             ScreenStateDiagnostics.configure(captureActive = true)
             CompassHeadingDiagnostics.reset()
-            DebugTelemetry.setEnabled(fullDiagnostics)
             DebugTelemetry.log(
                 "DiagnosticsFlow",
                 "capture enabled mode=$diagnosticsCaptureMode",
@@ -221,7 +220,6 @@ fun DebuggingSettingsScreen(
                 detail = "source=debug_screen",
             )
             CompassHeadingDiagnostics.flush(reason = "capture_toggle_off")
-            DebugTelemetry.setEnabled(false)
             CompassHeadingDiagnostics.reset()
             EnergyDiagnostics.configure(captureActive = false, fullDiagnostics = false)
             ScreenStateDiagnostics.configure(captureActive = false)
@@ -450,6 +448,7 @@ fun DebuggingSettingsScreen(
                         exportDialogMode = DiagnosticsExportDialogMode.GENERATING
                         exportDialogMessage = "Generating diagnostics file..."
                         val captureWasEnabled = gpsDebugTelemetry
+                        var captureFrozenForExport = false
                         try {
                             CompassDeepTraceDiagnostics.stop(reason = "export")
                             val hasBufferedLogs =
@@ -478,7 +477,8 @@ fun DebuggingSettingsScreen(
                                 )
                                 CompassHeadingDiagnostics.flush(reason = "capture_export")
                                 viewModel.setGpsDebugTelemetry(false)
-                                DebugTelemetry.setEnabled(false)
+                                DebugTelemetry.freezeForExport()
+                                captureFrozenForExport = true
                                 CompassHeadingDiagnostics.reset()
                                 EnergyDiagnostics.configure(captureActive = false, fullDiagnostics = false)
                                 ScreenStateDiagnostics.configure(captureActive = false)
@@ -636,7 +636,9 @@ fun DebuggingSettingsScreen(
                                 "Export failed.\nTap Resend Diagnostic to try again."
                         } finally {
                             viewModel.setGpsDebugTelemetry(false)
-                            DebugTelemetry.setEnabled(false)
+                            if (captureWasEnabled && !captureFrozenForExport) {
+                                DebugTelemetry.freezeForExport()
+                            }
                             EnergyDiagnostics.configure(captureActive = false, fullDiagnostics = false)
                             ScreenStateDiagnostics.configure(captureActive = false)
                             if (exportDialogMode == DiagnosticsExportDialogMode.GENERATING) {

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/MapSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/MapSettingsScreen.kt
@@ -196,8 +196,11 @@ fun MapSettingsScreen(
                         themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_HILL_SHADING_ID, false)
                     } else {
                         scope.launch {
-                            val demReady = themeViewModel.demReadinessForMap(selectedMapPath).isReady
-                            if (demReady) {
+                            val terrainAvailable =
+                                themeViewModel
+                                    .demReadinessForMap(selectedMapPath)
+                                    .hasAnyTerrain
+                            if (terrainAvailable) {
                                 themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_HILL_SHADING_ID, true)
                             } else {
                                 themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_HILL_SHADING_ID, false)

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/MapSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/MapSettingsScreen.kt
@@ -196,6 +196,12 @@ fun MapSettingsScreen(
                         themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_HILL_SHADING_ID, false)
                     } else {
                         scope.launch {
+                            if (selectedMapPath.isNullOrBlank()) {
+                                themeViewModel.setGlobalToggle(ThemeRepositoryImpl.GLOBAL_HILL_SHADING_ID, false)
+                                demSetupReason = DemSetupReason.HILL_SHADING_MAP_REQUIRED
+                                showDemSetupDialog = true
+                                return@launch
+                            }
                             val terrainAvailable =
                                 themeViewModel
                                     .demReadinessForMap(selectedMapPath)

--- a/app/src/test/java/com/glancemap/glancemapwearos/core/service/diagnostics/DebugTelemetryExportFreezeTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/core/service/diagnostics/DebugTelemetryExportFreezeTest.kt
@@ -1,0 +1,44 @@
+package com.glancemap.glancemapwearos.core.service.diagnostics
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class DebugTelemetryExportFreezeTest {
+    @Before
+    fun setUp() {
+        DebugTelemetry.setTransitionMarkersEnabledForTests(false)
+        DebugTelemetry.setEnabledFromLocationService(false)
+        DebugTelemetry.clear()
+    }
+
+    @After
+    fun tearDown() {
+        DebugTelemetry.setEnabledFromLocationService(false)
+        DebugTelemetry.clear()
+        DebugTelemetry.setTransitionMarkersEnabledForTests(true)
+    }
+
+    @Test
+    fun exportFreezeIgnoresStaleEnableUntilPersistedDisableArrives() {
+        DebugTelemetry.setEnabledFromLocationService(true)
+        val firstSession = DebugTelemetry.captureSessionSnapshot()
+
+        DebugTelemetry.freezeForExport()
+        DebugTelemetry.setEnabledFromLocationService(true)
+
+        val frozenSession = DebugTelemetry.captureSessionSnapshot()
+        assertFalse(frozenSession.active)
+        assertEquals(firstSession.sessionId, frozenSession.sessionId)
+
+        DebugTelemetry.setEnabledFromLocationService(false)
+        DebugTelemetry.setEnabledFromLocationService(true)
+
+        val nextSession = DebugTelemetry.captureSessionSnapshot()
+        assertTrue(nextSession.active)
+        assertEquals(firstSession.sessionId + 1L, nextSession.sessionId)
+    }
+}

--- a/app/src/test/java/com/glancemap/glancemapwearos/core/service/diagnostics/EnergyDiagnosticsTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/core/service/diagnostics/EnergyDiagnosticsTest.kt
@@ -11,7 +11,7 @@ import org.junit.Test
 class EnergyDiagnosticsTest {
     @Before
     fun setUp() {
-        DebugTelemetry.setEnabled(false)
+        DebugTelemetry.setEnabledFromLocationService(false)
         DebugTelemetry.clear()
         EnergyDiagnostics.clear()
         EnergyDiagnostics.setEnabled(false)
@@ -19,7 +19,7 @@ class EnergyDiagnosticsTest {
 
     @After
     fun tearDown() {
-        DebugTelemetry.setEnabled(false)
+        DebugTelemetry.setEnabledFromLocationService(false)
         DebugTelemetry.clear()
         EnergyDiagnostics.clear()
         EnergyDiagnostics.setEnabled(false)

--- a/app/src/test/java/com/glancemap/glancemapwearos/domain/sensors/FusedHeadingIntegrityEngineTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/domain/sensors/FusedHeadingIntegrityEngineTest.kt
@@ -36,6 +36,26 @@ class FusedHeadingIntegrityEngineTest {
     }
 
     @Test
+    fun acquiringDoesNotDisplaceSeedHeadingForAnUnverifiedFirstSample() {
+        val engine = integrityEngine()
+        engine.reset(
+            seedHeadingDeg = 100f,
+            atElapsedMs = 1_000L,
+            clearSensorEvidence = true,
+        )
+        val replay = Replay(engine, nowElapsedMs = 1_000L)
+
+        replay.magnetic(42f)
+        replay.advance(200L)
+        replay.magnetic(42f)
+        val snapshot = replay.absolute(headingDeg = 2f)
+
+        assertEquals(CompassTrackingState.ACQUIRING, snapshot.state)
+        assertEquals(100f, requireNotNull(snapshot.renderHeadingDeg), ANGLE_TOLERANCE_DEG)
+        assertFalse(snapshot.trusted)
+    }
+
+    @Test
     fun persistentWitnessDisagreementIsSuppressedAndCannotSteerTheMap() {
         val replay = Replay(integrityEngine())
         replay.acquireStableHeading(headingDeg = 10f)

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRendererHillshadeConfigTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRendererHillshadeConfigTest.kt
@@ -33,6 +33,31 @@ class MapRendererHillshadeConfigTest {
     }
 
     @Test
+    fun baseMapStartupPrewarmingIsDisabledWhileHillshadeIsActive() {
+        assertFalse(
+            shouldWarmMapStartupTileCache(
+                prewarmingEnabled = true,
+                skipNextStartupPrewarm = false,
+                hillshadeEnabled = true,
+            ),
+        )
+        assertTrue(
+            shouldWarmMapStartupTileCache(
+                prewarmingEnabled = true,
+                skipNextStartupPrewarm = false,
+                hillshadeEnabled = false,
+            ),
+        )
+        assertFalse(
+            shouldWarmMapStartupTileCache(
+                prewarmingEnabled = true,
+                skipNextStartupPrewarm = true,
+                hillshadeEnabled = false,
+            ),
+        )
+    }
+
+    @Test
     fun detailedTerrainOutputIsCappedAboveStandardResolution() {
         assertTrue(WEAR_HILLSHADE_MAX_OUTPUT_AXIS > 1200)
         assertEquals(-2, resolveWearHillshadeQualityFactor(inputAxisLen = 3600, adaptiveQualityFactor = 1))

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRendererHillshadeConfigTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRendererHillshadeConfigTest.kt
@@ -1,0 +1,44 @@
+package com.glancemap.glancemapwearos.presentation.features.maps
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MapRendererHillshadeConfigTest {
+    @Test
+    fun wearAlgorithmUsesAdaptiveResolutionWithoutHighQualityUpscaling() {
+        val algorithm = createWearHillShadingAlgorithm()
+
+        assertTrue(algorithm.isAdaptiveZoomEnabled)
+        assertFalse(algorithm.isHqEnabled)
+        assertEquals(WEAR_HILLSHADE_QUALITY_SCALE, algorithm.customQualityScale, 0.0)
+    }
+
+    @Test
+    fun hillshadeCacheIdentityChangesWithDemSourceAndContent() {
+        val standard =
+            resolveMapRendererHillshadeCacheId(
+                baseCacheId = "mapcache_base",
+                demSourceId = "mapsforge_dem3",
+                demSignature = "DEM:one",
+            )
+        val detailed =
+            resolveMapRendererHillshadeCacheId(
+                baseCacheId = "mapcache_base",
+                demSourceId = "mapzen_skadi_1s",
+                demSignature = "DEM:one",
+            )
+        val updated =
+            resolveMapRendererHillshadeCacheId(
+                baseCacheId = "mapcache_base",
+                demSourceId = "mapsforge_dem3",
+                demSignature = "DEM:two",
+            )
+
+        assertNotEquals(standard, detailed)
+        assertNotEquals(standard, updated)
+        assertTrue(standard.startsWith("mapcache_hillshade_"))
+    }
+}

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRendererHillshadeConfigTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRendererHillshadeConfigTest.kt
@@ -33,6 +33,14 @@ class MapRendererHillshadeConfigTest {
     }
 
     @Test
+    fun detailedTerrainOutputIsCappedAboveStandardResolution() {
+        assertTrue(WEAR_HILLSHADE_MAX_OUTPUT_AXIS > 1200)
+        assertEquals(-2, resolveWearHillshadeQualityFactor(inputAxisLen = 3600, adaptiveQualityFactor = 1))
+        assertEquals(1, resolveWearHillshadeQualityFactor(inputAxisLen = 1200, adaptiveQualityFactor = 1))
+        assertEquals(-3, resolveWearHillshadeQualityFactor(inputAxisLen = 3600, adaptiveQualityFactor = -3))
+    }
+
+    @Test
     fun hillshadeCacheIdentityChangesWithDemSourceAndContent() {
         val standard =
             resolveMapRendererHillshadeCacheId(

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRendererHillshadeConfigTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/MapRendererHillshadeConfigTest.kt
@@ -14,6 +14,22 @@ class MapRendererHillshadeConfigTest {
         assertTrue(algorithm.isAdaptiveZoomEnabled)
         assertFalse(algorithm.isHqEnabled)
         assertEquals(WEAR_HILLSHADE_QUALITY_SCALE, algorithm.customQualityScale, 0.0)
+        assertEquals(WEAR_HILLSHADE_MIN_ZOOM_LEVEL, algorithm.zoomMinOverride)
+    }
+
+    @Test
+    fun wearAlgorithmConstrainsDemConcurrencyAndPreprocessing() {
+        val params = createWearHillShadingParams()
+
+        assertEquals(1, params.readingThreadsCount)
+        assertEquals(1, params.computingThreadsCount)
+        assertFalse(params.isPreprocess)
+    }
+
+    @Test
+    fun hillshadeRenderingStartsOnlyAtDetailedZoom() {
+        assertFalse(shouldRenderHillshadeAtZoom((WEAR_HILLSHADE_MIN_ZOOM_LEVEL - 1).toByte()))
+        assertTrue(shouldRenderHillshadeAtZoom(WEAR_HILLSHADE_MIN_ZOOM_LEVEL.toByte()))
     }
 
     @Test

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsforgeHillshadeDemFolderTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsforgeHillshadeDemFolderTest.kt
@@ -1,20 +1,25 @@
 package com.glancemap.glancemapwearos.presentation.features.maps
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mapsforge.map.layer.hills.DemFile
+import org.mapsforge.map.layer.hills.HgtFileInfo
+import java.io.ByteArrayInputStream
 import java.io.File
+import java.io.InputStream
 import java.nio.file.Files
 
 class MapsforgeHillshadeDemFolderTest {
     @Test
     fun folderExposesOnlyDemTilesRequiredByCurrentMap() {
         val root = Files.createTempDirectory("hillshade-folder").toFile()
-        File(root, "N46/N46E006.hgt.zip").apply {
+        File(root, "N46/N46E006.hgt").apply {
             parentFile?.mkdirs()
             writeText("required")
         }
-        File(root, "N46/N46E007.hgt.zip").writeText("unrelated")
+        File(root, "N46/N46E007.hgt").writeText("unrelated")
         File(root, "N47/N47E006.hgt.gz").apply {
             parentFile?.mkdirs()
             writeText("unrelated")
@@ -189,4 +194,54 @@ class MapsforgeHillshadeDemFolderTest {
         assertEquals(1, demFiles.count())
         root.deleteRecursively()
     }
+
+    @Test
+    fun detailedDemIsDownsampledBeforeMapsforgeCalculatesItsGrid() {
+        val detailed = InMemoryDemFile(axisLen = 6)
+
+        val limited = limitHillshadeDemFileInput(detailed, maxAxisLen = 3)
+
+        assertEquals(2, hillshadeInputDownsamplingStride(sourceAxisLen = 6, maxAxisLen = 3))
+        assertEquals(3, HgtFileInfo.computeAxisLen(limited.size))
+        assertEquals(
+            listOf(0, 2, 4, 6, 14, 16, 18, 20, 28, 30, 32, 34, 42, 44, 46, 48),
+            limited.asRawStream().readBytes().toHgtSamples(),
+        )
+    }
+
+    @Test
+    fun standardDemIsNotDownsampled() {
+        val standard = InMemoryDemFile(axisLen = 3)
+
+        assertSame(standard, limitHillshadeDemFileInput(standard, maxAxisLen = 3))
+    }
+
+    private class InMemoryDemFile(
+        axisLen: Int,
+    ) : DemFile {
+        private val bytes =
+            ByteArray((axisLen + 1) * (axisLen + 1) * 2).also { output ->
+                repeat((axisLen + 1) * (axisLen + 1)) { sample ->
+                    output[sample * 2] = (sample shr 8).toByte()
+                    output[(sample * 2) + 1] = sample.toByte()
+                }
+            }
+
+        override fun getName(): String = "N00E000.hgt"
+
+        override fun getSize(): Long = bytes.size.toLong()
+
+        override fun openInputStream(bufferSize: Int): InputStream = ByteArrayInputStream(bytes)
+
+        override fun asStream(): InputStream = ByteArrayInputStream(bytes)
+
+        override fun asRawStream(): InputStream = ByteArrayInputStream(bytes)
+    }
 }
+
+private fun ByteArray.toHgtSamples(): List<Int> =
+    indices
+        .step(2)
+        .map { index ->
+            ((this[index].toInt() and 0xff) shl 8) or (this[index + 1].toInt() and 0xff)
+        }

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsforgeHillshadeDemFolderTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsforgeHillshadeDemFolderTest.kt
@@ -8,6 +8,29 @@ import java.nio.file.Files
 
 class MapsforgeHillshadeDemFolderTest {
     @Test
+    fun folderExposesOnlyDemTilesRequiredByCurrentMap() {
+        val root = Files.createTempDirectory("hillshade-folder").toFile()
+        File(root, "N46/N46E006.hgt.zip").apply {
+            parentFile?.mkdirs()
+            writeText("required")
+        }
+        File(root, "N46/N46E007.hgt.zip").writeText("unrelated")
+        File(root, "N47/N47E006.hgt.gz").apply {
+            parentFile?.mkdirs()
+            writeText("unrelated")
+        }
+
+        val files =
+            MapsforgeHillshadeDemFolder(
+                demRootDirs = listOf(root),
+                requiredTileIds = setOf("n46e006"),
+            ).files()
+
+        assertEquals(listOf("N46E006.hgt"), files.map { demFile -> demFile.name })
+        root.deleteRecursively()
+    }
+
+    @Test
     fun detailedWithoutRealTilesFallsBackToStandardRootOnly() {
         val root = Files.createTempDirectory("hillshade-roots").toFile()
         val detailed = File(root, "dem1").apply { mkdirs() }

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsforgeHillshadeDemFolderTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/maps/MapsforgeHillshadeDemFolderTest.kt
@@ -104,7 +104,7 @@ class MapsforgeHillshadeDemFolderTest {
     }
 
     @Test
-    fun completeStandardCoverageWinsOverPartialDetailedCoverage() {
+    fun partialDetailedCoverageUsesStandardPerTileFallback() {
         val root = Files.createTempDirectory("hillshade-roots").toFile()
         val detailed = File(root, "dem1").apply { mkdirs() }
         val standard = File(root, "dem3").apply { mkdirs() }
@@ -118,7 +118,7 @@ class MapsforgeHillshadeDemFolderTest {
                 requiredTileIds = setOf("N46E006", "N46E007"),
             )
 
-        assertEquals(listOf(standard), resolved)
+        assertEquals(listOf(detailed, standard), resolved)
         root.deleteRecursively()
     }
 
@@ -139,6 +139,54 @@ class MapsforgeHillshadeDemFolderTest {
             )
 
         assertEquals(listOf(detailed), resolved)
+        root.deleteRecursively()
+    }
+
+    @Test
+    fun visibleCoverageCountsDetailedFallbackAndMissingCells() {
+        val root = Files.createTempDirectory("hillshade-roots").toFile()
+        val detailed = File(root, "dem1").apply { mkdirs() }
+        val standard = File(root, "dem3").apply { mkdirs() }
+        File(detailed, "N46E006.hgt.gz").writeText("detailed")
+        File(standard, "N46E006.hgt.zip").writeText("shadowed-standard")
+        File(standard, "N46E007.hgt.zip").writeText("fallback-standard")
+
+        val coverage =
+            resolveVisibleHillshadeTerrainCoverage(
+                demRootDirs = listOf(detailed, standard),
+                requiredTileIds = setOf("N46E006", "N46E007", "N46E008"),
+            )
+
+        assertEquals(1, coverage.detailedTileCount)
+        assertEquals(1, coverage.standardFallbackTileCount)
+        assertEquals(1, coverage.missingTileCount)
+        assertEquals(2, coverage.availableTileCount)
+        assertTrue(coverage.hasAnyTerrain)
+        root.deleteRecursively()
+    }
+
+    @Test
+    fun emptyDetailedCellDoesNotShadowStandardFallback() {
+        val root = Files.createTempDirectory("hillshade-roots").toFile()
+        val detailed = File(root, "dem1").apply { mkdirs() }
+        val standard = File(root, "dem3").apply { mkdirs() }
+        File(detailed, "N46E006.hgt").createNewFile()
+        File(standard, "N46E006.hgt").writeText("fallback-standard")
+
+        val coverage =
+            resolveVisibleHillshadeTerrainCoverage(
+                demRootDirs = listOf(detailed, standard),
+                requiredTileIds = setOf("N46E006"),
+            )
+        val demFiles =
+            MapsforgeHillshadeDemFolder(
+                demRootDirs = listOf(detailed, standard),
+                requiredTileIds = setOf("N46E006"),
+            ).files()
+
+        assertEquals(0, coverage.detailedTileCount)
+        assertEquals(1, coverage.standardFallbackTileCount)
+        assertEquals(1, demFiles.count())
         root.deleteRecursively()
     }
 }

--- a/glancemapcompanionapp/build.gradle.kts
+++ b/glancemapcompanionapp/build.gradle.kts
@@ -107,7 +107,7 @@ android {
             useSupportLibrary = true
         }
         manifestPlaceholders["channelBufferSize"] = "8388608" // 8MB buffer
-        buildConfigField("String", "ARKLUZ_TRACKING_URL", "\"https://arkluz.com/dev/trk\"")
+        buildConfigField("String", "ARKLUZ_TRACKING_URL", "\"https://arkluz.com/trk\"")
         buildConfigField("String", "ARKLUZ_SMS_API_KEY", "\"$arkluzSmsApiKey\"")
     }
 

--- a/glancemapcompanionapp/build.gradle.kts
+++ b/glancemapcompanionapp/build.gradle.kts
@@ -107,7 +107,7 @@ android {
             useSupportLibrary = true
         }
         manifestPlaceholders["channelBufferSize"] = "8388608" // 8MB buffer
-        buildConfigField("String", "ARKLUZ_TRACKING_URL", "\"https://arkluz.com/trk\"")
+        buildConfigField("String", "ARKLUZ_TRACKING_URL", "\"https://arkluz.com/dev/trk\"")
         buildConfigField("String", "ARKLUZ_SMS_API_KEY", "\"$arkluzSmsApiKey\"")
     }
 

--- a/glancemapcompanionapp/src/main/AndroidManifest.xml
+++ b/glancemapcompanionapp/src/main/AndroidManifest.xml
@@ -6,8 +6,10 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/ArkluzLiveTrackingClient.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/ArkluzLiveTrackingClient.kt
@@ -643,7 +643,7 @@ internal fun buildArkluzLocationUrl(update: ArkluzLocationUpdate): HttpUrl {
             .addQueryParameter("pass", update.participantPassword)
             .addQueryParameter("user", update.userName)
 
-    update.altitudeMeters?.let { urlBuilder.addQueryParameter("alt", it.toString()) }
+    update.altitudeMeters?.let { urlBuilder.addQueryParameter("alt", formatArkluzAltitudeMeters(it)) }
     update.speedMetersPerSecond?.let { urlBuilder.addQueryParameter("speed", it.toString()) }
     update.notificationEmails.takeIf(String::isNotBlank)?.let { urlBuilder.addQueryParameter("email", it) }
     update.alertEmails.takeIf(String::isNotBlank)?.let { urlBuilder.addQueryParameter("alert", it) }
@@ -655,6 +655,8 @@ internal fun buildArkluzLocationUrl(update: ArkluzLocationUpdate): HttpUrl {
     update.dateId?.takeIf(String::isNotBlank)?.let { urlBuilder.addQueryParameter("date_id", it) }
     return urlBuilder.build()
 }
+
+internal fun formatArkluzAltitudeMeters(altitudeMeters: Double): String = String.format(Locale.US, "%.1f", altitudeMeters)
 
 internal fun buildArkluzSmsSupportUrl(
     trackingUrl: String,

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/ArkluzLiveTrackingClient.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/ArkluzLiveTrackingClient.kt
@@ -129,6 +129,7 @@ internal class ArkluzLiveTrackingClient(
                         .Builder()
                         .setType(MultipartBody.FORM)
                         .addFormDataPart("q", "upload")
+                        .addFormDataPart("api", "1")
                         .addFormDataPart("group", settings.group.trim())
                         .addFormDataPart("pass", settings.participantPassword.trim())
                 if (tempFile != null) {
@@ -153,6 +154,7 @@ internal class ArkluzLiveTrackingClient(
                         LiveTrackingDiagnosticRequest(
                             operation = LiveTrackingDiagnosticOperation.UPLOAD,
                         ),
+                    responseParser = String::toArkluzUploadResult,
                 )
             } finally {
                 tempFile?.delete()
@@ -405,6 +407,7 @@ internal class ArkluzLiveTrackingClient(
     private fun execute(
         request: Request,
         diagnosticRequest: LiveTrackingDiagnosticRequest,
+        responseParser: (String) -> ArkluzServerResult = String::toArkluzServerResult,
     ): ArkluzServerResult =
         withDiagnostics(diagnosticRequest) { recordOutcome ->
             httpClient.newCall(request).execute().use { response ->
@@ -420,8 +423,14 @@ internal class ArkluzLiveTrackingClient(
                     recordOutcome(LiveTrackingDiagnosticResult.SERVER_REJECTED, response.code)
                     error(serverMessage)
                 }
+                val serverResult =
+                    runCatching { responseParser(serverMessage) }
+                        .getOrElse { error ->
+                            recordOutcome(LiveTrackingDiagnosticResult.SERVER_REJECTED, response.code)
+                            throw error
+                        }
                 recordOutcome(LiveTrackingDiagnosticResult.SUCCESS, response.code)
-                serverMessage.toArkluzServerResult()
+                serverResult
             }
         }
 
@@ -772,6 +781,14 @@ private fun String.toArkluzServerResult(): ArkluzServerResult {
         responseValue = responseValue,
         groupAvailable = equals("group available", ignoreCase = true),
     )
+}
+
+internal fun String.toArkluzUploadResult(): ArkluzServerResult {
+    val response = trim()
+    check(response.equals("OK", ignoreCase = true)) {
+        response.ifBlank { "Arkluz did not confirm the upload." }
+    }
+    return ArkluzServerResult(message = "Comment sent")
 }
 
 internal fun String.toArkluzSmsSupport(): ArkluzSmsSupport =

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/ArkluzLiveTrackingClient.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/ArkluzLiveTrackingClient.kt
@@ -665,7 +665,9 @@ internal fun buildArkluzLocationUrl(update: ArkluzLocationUpdate): HttpUrl {
     return urlBuilder.build()
 }
 
-internal fun formatArkluzAltitudeMeters(altitudeMeters: Double): String = String.format(Locale.US, "%.1f", altitudeMeters)
+internal fun formatArkluzAltitudeMeters(
+    altitudeMeters: Double,
+): String = String.format(Locale.US, "%.1f", altitudeMeters)
 
 internal fun buildArkluzSmsSupportUrl(
     trackingUrl: String,

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingActiveSessionStore.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingActiveSessionStore.kt
@@ -1,0 +1,115 @@
+package com.glancemap.glancemapcompanionapp.livetracking
+
+import android.content.Context
+import android.net.Uri
+
+/**
+ * Makes an explicitly started live-tracking session recoverable if Android recreates its
+ * foreground-service process. The record is removed as soon as the user stops tracking.
+ */
+internal object LiveTrackingActiveSessionStore {
+    private const val PREFS_NAME = "arkluz_live_tracking_active_session"
+    private const val KEY_ACTIVE = "active"
+    private const val KEY_TRACKING_URL = "tracking_url"
+    private const val KEY_UPDATE_INTERVAL_SECONDS = "update_interval_seconds"
+    private const val KEY_GROUP = "group"
+    private const val KEY_PARTICIPANT_PASSWORD = "participant_password"
+    private const val KEY_FOLLOWER_PASSWORD = "follower_password"
+    private const val KEY_USER_NAME = "user_name"
+    private const val KEY_NOTIFICATION_EMAILS = "notification_emails"
+    private const val KEY_ALERT_EMAILS = "alert_emails"
+    private const val KEY_STUCK_ALARM_MINUTES = "stuck_alarm_minutes"
+    private const val KEY_COMMENTS = "comments"
+    private const val KEY_GPX_URI = "gpx_uri"
+    private const val KEY_GPX_NAME = "gpx_name"
+    private const val KEY_PAUSED = "paused"
+    private const val KEY_SENT_START = "sent_start"
+    private const val KEY_DATE_ID = "date_id"
+
+    internal data class Session(
+        val settings: LiveTrackingSettings,
+        val isPaused: Boolean,
+        val sentStart: Boolean,
+        val dateId: String?,
+    )
+
+    fun save(
+        context: Context,
+        settings: LiveTrackingSettings,
+        isPaused: Boolean,
+        sentStart: Boolean,
+        dateId: String?,
+    ) {
+        context
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(KEY_ACTIVE, true)
+            .putString(KEY_TRACKING_URL, settings.trackingUrl)
+            .putInt(KEY_UPDATE_INTERVAL_SECONDS, settings.updateIntervalSeconds)
+            .putString(KEY_GROUP, settings.group)
+            .putString(KEY_PARTICIPANT_PASSWORD, settings.participantPassword)
+            .putString(KEY_FOLLOWER_PASSWORD, settings.followerPassword)
+            .putString(KEY_USER_NAME, settings.userName)
+            .putString(KEY_NOTIFICATION_EMAILS, settings.notificationEmails)
+            .putString(KEY_ALERT_EMAILS, settings.alertEmails)
+            .putString(KEY_STUCK_ALARM_MINUTES, settings.stuckAlarmMinutes)
+            .putString(KEY_COMMENTS, settings.comments)
+            .putString(KEY_GPX_URI, settings.gpxUri?.toString())
+            .putString(KEY_GPX_NAME, settings.gpxName)
+            .putBoolean(KEY_PAUSED, isPaused)
+            .putBoolean(KEY_SENT_START, sentStart)
+            .putString(KEY_DATE_ID, dateId)
+            .apply()
+    }
+
+    fun load(context: Context): Session? {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        if (!prefs.getBoolean(KEY_ACTIVE, false)) return null
+
+        val group = prefs.getString(KEY_GROUP, "").orEmpty()
+        val participantPassword = prefs.getString(KEY_PARTICIPANT_PASSWORD, "").orEmpty()
+        val userName = prefs.getString(KEY_USER_NAME, "").orEmpty()
+        if (group.isBlank() || participantPassword.isBlank() || userName.isBlank()) {
+            clear(context)
+            return null
+        }
+
+        return Session(
+            settings =
+                LiveTrackingSettings(
+                    trackingUrl =
+                        prefs
+                            .getString(KEY_TRACKING_URL, ArkluzTrackingEndpoint.defaultUrl)
+                            .orEmpty()
+                            .ifBlank { ArkluzTrackingEndpoint.defaultUrl },
+                    updateIntervalSeconds = prefs.getInt(KEY_UPDATE_INTERVAL_SECONDS, 60),
+                    group = group,
+                    participantPassword = participantPassword,
+                    followerPassword = prefs.getString(KEY_FOLLOWER_PASSWORD, "").orEmpty(),
+                    userName = userName,
+                    notificationEmails = prefs.getString(KEY_NOTIFICATION_EMAILS, "").orEmpty(),
+                    alertEmails = prefs.getString(KEY_ALERT_EMAILS, "").orEmpty(),
+                    stuckAlarmMinutes = prefs.getString(KEY_STUCK_ALARM_MINUTES, "").orEmpty(),
+                    comments = prefs.getString(KEY_COMMENTS, "").orEmpty(),
+                    gpxUri =
+                        prefs
+                            .getString(KEY_GPX_URI, "")
+                            .orEmpty()
+                            .takeIf(String::isNotBlank)
+                            ?.let(Uri::parse),
+                    gpxName = prefs.getString(KEY_GPX_NAME, "").orEmpty(),
+                ),
+            isPaused = prefs.getBoolean(KEY_PAUSED, false),
+            sentStart = prefs.getBoolean(KEY_SENT_START, false),
+            dateId = prefs.getString(KEY_DATE_ID, null),
+        )
+    }
+
+    fun clear(context: Context) {
+        context
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .apply()
+    }
+}

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingActiveSessionStore.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingActiveSessionStore.kt
@@ -69,40 +69,40 @@ internal object LiveTrackingActiveSessionStore {
         val group = prefs.getString(KEY_GROUP, "").orEmpty()
         val participantPassword = prefs.getString(KEY_PARTICIPANT_PASSWORD, "").orEmpty()
         val userName = prefs.getString(KEY_USER_NAME, "").orEmpty()
-        if (group.isBlank() || participantPassword.isBlank() || userName.isBlank()) {
+        return if (group.isBlank() || participantPassword.isBlank() || userName.isBlank()) {
             clear(context)
-            return null
+            null
+        } else {
+            Session(
+                settings =
+                    LiveTrackingSettings(
+                        trackingUrl =
+                            prefs
+                                .getString(KEY_TRACKING_URL, ArkluzTrackingEndpoint.defaultUrl)
+                                .orEmpty()
+                                .ifBlank { ArkluzTrackingEndpoint.defaultUrl },
+                        updateIntervalSeconds = prefs.getInt(KEY_UPDATE_INTERVAL_SECONDS, 60),
+                        group = group,
+                        participantPassword = participantPassword,
+                        followerPassword = prefs.getString(KEY_FOLLOWER_PASSWORD, "").orEmpty(),
+                        userName = userName,
+                        notificationEmails = prefs.getString(KEY_NOTIFICATION_EMAILS, "").orEmpty(),
+                        alertEmails = prefs.getString(KEY_ALERT_EMAILS, "").orEmpty(),
+                        stuckAlarmMinutes = prefs.getString(KEY_STUCK_ALARM_MINUTES, "").orEmpty(),
+                        comments = prefs.getString(KEY_COMMENTS, "").orEmpty(),
+                        gpxUri =
+                            prefs
+                                .getString(KEY_GPX_URI, "")
+                                .orEmpty()
+                                .takeIf(String::isNotBlank)
+                                ?.let(Uri::parse),
+                        gpxName = prefs.getString(KEY_GPX_NAME, "").orEmpty(),
+                    ),
+                isPaused = prefs.getBoolean(KEY_PAUSED, false),
+                sentStart = prefs.getBoolean(KEY_SENT_START, false),
+                dateId = prefs.getString(KEY_DATE_ID, null),
+            )
         }
-
-        return Session(
-            settings =
-                LiveTrackingSettings(
-                    trackingUrl =
-                        prefs
-                            .getString(KEY_TRACKING_URL, ArkluzTrackingEndpoint.defaultUrl)
-                            .orEmpty()
-                            .ifBlank { ArkluzTrackingEndpoint.defaultUrl },
-                    updateIntervalSeconds = prefs.getInt(KEY_UPDATE_INTERVAL_SECONDS, 60),
-                    group = group,
-                    participantPassword = participantPassword,
-                    followerPassword = prefs.getString(KEY_FOLLOWER_PASSWORD, "").orEmpty(),
-                    userName = userName,
-                    notificationEmails = prefs.getString(KEY_NOTIFICATION_EMAILS, "").orEmpty(),
-                    alertEmails = prefs.getString(KEY_ALERT_EMAILS, "").orEmpty(),
-                    stuckAlarmMinutes = prefs.getString(KEY_STUCK_ALARM_MINUTES, "").orEmpty(),
-                    comments = prefs.getString(KEY_COMMENTS, "").orEmpty(),
-                    gpxUri =
-                        prefs
-                            .getString(KEY_GPX_URI, "")
-                            .orEmpty()
-                            .takeIf(String::isNotBlank)
-                            ?.let(Uri::parse),
-                    gpxName = prefs.getString(KEY_GPX_NAME, "").orEmpty(),
-                ),
-            isPaused = prefs.getBoolean(KEY_PAUSED, false),
-            sentStart = prefs.getBoolean(KEY_SENT_START, false),
-            dateId = prefs.getString(KEY_DATE_ID, null),
-        )
     }
 
     fun clear(context: Context) {

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingHelpers.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingHelpers.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
+import android.os.PowerManager
 import android.provider.ContactsContract
 import androidx.core.content.ContextCompat
 import java.io.ByteArrayOutputStream
@@ -282,6 +283,34 @@ internal fun hasLocationPermission(context: Context): Boolean =
         PackageManager.PERMISSION_GRANTED ||
         ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) ==
         PackageManager.PERMISSION_GRANTED
+
+internal fun hasBackgroundLocationPermission(context: Context): Boolean =
+    Build.VERSION.SDK_INT < Build.VERSION_CODES.Q ||
+        ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
+        PackageManager.PERMISSION_GRANTED
+
+internal fun needsBackgroundLocationPermission(context: Context): Boolean =
+    backgroundLocationProtectionRequired(
+        supportsBackgroundLocation = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q,
+        foregroundLocationGranted = hasLocationPermission(context),
+        backgroundLocationGranted = hasBackgroundLocationPermission(context),
+    )
+
+internal fun backgroundLocationProtectionRequired(
+    supportsBackgroundLocation: Boolean,
+    foregroundLocationGranted: Boolean,
+    backgroundLocationGranted: Boolean,
+): Boolean = supportsBackgroundLocation && foregroundLocationGranted && !backgroundLocationGranted
+
+internal fun isIgnoringBatteryOptimizations(context: Context): Boolean =
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        true
+    } else {
+        context
+            .getSystemService(PowerManager::class.java)
+            ?.isIgnoringBatteryOptimizations(context.packageName)
+            ?: false
+    }
 
 internal fun hasLiveTrackingNotificationPermission(context: Context): Boolean =
     Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingMainContent.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingMainContent.kt
@@ -67,6 +67,7 @@ internal fun ColumnScope.MainTrackingContent(
     showSendPlan: Boolean,
     canSendPlan: Boolean,
     isSendingPlan: Boolean,
+    planSent: Boolean,
     onSendPlan: () -> Unit,
     sessionState: LiveTrackingUiState,
     updateIntervalSeconds: Int,
@@ -318,10 +319,16 @@ internal fun ColumnScope.MainTrackingContent(
             if (showSendPlan) {
                 Button(
                     onClick = onSendPlan,
-                    enabled = canSendPlan && !isSendingPlan,
+                    enabled = canSendPlan && !isSendingPlan && !planSent,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    Text(if (isSendingPlan) "Sending" else "Send update")
+                    Text(
+                        when {
+                            isSendingPlan -> "Sending"
+                            planSent -> "Comment sent"
+                            else -> "Send update"
+                        },
+                    )
                 }
             }
             sendStatusMessage?.let { message ->

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingPreferences.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingPreferences.kt
@@ -21,6 +21,7 @@ internal data class SavedLiveTrackingDraft(
     val gpxName: String = "",
 )
 
+@Suppress("TooManyFunctions")
 internal object LiveTrackingPreferences {
     private const val PREFS_NAME = "arkluz_live_tracking"
     private const val KEY_GROUP = "group"

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingPreferences.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingPreferences.kt
@@ -94,6 +94,16 @@ internal object LiveTrackingPreferences {
             .apply()
     }
 
+    fun clearDraft(context: Context) {
+        context
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .remove(KEY_DRAFT_COMMENTS)
+            .remove(KEY_DRAFT_GPX_URI)
+            .remove(KEY_DRAFT_GPX_NAME)
+            .apply()
+    }
+
     fun loadGroupSettings(
         context: Context,
         group: String,

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingScreen.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingScreen.kt
@@ -15,6 +15,8 @@ import android.Manifest
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
+import android.provider.Settings
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -105,10 +107,16 @@ fun LiveTrackingScreen(
     }
     var selectedGpxName by remember { mutableStateOf(savedDraft.gpxName) }
     var hasLocationPermission by remember { mutableStateOf(hasLocationPermission(context)) }
+    var hasBackgroundLocationPermission by remember {
+        mutableStateOf(hasBackgroundLocationPermission(context))
+    }
     var hasNotificationPermission by remember { mutableStateOf(hasLiveTrackingNotificationPermission(context)) }
     var isStartWaitingForPermissionResult by remember { mutableStateOf(false) }
     var continueStartAfterPermissionResult by remember { mutableStateOf(false) }
+    var continueStartAfterBackgroundLocationResult by remember { mutableStateOf(false) }
     var showNotificationPermissionWarningDialog by remember { mutableStateOf(false) }
+    var showBackgroundLocationDialog by remember { mutableStateOf(false) }
+    var showBatteryOptimizationDialog by remember { mutableStateOf(false) }
     var validationMessage by remember { mutableStateOf<String?>(null) }
     var sendStatusMessage by remember { mutableStateOf<String?>(null) }
     var loginJoinStatusMessage by remember { mutableStateOf<String?>(null) }
@@ -382,6 +390,13 @@ fun LiveTrackingScreen(
                     LiveTrackingPermissionOutcome.CONTINUE -> continueStartAfterPermissionResult = true
                 }
             }
+        }
+    val backgroundLocationPermissionLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestPermission(),
+        ) { granted ->
+            hasBackgroundLocationPermission = granted || hasBackgroundLocationPermission(context)
+            continueStartAfterBackgroundLocationResult = true
         }
 
     BoxWithConstraints(
@@ -677,7 +692,10 @@ fun LiveTrackingScreen(
         fun startTrackingNow() {
             isStartWaitingForPermissionResult = false
             continueStartAfterPermissionResult = false
+            continueStartAfterBackgroundLocationResult = false
             showNotificationPermissionWarningDialog = false
+            showBackgroundLocationDialog = false
+            showBatteryOptimizationDialog = false
             isStartingSession = true
             validationMessage = null
             sendStatusMessage = null
@@ -687,6 +705,25 @@ fun LiveTrackingScreen(
                 LiveTrackingService.start(context = context, settings = settings)
                 isStartingSession = false
             }
+        }
+
+        fun continueStartWithBatteryProtection() {
+            if (!isIgnoringBatteryOptimizations(context)) {
+                isStartingSession = false
+                showBatteryOptimizationDialog = true
+                return
+            }
+            startTrackingNow()
+        }
+
+        fun continueStartWithBackgroundLocationProtection() {
+            hasBackgroundLocationPermission = hasBackgroundLocationPermission(context)
+            if (needsBackgroundLocationPermission(context)) {
+                isStartingSession = false
+                showBackgroundLocationDialog = true
+                return
+            }
+            continueStartWithBatteryProtection()
         }
 
         fun continueStartAfterSmsValidation() {
@@ -699,7 +736,7 @@ fun LiveTrackingScreen(
                 isStartWaitingForPermissionResult = true
                 locationPermissionLauncher.launch(missingPermissions)
             } else {
-                startTrackingNow()
+                continueStartWithBackgroundLocationProtection()
             }
         }
 
@@ -777,7 +814,15 @@ fun LiveTrackingScreen(
 
         LaunchedEffect(continueStartAfterPermissionResult) {
             if (continueStartAfterPermissionResult) {
-                startTrackingNow()
+                continueStartAfterPermissionResult = false
+                continueStartWithBackgroundLocationProtection()
+            }
+        }
+
+        LaunchedEffect(continueStartAfterBackgroundLocationResult) {
+            if (continueStartAfterBackgroundLocationResult) {
+                continueStartAfterBackgroundLocationResult = false
+                continueStartWithBatteryProtection()
             }
         }
 
@@ -1170,7 +1215,7 @@ fun LiveTrackingScreen(
                     )
                 },
                 confirmButton = {
-                    Button(onClick = { startTrackingNow() }) {
+                    Button(onClick = { continueStartWithBackgroundLocationProtection() }) {
                         Text("Start anyway")
                     }
                 },
@@ -1182,6 +1227,98 @@ fun LiveTrackingScreen(
                         },
                     ) {
                         Text("Cancel")
+                    }
+                },
+            )
+        }
+        if (showBackgroundLocationDialog) {
+            AlertDialog(
+                onDismissRequest = {
+                    showBackgroundLocationDialog = false
+                    isStartingSession = false
+                },
+                title = { Text("Keep GPS tracking in the background") },
+                text = {
+                    Text(
+                        "Allow location all the time so Android can restore live tracking if the app " +
+                            "is no longer visible. On Android 11 and newer, select Location then " +
+                            "Allow all the time in the system settings.",
+                    )
+                },
+                confirmButton = {
+                    Button(
+                        onClick = {
+                            showBackgroundLocationDialog = false
+                            if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
+                                backgroundLocationPermissionLauncher.launch(
+                                    Manifest.permission.ACCESS_BACKGROUND_LOCATION,
+                                )
+                            } else {
+                                runCatching {
+                                    context.startActivity(
+                                        Intent(
+                                            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                                            Uri.fromParts("package", context.packageName, null),
+                                        ),
+                                    )
+                                }
+                            }
+                        },
+                    ) {
+                        Text("Open location settings")
+                    }
+                },
+                dismissButton = {
+                    TextButton(
+                        onClick = {
+                            showBackgroundLocationDialog = false
+                            continueStartWithBatteryProtection()
+                        },
+                    ) {
+                        Text("Start with foreground service")
+                    }
+                },
+            )
+        }
+        if (showBatteryOptimizationDialog) {
+            AlertDialog(
+                onDismissRequest = {
+                    showBatteryOptimizationDialog = false
+                    isStartingSession = false
+                },
+                title = { Text("Protect live tracking from battery saving") },
+                text = {
+                    Text(
+                        "Battery saving can stop long-running tracking. Allow unrestricted battery " +
+                            "use for GlanceMap. On Samsung, also ensure the app is not in Sleeping " +
+                            "apps or Deep sleeping apps.",
+                    )
+                },
+                confirmButton = {
+                    Button(
+                        onClick = {
+                            showBatteryOptimizationDialog = false
+                            runCatching {
+                                context.startActivity(
+                                    Intent(
+                                        Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+                                        Uri.fromParts("package", context.packageName, null),
+                                    ),
+                                )
+                            }
+                        },
+                    ) {
+                        Text("Open battery settings")
+                    }
+                },
+                dismissButton = {
+                    TextButton(
+                        onClick = {
+                            showBatteryOptimizationDialog = false
+                            startTrackingNow()
+                        },
+                    ) {
+                        Text("Start anyway")
                     }
                 },
             )

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingScreen.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingScreen.kt
@@ -65,6 +65,11 @@ private enum class EmailPickerTarget {
     ALERT,
 }
 
+private enum class ExternalSettingsStartStep {
+    BACKGROUND_LOCATION,
+    BATTERY_OPTIMIZATION,
+}
+
 internal enum class RecordedTrackDownloadTarget {
     USER,
     GROUP,
@@ -114,6 +119,12 @@ fun LiveTrackingScreen(
     var isStartWaitingForPermissionResult by remember { mutableStateOf(false) }
     var continueStartAfterPermissionResult by remember { mutableStateOf(false) }
     var continueStartAfterBackgroundLocationResult by remember { mutableStateOf(false) }
+    var pendingExternalSettingsStartStep by remember {
+        mutableStateOf<ExternalSettingsStartStep?>(null)
+    }
+    var continueStartAfterExternalSettingsResult by remember {
+        mutableStateOf<ExternalSettingsStartStep?>(null)
+    }
     var showNotificationPermissionWarningDialog by remember { mutableStateOf(false) }
     var showBackgroundLocationDialog by remember { mutableStateOf(false) }
     var showBatteryOptimizationDialog by remember { mutableStateOf(false) }
@@ -408,6 +419,16 @@ fun LiveTrackingScreen(
         ) { granted ->
             hasBackgroundLocationPermission = granted || hasBackgroundLocationPermission(context)
             continueStartAfterBackgroundLocationResult = true
+        }
+    val externalSettingsLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.StartActivityForResult(),
+        ) {
+            val step =
+                pendingExternalSettingsStartStep
+                    ?: return@rememberLauncherForActivityResult
+            pendingExternalSettingsStartStep = null
+            continueStartAfterExternalSettingsResult = step
         }
 
     BoxWithConstraints(
@@ -704,6 +725,8 @@ fun LiveTrackingScreen(
             isStartWaitingForPermissionResult = false
             continueStartAfterPermissionResult = false
             continueStartAfterBackgroundLocationResult = false
+            pendingExternalSettingsStartStep = null
+            continueStartAfterExternalSettingsResult = null
             showNotificationPermissionWarningDialog = false
             showBackgroundLocationDialog = false
             showBatteryOptimizationDialog = false
@@ -834,6 +857,22 @@ fun LiveTrackingScreen(
             if (continueStartAfterBackgroundLocationResult) {
                 continueStartAfterBackgroundLocationResult = false
                 continueStartWithBatteryProtection()
+            }
+        }
+
+        LaunchedEffect(continueStartAfterExternalSettingsResult) {
+            when (continueStartAfterExternalSettingsResult) {
+                ExternalSettingsStartStep.BACKGROUND_LOCATION -> {
+                    continueStartAfterExternalSettingsResult = null
+                    continueStartWithBackgroundLocationProtection()
+                }
+
+                ExternalSettingsStartStep.BATTERY_OPTIMIZATION -> {
+                    continueStartAfterExternalSettingsResult = null
+                    continueStartWithBatteryProtection()
+                }
+
+                null -> Unit
             }
         }
 
@@ -1267,7 +1306,9 @@ fun LiveTrackingScreen(
                                 )
                             } else {
                                 runCatching {
-                                    context.startActivity(
+                                    pendingExternalSettingsStartStep =
+                                        ExternalSettingsStartStep.BACKGROUND_LOCATION
+                                    externalSettingsLauncher.launch(
                                         Intent(
                                             Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
                                             Uri.fromParts("package", context.packageName, null),
@@ -1311,7 +1352,9 @@ fun LiveTrackingScreen(
                         onClick = {
                             showBatteryOptimizationDialog = false
                             runCatching {
-                                context.startActivity(
+                                pendingExternalSettingsStartStep =
+                                    ExternalSettingsStartStep.BATTERY_OPTIMIZATION
+                                externalSettingsLauncher.launch(
                                     Intent(
                                         Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
                                         Uri.fromParts("package", context.packageName, null),

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingScreen.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingScreen.kt
@@ -182,6 +182,17 @@ fun LiveTrackingScreen(
         )
     }
 
+    LaunchedEffect(sessionState.status) {
+        if (sessionState.status == "Stopped") {
+            comments = ""
+            selectedGpxUri = null
+            selectedGpxName = ""
+            planSent = false
+            sendStatusMessage = null
+            LiveTrackingPreferences.clearDraft(context)
+        }
+    }
+
     val gpxPicker =
         rememberLauncherForActivityResult(
             contract = ActivityResultContracts.OpenDocument(),
@@ -877,6 +888,7 @@ fun LiveTrackingScreen(
                         showSendPlan = showSendPlan,
                         canSendPlan = canSendPlan,
                         isSendingPlan = isSendingPlan,
+                        planSent = planSent,
                         onSendPlan = {
                             if (!sessionState.isTracking) {
                                 sendStatusMessage = "Start live tracking before sending a route or comment."

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingService.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingService.kt
@@ -75,47 +75,31 @@ class LiveTrackingService : Service() {
     ): Int =
         when (intent?.action) {
             ACTION_PAUSE -> {
-                pauseTracking()
-                START_STICKY
+                if (restoreActiveSessionIfNeeded()) pauseTracking()
+                START_REDELIVER_INTENT
             }
 
             ACTION_RESUME -> {
-                resumeTracking()
-                START_STICKY
+                if (restoreActiveSessionIfNeeded()) resumeTracking()
+                START_REDELIVER_INTENT
             }
 
-            ACTION_UPDATE_ALERT_SETTINGS -> updateAlertSettings(intent, startId)
+            ACTION_UPDATE_ALERT_SETTINGS -> {
+                if (!restoreActiveSessionIfNeeded()) {
+                    stopSelf(startId)
+                    START_NOT_STICKY
+                } else {
+                    updateAlertSettings(intent)
+                    START_REDELIVER_INTENT
+                }
+            }
 
             ACTION_STOP -> {
                 stopTracking()
                 START_NOT_STICKY
             }
 
-            else -> {
-                val parsedSettings = intent?.toLiveTrackingSettings()
-                when {
-                    parsedSettings == null -> {
-                        LiveTrackingSessionStore.setStopped("Missing live tracking settings")
-                        stopSelf()
-                        START_NOT_STICKY
-                    }
-
-                    settings != null -> START_STICKY
-
-                    else -> {
-                        settings = parsedSettings
-                        sentStart = false
-                        dateId = null
-                        isPaused = false
-                        isStopping = false
-                        LiveTrackingControlQueue.clear(this)
-                        LiveTrackingSessionStore.setStarting()
-                        startForegroundNotification("Starting live tracking")
-                        startTracking()
-                        START_STICKY
-                    }
-                }
-            }
+            else -> startOrRestoreTracking(intent)
         }
 
     override fun onBind(intent: Intent?): IBinder? = null
@@ -126,14 +110,50 @@ class LiveTrackingService : Service() {
         super.onDestroy()
     }
 
-    private fun updateAlertSettings(
-        intent: Intent,
-        startId: Int,
-    ): Int {
-        if (settings == null) {
-            stopSelf(startId)
+    private fun startOrRestoreTracking(intent: Intent?): Int {
+        if (restoreActiveSessionIfNeeded()) return START_REDELIVER_INTENT
+
+        val parsedSettings = intent?.toLiveTrackingSettings()
+        if (parsedSettings == null) {
+            LiveTrackingSessionStore.setStopped("Missing live tracking settings")
+            stopSelf()
             return START_NOT_STICKY
         }
+
+        settings = parsedSettings
+        sentStart = false
+        dateId = null
+        isPaused = false
+        isStopping = false
+        LiveTrackingControlQueue.clear(this)
+        persistActiveSession()
+        LiveTrackingSessionStore.setStarting()
+        startForegroundNotification("Starting live tracking")
+        startTracking()
+        return START_REDELIVER_INTENT
+    }
+
+    private fun restoreActiveSessionIfNeeded(): Boolean {
+        if (settings != null) return true
+        val session = LiveTrackingActiveSessionStore.load(this) ?: return false
+
+        settings = session.settings
+        isPaused = session.isPaused
+        sentStart = session.sentStart
+        dateId = session.dateId
+        isStopping = false
+        if (isPaused) {
+            startForegroundNotification("Live tracking paused")
+            LiveTrackingSessionStore.setPaused()
+        } else {
+            startForegroundNotification("Restoring live tracking")
+            LiveTrackingSessionStore.setActive(status = "Restoring GPS tracking")
+            startTracking()
+        }
+        return true
+    }
+
+    private fun updateAlertSettings(intent: Intent) {
         val notificationEmails = intent.getStringExtra(EXTRA_NOTIFICATION_EMAILS).orEmpty()
         val alertEmails = intent.getStringExtra(EXTRA_ALERT_EMAILS).orEmpty()
         val stuckAlarmMinutes = intent.getStringExtra(EXTRA_STUCK_ALARM_MINUTES).orEmpty()
@@ -145,15 +165,14 @@ class LiveTrackingService : Service() {
                         alertEmails = alertEmails,
                         stuckAlarmMinutes = stuckAlarmMinutes,
                     )
+                persistActiveSession()
             }
         }
-        return START_STICKY
     }
 
     private fun startTracking() {
         if (!hasLocationPermission()) {
-            LiveTrackingSessionStore.setStopped("Location permission is required")
-            stopSelf()
+            finishStopped("Location permission is required")
             return
         }
 
@@ -208,6 +227,7 @@ class LiveTrackingService : Service() {
                 if (sentStartInRequest) {
                     sentStart = true
                     result.dateId?.let { dateId = it }
+                    persistActiveSession()
                 }
                 val serverMessage = result.message.takeUnless { it == "Server accepted request" }
                 val status =
@@ -338,6 +358,7 @@ class LiveTrackingService : Service() {
         if (isPaused || isStopping || !sentStart) return
         runCatching { locationClient.removeLocationUpdates(locationCallback) }
         isPaused = true
+        persistActiveSession()
         LiveTrackingControlQueue.enqueue(
             this,
             buildSessionControl(
@@ -360,12 +381,11 @@ class LiveTrackingService : Service() {
         val location = lastLocation ?: return
         if (!isPaused || isStopping) return
         if (!hasLocationPermission()) {
-            LiveTrackingSessionStore.setStopped("Location permission is required")
-            updateNotification("Location permission is required")
-            stopSelf()
+            finishStopped("Location permission is required")
             return
         }
         isPaused = false
+        persistActiveSession()
         LiveTrackingControlQueue.enqueue(
             this,
             buildSessionControl(
@@ -538,6 +558,7 @@ class LiveTrackingService : Service() {
 
     private fun finishStopped(status: String) {
         LiveTrackingControlQueue.clear(this)
+        LiveTrackingActiveSessionStore.clear(this)
         LiveTrackingSessionStore.setStopped(status)
         ServiceCompat.stopForeground(this@LiveTrackingService, ServiceCompat.STOP_FOREGROUND_REMOVE)
         stopSelf()
@@ -545,7 +566,7 @@ class LiveTrackingService : Service() {
 
     private fun startForegroundNotification(text: String) {
         val type =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
             } else {
                 0
@@ -621,6 +642,17 @@ class LiveTrackingService : Service() {
             ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) ==
             PackageManager.PERMISSION_GRANTED
 
+    private fun persistActiveSession() {
+        val activeSettings = settings ?: return
+        LiveTrackingActiveSessionStore.save(
+            context = this,
+            settings = activeSettings,
+            isPaused = isPaused,
+            sentStart = sentStart,
+            dateId = dateId,
+        )
+    }
+
     companion object {
         private const val CHANNEL_ID = "live_tracking_channel"
         private const val NOTIFICATION_ID = 42
@@ -656,6 +688,8 @@ class LiveTrackingService : Service() {
             context: Context,
             settings: LiveTrackingSettings,
         ) {
+            // A user-initiated start supersedes any session that Android was eligible to restore.
+            LiveTrackingActiveSessionStore.clear(context)
             val intent =
                 Intent(context, LiveTrackingService::class.java)
                     .putExtra(EXTRA_TRACKING_URL, settings.trackingUrl)

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingService.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingService.kt
@@ -110,48 +110,54 @@ class LiveTrackingService : Service() {
         super.onDestroy()
     }
 
-    private fun startOrRestoreTracking(intent: Intent?): Int {
-        if (restoreActiveSessionIfNeeded()) return START_REDELIVER_INTENT
-
-        val parsedSettings = intent?.toLiveTrackingSettings()
-        if (parsedSettings == null) {
-            LiveTrackingSessionStore.setStopped("Missing live tracking settings")
-            stopSelf()
-            return START_NOT_STICKY
-        }
-
-        settings = parsedSettings
-        sentStart = false
-        dateId = null
-        isPaused = false
-        isStopping = false
-        LiveTrackingControlQueue.clear(this)
-        persistActiveSession()
-        LiveTrackingSessionStore.setStarting()
-        startForegroundNotification("Starting live tracking")
-        startTracking()
-        return START_REDELIVER_INTENT
-    }
-
-    private fun restoreActiveSessionIfNeeded(): Boolean {
-        if (settings != null) return true
-        val session = LiveTrackingActiveSessionStore.load(this) ?: return false
-
-        settings = session.settings
-        isPaused = session.isPaused
-        sentStart = session.sentStart
-        dateId = session.dateId
-        isStopping = false
-        if (isPaused) {
-            startForegroundNotification("Live tracking paused")
-            LiveTrackingSessionStore.setPaused()
+    private fun startOrRestoreTracking(intent: Intent?): Int =
+        if (restoreActiveSessionIfNeeded()) {
+            START_REDELIVER_INTENT
         } else {
-            startForegroundNotification("Restoring live tracking")
-            LiveTrackingSessionStore.setActive(status = "Restoring GPS tracking")
-            startTracking()
+            val parsedSettings = intent?.toLiveTrackingSettings()
+            if (parsedSettings == null) {
+                LiveTrackingSessionStore.setStopped("Missing live tracking settings")
+                stopSelf()
+                START_NOT_STICKY
+            } else {
+                settings = parsedSettings
+                sentStart = false
+                dateId = null
+                isPaused = false
+                isStopping = false
+                LiveTrackingControlQueue.clear(this)
+                persistActiveSession()
+                LiveTrackingSessionStore.setStarting()
+                startForegroundNotification("Starting live tracking")
+                startTracking()
+                START_REDELIVER_INTENT
+            }
         }
-        return true
-    }
+
+    private fun restoreActiveSessionIfNeeded(): Boolean =
+        if (settings != null) {
+            true
+        } else {
+            val session = LiveTrackingActiveSessionStore.load(this)
+            if (session == null) {
+                false
+            } else {
+                settings = session.settings
+                isPaused = session.isPaused
+                sentStart = session.sentStart
+                dateId = session.dateId
+                isStopping = false
+                if (isPaused) {
+                    startForegroundNotification("Live tracking paused")
+                    LiveTrackingSessionStore.setPaused()
+                } else {
+                    startForegroundNotification("Restoring live tracking")
+                    LiveTrackingSessionStore.setActive(status = "Restoring GPS tracking")
+                    startTracking()
+                }
+                true
+            }
+        }
 
     private fun updateAlertSettings(intent: Intent) {
         val notificationEmails = intent.getStringExtra(EXTRA_NOTIFICATION_EMAILS).orEmpty()

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingService.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingService.kt
@@ -504,7 +504,10 @@ class LiveTrackingService : Service() {
         serviceScope.launch {
             val location = lastLocation
             if (location == null) {
-                finishStopped("Stopped")
+                finishStopped(
+                    status = "Stopped",
+                    clearPlannedDraft = true,
+                )
                 return@launch
             }
             retryStopUntilConfirmed(location)
@@ -519,7 +522,10 @@ class LiveTrackingService : Service() {
             val result = runCatching { sendStopConfirmation(location) }
             result
                 .onSuccess {
-                    finishStopped("Stopped")
+                    finishStopped(
+                        status = "Stopped",
+                        clearPlannedDraft = true,
+                    )
                     return
                 }.onFailure { error ->
                     if (!error.isRetryableArkluzFailure()) {
@@ -556,9 +562,15 @@ class LiveTrackingService : Service() {
         }
     }
 
-    private fun finishStopped(status: String) {
+    private fun finishStopped(
+        status: String,
+        clearPlannedDraft: Boolean = false,
+    ) {
         LiveTrackingControlQueue.clear(this)
         LiveTrackingActiveSessionStore.clear(this)
+        if (clearPlannedDraft) {
+            LiveTrackingPreferences.clearDraft(this)
+        }
         LiveTrackingSessionStore.setStopped(status)
         ServiceCompat.stopForeground(this@LiveTrackingService, ServiceCompat.STOP_FOREGROUND_REMOVE)
         stopSelf()

--- a/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingSettingsContent.kt
+++ b/glancemapcompanionapp/src/main/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingSettingsContent.kt
@@ -271,19 +271,19 @@ private fun NoMovementAlertInput(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Checkbox(
-                checked = isDisabled,
-                onCheckedChange = { disabled ->
+                checked = !isDisabled,
+                onCheckedChange = { enabled ->
                     onMinutesChange(
-                        if (disabled) {
-                            "-1"
-                        } else {
+                        if (enabled) {
                             lastEnabledMinutes
+                        } else {
+                            "-1"
                         },
                     )
                 },
             )
             Text(
-                text = "Disable no-movement alerts",
+                text = "Enable no-movement alerts",
                 style = MaterialTheme.typography.bodySmall,
             )
         }

--- a/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/livetracking/ArkluzSessionControlUrlTest.kt
+++ b/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/livetracking/ArkluzSessionControlUrlTest.kt
@@ -14,6 +14,13 @@ class ArkluzSessionControlUrlTest {
     }
 
     @Test
+    fun locationAltitudeIsRoundedToOneDecimalPlace() {
+        val url = buildArkluzLocationUrl(update(altitudeMeters = 1234.567890123))
+
+        assertEquals("1234.6", url.queryParameter("alt"))
+    }
+
+    @Test
     fun pauseIncludesPauseAndDateIdWithoutStartingNewActivity() {
         val url = buildArkluzLocationUrl(update(pause = true, dateId = "20260622-42"))
 
@@ -37,11 +44,12 @@ class ArkluzSessionControlUrlTest {
         pause: Boolean = false,
         resume: Boolean = false,
         dateId: String? = null,
+        altitudeMeters: Double? = null,
     ) = ArkluzLocationUpdate(
         trackingUrl = "https://arkluz.com/trk",
         latitude = 45.0,
         longitude = 6.0,
-        altitudeMeters = null,
+        altitudeMeters = altitudeMeters,
         speedMetersPerSecond = null,
         accuracyMeters = 5f,
         epochMilliseconds = 1_750_000_000_000,

--- a/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/livetracking/ArkluzUploadResponseTest.kt
+++ b/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/livetracking/ArkluzUploadResponseTest.kt
@@ -1,0 +1,31 @@
+package com.glancemap.glancemapcompanionapp.livetracking
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ArkluzUploadResponseTest {
+    @Test
+    fun acceptsPlainOkResponse() {
+        val result = "OK\n".toArkluzUploadResult()
+
+        assertEquals("Comment sent", result.message)
+    }
+
+    @Test
+    fun rejectsArkluzErrorResponse() {
+        val error = runCatching { "Error: invalid GPX\n".toArkluzUploadResult() }.exceptionOrNull()
+
+        assertNotNull(error)
+        assertEquals("Error: invalid GPX", error?.message)
+    }
+
+    @Test
+    fun rejectsUnexpectedResponse() {
+        val error = runCatching { "<html>Upload complete</html>".toArkluzUploadResult() }.exceptionOrNull()
+
+        assertNotNull(error)
+        assertTrue(error?.message.orEmpty().contains("Upload complete"))
+    }
+}

--- a/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingPermissionOutcomeTest.kt
+++ b/glancemapcompanionapp/src/test/java/com/glancemap/glancemapcompanionapp/livetracking/LiveTrackingPermissionOutcomeTest.kt
@@ -43,4 +43,32 @@ class LiveTrackingPermissionOutcomeTest {
             ),
         )
     }
+
+    @Test
+    fun backgroundProtectionIsRequestedOnlyWhenForegroundLocationExists() {
+        assertEquals(
+            true,
+            backgroundLocationProtectionRequired(
+                supportsBackgroundLocation = true,
+                foregroundLocationGranted = true,
+                backgroundLocationGranted = false,
+            ),
+        )
+        assertEquals(
+            false,
+            backgroundLocationProtectionRequired(
+                supportsBackgroundLocation = true,
+                foregroundLocationGranted = false,
+                backgroundLocationGranted = false,
+            ),
+        )
+        assertEquals(
+            false,
+            backgroundLocationProtectionRequired(
+                supportsBackgroundLocation = false,
+                foregroundLocationGranted = true,
+                backgroundLocationGranted = false,
+            ),
+        )
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,8 +39,8 @@ android.r8.strictFullModeForKeepRules=false
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
 glanceMapVersionName=1.2.0
-glanceMapWearVersionCode=1025
-glanceMapPhoneVersionCode=2023
+glanceMapWearVersionCode=1026
+glanceMapPhoneVersionCode=2024
 
 # Elevate theme build-time sync (download -> generated assets -> packaged in APK)
 elevateThemeVersion=5.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ android.r8.strictFullModeForKeepRules=false
 # Bump the matching artifact by 1 for each Play upload.
 glanceMapVersionName=1.2.0
 glanceMapWearVersionCode=1026
-glanceMapPhoneVersionCode=2024
+glanceMapPhoneVersionCode=2025
 
 # Elevate theme build-time sync (download -> generated assets -> packaged in APK)
 elevateThemeVersion=5.6


### PR DESCRIPTION
## Summary

- Correct compass acquisition behavior and the diagnostics-export capture race on Wear.
- Render hillshade as an independent layer, prioritize Detailed terrain, bound detailed DEM input, and avoid base-map prewarming while hillshade is active.
- Improve companion live tracking: background location and battery-protection guidance, resuming a pending start after system settings, confirmed comment updates, and clearing route/comment drafts when tracking stops.
- Restore the production Arkluz endpoint and bump the companion version code to 2025.

## Why

Detailed DEM input previously caused excessive allocation before Mapsforge could reduce hillshade output, leading to timeouts or a black screen. Companion tracking also needed background-protection handling and clearer upload feedback.

## Validation

- `:app:ktlintCheck`
- Focused Wear hillshade unit tests and `:app:compileDebugKotlin`
- `:glancemapcompanionapp:ktlintCheck`
- `:glancemapcompanionapp:testDebugUnitTest`
- `:glancemapcompanionapp:compileDebugKotlin`
