### PR TITLE
Improve REC tracking reliability

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/recording/RecordingTrackFilter.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/recording/RecordingTrackFilter.kt
@@ -38,7 +38,6 @@ internal enum class RecordingFixQualityReason {
 internal data class RecordingFixQualityResult(
     val status: RecordingFixQualityStatus,
     val reason: RecordingFixQualityReason,
-    val startsNewSegment: Boolean = false,
 ) {
     val accepted: Boolean get() = status == RecordingFixQualityStatus.ACCEPTED
 }
@@ -46,8 +45,7 @@ internal data class RecordingFixQualityResult(
 /**
  * Rejects fixes that cannot safely become part of the canonical recording. A single
  * implausible jump is held until the next sampled fix either disproves it or confirms that
- * GPS has genuinely reacquired in a different location. Confirmed reacquisition starts a new
- * segment so the missing interval never becomes artificial distance.
+ * GPS has genuinely reacquired in a different location.
  */
 internal class RecordingFixQualityGate {
     private var lastSeenElapsedRealtimeMillis = Long.MIN_VALUE
@@ -122,14 +120,12 @@ internal class RecordingFixQualityGate {
     private fun accept(
         candidate: RecordingFixSample,
         reason: RecordingFixQualityReason,
-        startsNewSegment: Boolean = false,
     ): RecordingFixQualityResult {
         lastAccepted = candidate
         pendingImplausible = null
         return RecordingFixQualityResult(
             status = RecordingFixQualityStatus.ACCEPTED,
             reason = reason,
-            startsNewSegment = startsNewSegment,
         )
     }
 
@@ -158,7 +154,6 @@ internal class RecordingFixQualityGate {
             return accept(
                 candidate = candidate,
                 reason = RecordingFixQualityReason.CONFIRMED_RELOCATION,
-                startsNewSegment = true,
             )
         }
         pendingImplausible = candidate

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/recording/TraceRecordingViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/recording/TraceRecordingViewModel.kt
@@ -16,6 +16,8 @@ import com.glancemap.glancemapwearos.presentation.features.recording.dashboard.b
 import com.glancemap.glancemapwearos.presentation.features.recording.external.ExternalSensorConnectionStatus
 import com.glancemap.glancemapwearos.presentation.features.recording.sensors.RecordingSensorMetrics
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -121,6 +123,8 @@ class TraceRecordingViewModel(
     private var maxSmoothedAdjustmentMeters = 0.0
     private var latestRecordingStartLocation: Location? = null
     private var latestGpsSignalSnapshot = GpsSignalSnapshot()
+    private var pendingRecordingStartSource: String? = null
+    private var pendingRecordingStartTimeout: Job? = null
 
     init {
         settingsRepository.recordingSampleIntervalSeconds
@@ -225,15 +229,19 @@ class TraceRecordingViewModel(
 
     fun startRecording() {
         if (isRecordingStartBlocked()) return
-        if (ensureLocationReadyForRecordingStart(source = "rec_tap")) {
+        if (isLocationReadyForRecordingStart()) {
             startRecordingAfterLocationPreflight()
+        } else {
+            waitForFreshLocationBeforeStartingRecording(source = "rec_tap")
         }
     }
 
     private fun isRecordingStartBlocked(): Boolean {
         val state = _uiState.value
         if (state.active || state.saving) return true
-        return _startWarning.value != null || _locationStartWarning.value != null
+        return _startWarning.value != null ||
+            _locationStartWarning.value != null ||
+            pendingRecordingStartSource != null
     }
 
     private fun startRecordingAfterLocationPreflight() {
@@ -340,6 +348,7 @@ class TraceRecordingViewModel(
 
     fun onGpsSignalSnapshot(snapshot: GpsSignalSnapshot) {
         latestGpsSignalSnapshot = snapshot
+        startPendingRecordingWhenLocationReady()
     }
 
     private fun startRecordingNow() {
@@ -375,6 +384,7 @@ class TraceRecordingViewModel(
 
     fun onLocation(location: Location?) {
         latestRecordingStartLocation = location
+        startPendingRecordingWhenLocationReady()
         if (location == null) return
         val state = _uiState.value
         if (!state.active || state.saving) return
@@ -512,23 +522,16 @@ class TraceRecordingViewModel(
             }
             return
         }
-        val startsNewSegmentAfterGpsGap =
-            recordingGapRequiresNewSegment(
-                elapsedSinceAcceptedMs = elapsedSinceAcceptedMs,
-                gapThresholdMillis = recordingGapThresholdMillis(),
-                hasRecordedPoints = state.points.isNotEmpty(),
-            )
-        val startsNewSegmentForPoint =
-            startNewSegmentOnNextPoint ||
-                fixQualityResult.startsNewSegment ||
-                startsNewSegmentAfterGpsGap
+        // A REC session stays continuous despite transient GPS gaps or fix reacquisition.
+        // Only a user-initiated pause/resume creates an explicit GPX segment boundary.
+        val startsNewSegmentForPoint = startNewSegmentOnNextPoint
         startNewSegmentOnNextPoint = false
         if (fixQualityResult.reason == RecordingFixQualityReason.CONFIRMED_RELOCATION) {
             qualityRelocationCount += 1
             DebugTelemetry.log(
                 "TraceRecording",
                 "event=fix_quality_confirmed_relocation count=$qualityRelocationCount " +
-                    "action=new_segment accuracyMeters=${livePoint.accuracyMeters?.formatTelemetry(1) ?: "na"}",
+                    "action=continue_track accuracyMeters=${livePoint.accuracyMeters?.formatTelemetry(1) ?: "na"}",
             )
         }
         if (fixQualityResult.reason == RecordingFixQualityReason.CONFIRMED_SUSTAINED_MOVEMENT) {
@@ -539,23 +542,16 @@ class TraceRecordingViewModel(
                     "accuracyMeters=${livePoint.accuracyMeters?.formatTelemetry(1) ?: "na"}",
             )
         }
-        if (forceAcceptReason == null && elapsedSinceAcceptedMs >= recordingGapThresholdMillis()) {
+        if (forceAcceptReason == null && elapsedSinceAcceptedMs >= recordingGapTelemetryThresholdMillis()) {
             gapRecoveryAcceptCount += 1
             DebugTelemetry.log(
                 "TraceRecording",
                 "event=gap_recovery_accept gapRecoveryAcceptCount=$gapRecoveryAcceptCount " +
                     "elapsedSinceAcceptedMs=$elapsedSinceAcceptedMs " +
-                    "thresholdMs=${recordingGapThresholdMillis()} " +
+                    "thresholdMs=${recordingGapTelemetryThresholdMillis()} " +
                     "sampleIntervalSeconds=$sampleIntervalSeconds " +
                     "provider=${sanitizeTelemetryValue(location.provider ?: "na")} " +
                     "accuracyMeters=${livePoint.accuracyMeters?.toInt() ?: -1}",
-            )
-        }
-        if (startsNewSegmentAfterGpsGap) {
-            DebugTelemetry.log(
-                "TraceRecording",
-                "event=gps_loss_segment elapsedSinceAcceptedMs=$elapsedSinceAcceptedMs " +
-                    "thresholdMs=${recordingGapThresholdMillis()} action=new_segment",
             )
         }
         if (forceAcceptReason != null) {
@@ -736,11 +732,9 @@ class TraceRecordingViewModel(
     }
 
     private fun ensureLocationReadyForRecordingStart(source: String): Boolean {
+        if (isLocationReadyForRecordingStart()) return true
         val location = latestRecordingStartLocation
         val hasUsableLocation = location?.let(::isUsableLocation) == true
-        if (isRecordingStartLocationReady(hasUsableLocation, latestGpsSignalSnapshot)) {
-            return true
-        }
         _locationStartWarning.value =
             RecordingLocationStartWarning
         DebugTelemetry.log(
@@ -752,6 +746,47 @@ class TraceRecordingViewModel(
                 "lastFixAgeMs=${latestGpsSignalSnapshot.lastFixAgeMs}",
         )
         return false
+    }
+
+    private fun isLocationReadyForRecordingStart(): Boolean =
+        isRecordingStartLocationReady(
+            hasUsableLocation = latestRecordingStartLocation?.let(::isUsableLocation) == true,
+            gpsSignalSnapshot = latestGpsSignalSnapshot,
+        )
+
+    private fun waitForFreshLocationBeforeStartingRecording(source: String) {
+        pendingRecordingStartSource = source
+        _uiState.value = _uiState.value.copy(message = "Starting REC…")
+        DebugTelemetry.log(
+            "TraceRecording",
+            "event=start_waiting_for_fresh_location source=$source " +
+                "timeoutMs=$RECORDING_START_FRESH_FIX_TIMEOUT_MS",
+        )
+        pendingRecordingStartTimeout =
+            viewModelScope.launch {
+                delay(RECORDING_START_FRESH_FIX_TIMEOUT_MS)
+                if (pendingRecordingStartSource != source) return@launch
+                pendingRecordingStartSource = null
+                pendingRecordingStartTimeout = null
+                _uiState.value = _uiState.value.copy(message = null)
+                ensureLocationReadyForRecordingStart(source = "${source}_timeout")
+            }
+    }
+
+    private fun startPendingRecordingWhenLocationReady() {
+        val source = pendingRecordingStartSource ?: return
+        if (!isLocationReadyForRecordingStart()) return
+
+        pendingRecordingStartSource = null
+        pendingRecordingStartTimeout?.cancel()
+        pendingRecordingStartTimeout = null
+        _uiState.value = _uiState.value.copy(message = null)
+        DebugTelemetry.log(
+            "TraceRecording",
+            "event=start_pending_location_ready source=$source " +
+                "lastFixAgeMs=${latestGpsSignalSnapshot.lastFixAgeMs}",
+        )
+        startRecordingAfterLocationPreflight()
     }
 
     fun onSensorMetrics(metrics: RecordingSensorMetrics) {
@@ -1295,7 +1330,7 @@ class TraceRecordingViewModel(
         val addedPausedMillis = state.pausedAtMillis?.let { nowMillis - it }?.coerceAtLeast(0L) ?: 0L
         lastAcceptedElapsedMs = Long.MIN_VALUE
         lastAcceptedPointTimeMillis = null
-        startNewSegmentOnNextPoint = state.points.isNotEmpty()
+        startNewSegmentOnNextPoint = false
         recordingFixQualityGate.reset()
         resetAutoPauseMotionState()
         autoResumeTriggerCount += 1
@@ -1466,7 +1501,7 @@ class TraceRecordingViewModel(
             val gapMillis = (point.timeMillis - previousPointTimeMillis).coerceAtLeast(0L)
             val expectedActiveGapMillis = expectedActivePointGapMillis()
             gpsActiveDurationMillis += minOf(gapMillis, expectedActiveGapMillis)
-            val thresholdMillis = recordingGapThresholdMillis()
+            val thresholdMillis = recordingGapTelemetryThresholdMillis()
             if (gapMillis > thresholdMillis) {
                 recordingGapCount += 1
                 recordingMaxGapMillis = maxOf(recordingMaxGapMillis, gapMillis)
@@ -1544,7 +1579,7 @@ class TraceRecordingViewModel(
         return (durationMillis / intervalMillis + 1L).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
     }
 
-    private fun recordingGapThresholdMillis(): Long = maxOf(effectiveSampleIntervalSeconds() * 2_000L, RECORDING_GAP_MIN_THRESHOLD_MS)
+    private fun recordingGapTelemetryThresholdMillis(): Long = maxOf(effectiveSampleIntervalSeconds() * 2_000L, RECORDING_GAP_TELEMETRY_MIN_THRESHOLD_MS)
 
     private fun updateAccuracyTelemetry(accuracyMeters: Float?) {
         val accuracy = accuracyMeters ?: return
@@ -1782,7 +1817,7 @@ private fun sensorAgeMillis(
     updatedAtMillis: Long,
 ): Long = updatedAtMillis.takeIf { it > 0L }?.let { (nowMillis - it).coerceAtLeast(0L) } ?: -1L
 
-private const val RECORDING_GAP_MIN_THRESHOLD_MS = 15_000L
+private const val RECORDING_GAP_TELEMETRY_MIN_THRESHOLD_MS = 15_000L
 private const val RECORDING_GPS_ACTIVE_GAP_FLOOR_MS = 1_000L
 private const val RECORDING_GPS_ACTIVE_GAP_CAP_MS = 15_000L
 private const val RECORDING_FORCE_ACCEPT_MIN_AGE_MS = 2_000L
@@ -1870,15 +1905,6 @@ internal fun recordingJitterDistanceToSuppress(
     return distanceMeters.takeIf { it <= deadbandMeters }
 }
 
-internal fun recordingGapRequiresNewSegment(
-    elapsedSinceAcceptedMs: Long,
-    gapThresholdMillis: Long,
-    hasRecordedPoints: Boolean,
-): Boolean =
-    hasRecordedPoints &&
-        gapThresholdMillis > 0L &&
-        elapsedSinceAcceptedMs >= gapThresholdMillis
-
 private fun elevationGainLossMeters(points: List<RecordedTracePoint>): Pair<Double, Double> {
     var gain = 0.0
     var loss = 0.0
@@ -1927,6 +1953,7 @@ private fun Float.formatTelemetry(decimalPlaces: Int): String = toDouble().forma
 
 private const val RECORDING_TELEMETRY_POINT_INTERVAL = 10
 private const val RECORDING_LIVE_TELEMETRY_SKIP_INTERVAL = 20
+private const val RECORDING_START_FRESH_FIX_TIMEOUT_MS = 6_000L
 private const val RECORDING_JITTER_TELEMETRY_INTERVAL = 10
 private const val RECORDING_JITTER_KEEPALIVE_MS = 30_000L
 private const val RECORDING_JITTER_MAX_SPEED_MPS = 0.5f

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/recording/TraceRecordingViewModel.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/recording/TraceRecordingViewModel.kt
@@ -1579,7 +1579,11 @@ class TraceRecordingViewModel(
         return (durationMillis / intervalMillis + 1L).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
     }
 
-    private fun recordingGapTelemetryThresholdMillis(): Long = maxOf(effectiveSampleIntervalSeconds() * 2_000L, RECORDING_GAP_TELEMETRY_MIN_THRESHOLD_MS)
+    private fun recordingGapTelemetryThresholdMillis(): Long =
+        maxOf(
+            effectiveSampleIntervalSeconds() * 2_000L,
+            RECORDING_GAP_TELEMETRY_MIN_THRESHOLD_MS,
+        )
 
     private fun updateAccuracyTelemetry(accuracyMeters: Float?) {
         val accuracy = accuracyMeters ?: return

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/RecordingSettingsScreen.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/settings/RecordingSettingsScreen.kt
@@ -21,7 +21,9 @@ fun RecordingSettingsScreen(
     val listTokens = rememberSettingsListTokens()
     val showSavedGpxOnMap by viewModel.recordingShowSavedGpxOnMap.collectAsState()
     val startWithTurnByTurn by viewModel.recordingStartWithTurnByTurn.collectAsState()
+    val autoPauseMode by viewModel.recordingAutoPauseMode.collectAsState()
     val trackSmoothingMode by viewModel.recordingTrackSmoothingMode.collectAsState()
+    val autoPauseEnabled = autoPauseMode == SettingsRepository.RECORDING_AUTO_PAUSE_ALWAYS
     var showInfoDialog by remember { mutableStateOf(false) }
 
     WearSettingsListScreen(listTokens = listTokens, horizontalAlignment = Alignment.CenterHorizontally) {
@@ -35,6 +37,22 @@ fun RecordingSettingsScreen(
             GeneralSettingsShortcutChip(
                 onClick = onOpenGeneralSettings,
                 applyTopPadding = false,
+            )
+        }
+        item {
+            SettingsToggleChip(
+                checked = autoPauseEnabled,
+                onCheckedChanged = { enabled ->
+                    viewModel.setRecordingAutoPauseMode(
+                        if (enabled) {
+                            SettingsRepository.RECORDING_AUTO_PAUSE_ALWAYS
+                        } else {
+                            SettingsRepository.RECORDING_AUTO_PAUSE_OFF
+                        },
+                    )
+                },
+                label = "Auto-pause",
+                secondaryLabel = if (autoPauseEnabled) "Pause REC when still" else "Keep REC running",
             )
         }
         item {

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/recording/RecordingTrackFilterTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/recording/RecordingTrackFilterTest.kt
@@ -2,7 +2,6 @@ package com.glancemap.glancemapwearos.presentation.features.recording
 
 import com.glancemap.glancemapwearos.data.repository.SettingsRepository
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -66,7 +65,6 @@ class RecordingTrackFilterTest {
 
         assertEquals(RecordingFixQualityStatus.HELD, jump.status)
         assertTrue(recovered.accepted)
-        assertFalse(recovered.startsNewSegment)
     }
 
     @Test
@@ -81,7 +79,7 @@ class RecordingTrackFilterTest {
     }
 
     @Test
-    fun twoConsistentFixesAfterJumpStartNewSegment() {
+    fun twoConsistentFixesAfterJumpConfirmRelocation() {
         val gate = RecordingFixQualityGate()
         assertTrue(gate.evaluate(sample(x = 0.0, elapsedMillis = 1_000L), HIKE).accepted)
         assertEquals(
@@ -92,7 +90,6 @@ class RecordingTrackFilterTest {
         val confirmed = gate.evaluate(sample(x = 504.0, elapsedMillis = 7_000L), HIKE)
 
         assertTrue(confirmed.accepted)
-        assertTrue(confirmed.startsNewSegment)
         assertEquals(RecordingFixQualityReason.CONFIRMED_RELOCATION, confirmed.reason)
     }
 
@@ -125,13 +122,11 @@ class RecordingTrackFilterTest {
 
         assertEquals(RecordingFixQualityStatus.HELD, firstFastFix.status)
         assertTrue(confirmedFastFix.accepted)
-        assertFalse(confirmedFastFix.startsNewSegment)
         assertEquals(
             RecordingFixQualityReason.CONFIRMED_SUSTAINED_MOVEMENT,
             confirmedFastFix.reason,
         )
         assertTrue(followingFastFix.accepted)
-        assertFalse(followingFastFix.startsNewSegment)
     }
 
     @Test
@@ -160,33 +155,7 @@ class RecordingTrackFilterTest {
             )
 
         assertTrue(result.accepted)
-        assertTrue(result.startsNewSegment)
         assertEquals(RecordingFixQualityReason.CONFIRMED_RELOCATION, result.reason)
-    }
-
-    @Test
-    fun gpsLossGapStartsANewSegmentOnlyAfterTheThreshold() {
-        assertFalse(
-            recordingGapRequiresNewSegment(
-                elapsedSinceAcceptedMs = 14_999L,
-                gapThresholdMillis = 15_000L,
-                hasRecordedPoints = true,
-            ),
-        )
-        assertTrue(
-            recordingGapRequiresNewSegment(
-                elapsedSinceAcceptedMs = 15_000L,
-                gapThresholdMillis = 15_000L,
-                hasRecordedPoints = true,
-            ),
-        )
-        assertFalse(
-            recordingGapRequiresNewSegment(
-                elapsedSinceAcceptedMs = 30_000L,
-                gapThresholdMillis = 15_000L,
-                hasRecordedPoints = false,
-            ),
-        )
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ android.r8.strictFullModeForKeepRules=false
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
 glanceMapVersionName=1.2.0
-glanceMapWearVersionCode=1026
+glanceMapWearVersionCode=1027
 glanceMapPhoneVersionCode=2025
 
 # Elevate theme build-time sync (download -> generated assets -> packaged in APK)


### PR DESCRIPTION
## Summary
- wait briefly for a fresh GPS fix when REC is started and surface the usual warning only after the timeout
- keep REC GPX tracks continuous through transient GPS gaps and confirmed relocations
- expose the shared REC auto-pause setting above the REC settings, and bump the Wear OS version code to 1027

## Validation
- ./gradlew :app:compileDebugKotlin
- ./gradlew :app:ktlintCheck :app:testDebugUnitTest --tests com.glancemap.glancemapwearos.presentation.features.recording.RecordingTrackFilterTest --tests com.glancemap.glancemapwearos.presentation.features.recording.TraceGpxEncoderTest --tests com.glancemap.glancemapwearos.presentation.features.recording.RecordingStartWarningTest --no-daemon --console=plain