### PR TITLE
Stabilize Watch GPS marker behavior

### DIFF
--- a/app/src/main/java/com/glancemap/glancemapwearos/core/service/location/model/GpsSignalTracker.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/core/service/location/model/GpsSignalTracker.kt
@@ -18,6 +18,7 @@ internal class GpsSignalTracker {
     private var environmentWarningSinceMs: Long = 0L
     private var sourceEpoch: Long = 0L
     private var activeSourceMode: LocationSourceMode? = null
+    private var lastLiveSourceMode: LocationSourceMode? = null
 
     fun onSourceModeChanged(
         sourceMode: LocationSourceMode?,
@@ -25,17 +26,17 @@ internal class GpsSignalTracker {
     ) {
         val previousSourceMode = activeSourceMode
         val sourceChanged = previousSourceMode != sourceMode
+        val liveSourceTransition = updateLiveSourceMode(sourceMode)
         val watchGpsOnlyActive = sourceMode == LocationSourceMode.WATCH_GPS
         if (!watchGpsOnlyActive) {
             watchGpsDegradedFixStreak = 0
             watchGpsDegradedSinceMs = 0L
         }
-        if (sourceChanged) {
+        if (liveSourceTransition.startsNewEpoch) {
             sourceEpoch += 1L
         }
         activeSourceMode = sourceMode
-        val needsFreshLiveFix =
-            sourceChanged && previousSourceMode != null && sourceMode != null
+        val needsFreshLiveFix = liveSourceTransition == LiveSourceTransition.HANDOFF
         snapshot =
             snapshot.copy(
                 watchGpsOnlyActive = watchGpsOnlyActive,
@@ -191,6 +192,7 @@ internal class GpsSignalTracker {
         environmentWarningSinceMs = 0L
         sourceEpoch = 0L
         activeSourceMode = null
+        lastLiveSourceMode = null
         snapshot =
             GpsSignalSnapshot(
                 isLocationAvailable = false,
@@ -206,6 +208,7 @@ internal class GpsSignalTracker {
         environmentWarningSinceMs = 0L
         sourceEpoch = 0L
         activeSourceMode = null
+        lastLiveSourceMode = null
         snapshot = GpsSignalSnapshot()
     }
 
@@ -213,6 +216,26 @@ internal class GpsSignalTracker {
         if (!accuracyM.isFinite()) return false
         return abs(accuracyM - WATCH_GPS_ACCURACY_FLOOR_M) <= WATCH_GPS_ACCURACY_FLOOR_TOLERANCE_M
     }
+
+    private fun updateLiveSourceMode(sourceMode: LocationSourceMode?): LiveSourceTransition {
+        sourceMode ?: return LiveSourceTransition.NONE
+        val previousLiveSourceMode = lastLiveSourceMode
+        lastLiveSourceMode = sourceMode
+        return when {
+            previousLiveSourceMode == null -> LiveSourceTransition.INITIAL
+            previousLiveSourceMode != sourceMode -> LiveSourceTransition.HANDOFF
+            else -> LiveSourceTransition.SAME
+        }
+    }
+}
+
+private enum class LiveSourceTransition(
+    val startsNewEpoch: Boolean,
+) {
+    NONE(startsNewEpoch = false),
+    INITIAL(startsNewEpoch = true),
+    SAME(startsNewEpoch = false),
+    HANDOFF(startsNewEpoch = true),
 }
 
 internal data class GpsSignalSample(

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/effects/NavigateLocationEffects.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/features/navigate/effects/NavigateLocationEffects.kt
@@ -462,19 +462,24 @@ internal fun rememberNavigateLocationUiState(
             watchGpsDegradedWarning = watchGpsDegradedWarning,
         )
 
-    LaunchedEffect(indicatorSourceEpoch) {
-        // The first source application has no old marker to invalidate. Every later source epoch
-        // replaces Phone/Watch data, so a retained marker would otherwise look live but be wrong.
-        if (indicatorSourceEpoch <= 1L) return@LaunchedEffect
-        locationMarker?.let { marker ->
-            mapView.mutateLayers { layers -> layers.remove(marker) }
+    LaunchedEffect(
+        indicatorSourceEpoch,
+        indicatorRequiresFreshLiveFixAfterSourceChange,
+    ) {
+        if (
+            !shouldHoldMarkerForLiveSourceHandoff(
+                sourceEpoch = indicatorSourceEpoch,
+                requiresFreshLiveFix = indicatorRequiresFreshLiveFixAfterSourceChange,
+            )
+        ) {
+            return@LaunchedEffect
         }
-        locationMarker = null
-        lastRenderedMarkerLatLong = null
+        // Keep the last rendered marker visible during a real Phone/Watch handoff. Motion is
+        // cleared so the old source cannot drive prediction; the first accepted fix from the new
+        // source resumes updates on the existing marker without a visible gap.
         lastAcceptedLocationFixElapsedMs = 0L
         latestAcceptedFixSpeedMps = 0f
         latestAcceptedFixBearingDeg = null
-        lastMarkerVisualUpdateAtElapsedMs = 0L
         lastMarkerMotionAdvanceAtElapsedMs = 0L
         markerMotionController.reset(
             reason = "location_source_changed",
@@ -1543,6 +1548,11 @@ private fun isKnownWatchGpsAccuracyFloor(
 internal fun resolveGpsIndicatorDisplayState(
     rawState: GpsFixIndicatorState,
 ): GpsFixIndicatorState = rawState
+
+internal fun shouldHoldMarkerForLiveSourceHandoff(
+    sourceEpoch: Long,
+    requiresFreshLiveFix: Boolean,
+): Boolean = sourceEpoch > 1L && requiresFreshLiveFix
 
 internal fun resolveGpsIndicatorEscalationState(
     rawState: GpsFixIndicatorState,

--- a/app/src/test/java/com/glancemap/glancemapwearos/core/service/location/model/GpsSignalTrackerTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/core/service/location/model/GpsSignalTrackerTest.kt
@@ -139,4 +139,42 @@ class GpsSignalTrackerTest {
 
         assertFalse(tracker.snapshot.requiresFreshLiveFixAfterSourceChange)
     }
+
+    @Test
+    fun restartingSameSourceDoesNotCreateLiveSourceHandoff() {
+        val tracker = GpsSignalTracker()
+        tracker.onSourceModeChanged(
+            sourceMode = LocationSourceMode.AUTO_FUSED,
+            nowElapsedMs = 1_000L,
+        )
+
+        val initialEpoch = tracker.snapshot.sourceEpoch
+        tracker.onSourceModeChanged(sourceMode = null)
+        tracker.onSourceModeChanged(
+            sourceMode = LocationSourceMode.AUTO_FUSED,
+            nowElapsedMs = 2_000L,
+        )
+
+        assertEquals(initialEpoch, tracker.snapshot.sourceEpoch)
+        assertFalse(tracker.snapshot.requiresFreshLiveFixAfterSourceChange)
+        assertEquals(LocationSourceMode.AUTO_FUSED.telemetryValue, tracker.snapshot.activeSourceModeValue)
+    }
+
+    @Test
+    fun changingLiveSourceAcrossTrackingStopStillRequiresFreshFix() {
+        val tracker = GpsSignalTracker()
+        tracker.onSourceModeChanged(
+            sourceMode = LocationSourceMode.AUTO_FUSED,
+            nowElapsedMs = 1_000L,
+        )
+        tracker.onSourceModeChanged(sourceMode = null)
+        tracker.onSourceModeChanged(
+            sourceMode = LocationSourceMode.WATCH_GPS,
+            nowElapsedMs = 2_000L,
+        )
+
+        assertEquals(2L, tracker.snapshot.sourceEpoch)
+        assertTrue(tracker.snapshot.requiresFreshLiveFixAfterSourceChange)
+        assertEquals(LocationSourceMode.WATCH_GPS.telemetryValue, tracker.snapshot.activeSourceModeValue)
+    }
 }

--- a/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/effects/NavigateLocationEffectsTimeTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/presentation/features/navigate/effects/NavigateLocationEffectsTimeTest.kt
@@ -202,6 +202,28 @@ class NavigateLocationEffectsTimeTest {
     }
 
     @Test
+    fun markerIsHeldOnlyDuringUnresolvedLiveSourceHandoff() {
+        assertTrue(
+            shouldHoldMarkerForLiveSourceHandoff(
+                sourceEpoch = 2L,
+                requiresFreshLiveFix = true,
+            ),
+        )
+        assertFalse(
+            shouldHoldMarkerForLiveSourceHandoff(
+                sourceEpoch = 2L,
+                requiresFreshLiveFix = false,
+            ),
+        )
+        assertFalse(
+            shouldHoldMarkerForLiveSourceHandoff(
+                sourceEpoch = 1L,
+                requiresFreshLiveFix = true,
+            ),
+        )
+    }
+
+    @Test
     fun indicatorEscalatesFromBlueToYellowToRedWhenFixStaysMissing() {
         assertEquals(
             GpsFixIndicatorState.SEARCHING,

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ android.r8.strictFullModeForKeepRules=false
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
 glanceMapVersionName=1.2.0
-glanceMapWearVersionCode=1028
+glanceMapWearVersionCode=1029
 glanceMapPhoneVersionCode=2027
 
 # Elevate theme build-time sync (download -> generated assets -> packaged in APK)


### PR DESCRIPTION
## Summary
- preserve the Watch location marker across transient GPS source changes
- pause prediction until a fresh fix arrives after a real source handoff
- bump the Wear version code to 1029 while keeping version name 1.2.0

## Verification
- :app:ktlintCheck
- :app:detekt
- :app:testDebugUnitTest
- :app:compileReleaseKotlin