### PR TITLE
Bump Wear OS and Companion version codes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,8 +39,8 @@ android.r8.strictFullModeForKeepRules=false
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
 glanceMapVersionName=1.2.1
-glanceMapWearVersionCode=1031
-glanceMapPhoneVersionCode=2028
+glanceMapWearVersionCode=1032
+glanceMapPhoneVersionCode=2029
 
 # Mapsforge DEM3 downloader task (manual): ./gradlew :app:downloadMapsforgeDem3 -Pdem3Tiles=N46E006
 dem3BaseUrl=https://download.mapsforge.org/maps/dem/dem3


### PR DESCRIPTION
## Summary
- bump Wear OS versionCode from 1031 to 1032
- bump Companion versionCode from 2028 to 2029

## Validation
- git diff --check passed
- scripts/quality-gate.sh reached the existing uncommitted layout files and failed on unrelated ktlint violations at CompanionLayoutProvider.kt:151 and CompanionLayoutContext.kt:152
- no application code or tests changed