### PR TITLE
Allow compass-less Wear watches

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
         android:required="false" />
     <uses-feature
         android:name="android.hardware.sensor.compass"
-        android:required="true" />
+        android:required="false" />
     <uses-feature
         android:name="android.hardware.sensor.heartrate"
         android:required="false" />

--- a/app/src/main/java/com/glancemap/glancemapwearos/domain/sensors/CompassHardwareCapability.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/domain/sensors/CompassHardwareCapability.kt
@@ -1,0 +1,30 @@
+package com.glancemap.glancemapwearos.domain.sensors
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.hardware.Sensor
+import android.hardware.SensorManager
+
+internal data class CompassHardwareCapability(
+    val compassFeatureAvailable: Boolean,
+    val magnetometerAvailable: Boolean,
+) {
+    val hardwareCompassUnavailable: Boolean
+        get() = !compassFeatureAvailable && !magnetometerAvailable
+}
+
+internal fun resolveCompassHardwareCapability(context: Context): CompassHardwareCapability {
+    val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+    return CompassHardwareCapability(
+        compassFeatureAvailable =
+            context.packageManager.hasSystemFeature(PackageManager.FEATURE_SENSOR_COMPASS),
+        magnetometerAvailable = sensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD) != null,
+    )
+}
+
+internal fun shouldShowCompassHardwareUnavailableNotice(
+    capability: CompassHardwareCapability,
+    acknowledged: Boolean,
+): Boolean =
+    // Runtime HeadingSource.NONE is intentionally not an input: it can be a normal temporary state.
+    capability.hardwareCompassUnavailable && !acknowledged

--- a/app/src/main/java/com/glancemap/glancemapwearos/presentation/MainActivity.kt
+++ b/app/src/main/java/com/glancemap/glancemapwearos/presentation/MainActivity.kt
@@ -38,6 +38,8 @@ import com.glancemap.glancemapwearos.core.service.location.model.resolveLocation
 import com.glancemap.glancemapwearos.core.service.location.policy.NavigationRuntimeInputs
 import com.glancemap.glancemapwearos.core.service.location.policy.navigationRuntimeDemand
 import com.glancemap.glancemapwearos.data.repository.SettingsRepository
+import com.glancemap.glancemapwearos.domain.sensors.resolveCompassHardwareCapability
+import com.glancemap.glancemapwearos.domain.sensors.shouldShowCompassHardwareUnavailableNotice
 import com.glancemap.glancemapwearos.presentation.design.theme.GlanceMapTheme
 import com.glancemap.glancemapwearos.presentation.features.download.DownloadScreen
 import com.glancemap.glancemapwearos.presentation.features.download.DownloadSettingsScreen
@@ -1051,6 +1053,7 @@ class MainActivity : ComponentActivity() {
                         }
                     }
                 }
+                compassHardwareUnavailableNotice()
                 WearActionDialog(
                     visible = recordingStartWarning != null,
                     title = "External sensors unavailable",
@@ -1133,6 +1136,42 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    @Composable
+    private fun compassHardwareUnavailableNotice() {
+        val context = LocalContext.current.applicationContext
+        val prefs =
+            remember(context) {
+                context.getSharedPreferences(COMPASS_HARDWARE_NOTICE_PREFS, Context.MODE_PRIVATE)
+            }
+        val capability = remember(context) { resolveCompassHardwareCapability(context) }
+        var acknowledged by
+            remember {
+                mutableStateOf(
+                    prefs.getBoolean(COMPASS_HARDWARE_NOTICE_ACKNOWLEDGED, false),
+                )
+            }
+        val acknowledge = {
+            prefs.edit().putBoolean(COMPASS_HARDWARE_NOTICE_ACKNOWLEDGED, true).apply()
+            acknowledged = true
+        }
+
+        WearActionDialog(
+            visible =
+                shouldShowCompassHardwareUnavailableNotice(
+                    capability = capability,
+                    acknowledged = acknowledged,
+                ),
+            title = "Compass not available on this watch",
+            message =
+                "This watch does not expose a hardware compass to apps. Maps, GPS navigation and activity " +
+                    "recording will continue to work, but compass-follow map rotation and directional " +
+                    "heading may be limited.",
+            confirmText = "Continue",
+            onConfirm = acknowledge,
+            onDismissRequest = {},
+        )
     }
 
     override fun onResume() {
@@ -1248,3 +1287,6 @@ class MainActivity : ComponentActivity() {
             interactive = getSystemService(PowerManager::class.java)?.isInteractive,
         )
 }
+
+private const val COMPASS_HARDWARE_NOTICE_PREFS = "compass_hardware_notice"
+private const val COMPASS_HARDWARE_NOTICE_ACKNOWLEDGED = "acknowledged"

--- a/app/src/test/java/com/glancemap/glancemapwearos/domain/sensors/CompassHardwareCapabilityTest.kt
+++ b/app/src/test/java/com/glancemap/glancemapwearos/domain/sensors/CompassHardwareCapabilityTest.kt
@@ -1,0 +1,61 @@
+package com.glancemap.glancemapwearos.domain.sensors
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CompassHardwareCapabilityTest {
+    @Test
+    fun temporaryHeadingNoneOnCompassCapableWatchDoesNotShowTheNotice() {
+        val temporaryHeadingSource = HeadingSource.NONE
+        val capability =
+            CompassHardwareCapability(
+                compassFeatureAvailable = true,
+                magnetometerAvailable = true,
+            )
+
+        assertEquals(HeadingSource.NONE, temporaryHeadingSource)
+        assertFalse(capability.hardwareCompassUnavailable)
+        assertFalse(
+            shouldShowCompassHardwareUnavailableNotice(
+                capability = capability,
+                acknowledged = false,
+            ),
+        )
+    }
+
+    @Test
+    fun absentCompassHardwareShowsTheNoticeOnlyUntilAcknowledged() {
+        val capability =
+            CompassHardwareCapability(
+                compassFeatureAvailable = false,
+                magnetometerAvailable = false,
+            )
+
+        assertTrue(capability.hardwareCompassUnavailable)
+        assertTrue(
+            shouldShowCompassHardwareUnavailableNotice(
+                capability = capability,
+                acknowledged = false,
+            ),
+        )
+        assertFalse(
+            shouldShowCompassHardwareUnavailableNotice(
+                capability = capability,
+                acknowledged = true,
+            ),
+        )
+    }
+
+    @Test
+    fun exposedMagnetometerPreventsAFalseNoticeWhenFeatureMetadataIsMissing() {
+        val capability =
+            CompassHardwareCapability(
+                compassFeatureAvailable = false,
+                magnetometerAvailable = true,
+            )
+
+        assertFalse(capability.hardwareCompassUnavailable)
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ android.r8.strictFullModeForKeepRules=false
 # Scheme: 1000-series for Wear, 2000-series for phone.
 # Bump the matching artifact by 1 for each Play upload.
 glanceMapVersionName=1.2.1
-glanceMapWearVersionCode=1032
+glanceMapWearVersionCode=1033
 glanceMapPhoneVersionCode=2029
 
 # Mapsforge DEM3 downloader task (manual): ./gradlew :app:downloadMapsforgeDem3 -Pdem3Tiles=N46E006


### PR DESCRIPTION
## Summary
- Allow installation on Wear watches without a required compass feature.
- Show the shared one-time hardware notice only when both feature metadata and the magnetometer are absent.
- Bump the Wear version code to 1033.

## Validation
- scripts/quality-gate.sh
- git diff --check